### PR TITLE
Bump unison trunk

### DIFF
--- a/src/Share/Backend.hs
+++ b/src/Share/Backend.hs
@@ -61,7 +61,7 @@ import Unison.ConstructorType qualified as CT
 import Unison.DataDeclaration qualified as DD
 import Unison.Hashing.V2.Convert qualified as Hashing
 import Unison.Name qualified as Name
-import Unison.NameSegment (NameSegment (..))
+import Unison.NameSegment.Internal (NameSegment (..))
 import Unison.Parser.Ann (Ann)
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnvDecl qualified as PPED
@@ -143,7 +143,7 @@ mkTermDefinition termPPED width r docs tm = do
           docs
 
 termListEntry ::
-  PG.QueryM m =>
+  (PG.QueryM m) =>
   Type Symbol Ann ->
   ExactName NameSegment V2Referent.Referent ->
   m (Backend.TermEntry Symbol Ann)
@@ -161,7 +161,7 @@ termListEntry typ (ExactName nameSegment ref) = do
       }
 
 typeListEntry ::
-  PG.QueryM m =>
+  (PG.QueryM m) =>
   ExactName NameSegment Reference ->
   m Backend.TypeEntry
 typeListEntry (ExactName nameSegment ref) = do
@@ -193,14 +193,14 @@ getTermTag r termType = do
     V2Referent.Con ref _ -> Just <$> Codebase.expectDeclKind ref
   pure $
     if
-        | isDoc -> Doc
-        | isTest -> Test
-        | Just CT.Effect <- constructorType -> Constructor Ability
-        | Just CT.Data <- constructorType -> Constructor Data
-        | otherwise -> Plain
+      | isDoc -> Doc
+      | isTest -> Test
+      | Just CT.Effect <- constructorType -> Constructor Ability
+      | Just CT.Data <- constructorType -> Constructor Data
+      | otherwise -> Plain
 
 getTypeTag ::
-  PG.QueryM m =>
+  (PG.QueryM m) =>
   Reference.TypeReference ->
   m TypeTag
 getTypeTag r = do

--- a/src/Share/Codebase/Types.hs
+++ b/src/Share/Codebase/Types.hs
@@ -19,9 +19,10 @@ import Unison.Codebase.Runtime qualified as Rt
 import Unison.Parser.Ann (Ann)
 import Unison.Reference qualified as Reference
 import Unison.Symbol (Symbol)
+import Unison.NameSegment.Internal (NameSegment (..))
 
 publicRoot :: Path.Path
-publicRoot = Path.singleton "public"
+publicRoot = Path.singleton $ NameSegment "public"
 
 -- | The scope of a given codebase transaction.
 data CodebaseEnv = CodebaseEnv

--- a/src/Share/Postgres/NameLookups/Types.hs
+++ b/src/Share/Postgres/NameLookups/Types.hs
@@ -34,7 +34,7 @@ import Share.Prelude
 import U.Codebase.Referent (ConstructorType)
 import Unison.Name (Name)
 import Unison.Name qualified as Name
-import Unison.NameSegment (NameSegment (..))
+import Unison.NameSegment.Internal (NameSegment (..))
 
 -- | Proof that we've checked that a given name lookup exists before we try to use it.
 data NameLookupReceipt = UnsafeNameLookupReceipt
@@ -75,7 +75,7 @@ newtype ReversedName = ReversedName (NonEmpty Text)
 
 reversedNameToName :: ReversedName -> Name
 reversedNameToName (ReversedName revName) =
-  Name.fromReverseSegments (coerce @(NonEmpty Text) @(NonEmpty NameSegment) revName)
+  Name.fromReverseSegments (NameSegment <$> revName)
 
 instance From ReversedName Name where
   from = reversedNameToName
@@ -158,7 +158,7 @@ data NamedRef ref = NamedRef {reversedSegments :: ReversedName, ref :: ref}
 ref_ :: Lens (NamedRef ref) (NamedRef ref') ref ref'
 ref_ = lens ref (\namedRef ref -> namedRef {ref = ref})
 
-instance PG.DecodeRow ref => PG.DecodeRow (NamedRef ref) where
+instance (PG.DecodeRow ref) => PG.DecodeRow (NamedRef ref) where
   decodeRow = do
     reversedSegments <- PG.decodeField
     ref <- PG.decodeRow

--- a/src/Share/Postgres/Orphans.hs
+++ b/src/Share/Postgres/Orphans.hs
@@ -10,15 +10,15 @@ import Data.Bytes.Put (runPutS)
 import Data.Either.Extra qualified as Either
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
-import Share.Prelude
-import Share.Utils.Logging qualified as Logging
-import Share.Web.Errors (ErrorID (..), ToServerError (..))
 import Hasql.Decoders qualified as Decoders
 import Hasql.Encoders qualified as Encoders
 import Hasql.Interpolate qualified as Hasql
 import Hasql.Session qualified as Hasql
 import Servant (err500)
 import Servant.API
+import Share.Prelude
+import Share.Utils.Logging qualified as Logging
+import Share.Web.Errors (ErrorID (..), ToServerError (..))
 import U.Codebase.HashTags (BranchHash (..), CausalHash (..), ComponentHash (..), PatchHash (..))
 import U.Codebase.Reference (Id' (Id), Reference' (..))
 import U.Codebase.Referent (ConstructorType (..), Referent' (..))
@@ -32,7 +32,7 @@ import Unison.Hash (Hash)
 import Unison.Hash qualified as Hash
 import Unison.Hash32 (Hash32)
 import Unison.Hash32 qualified as Hash32
-import Unison.NameSegment (NameSegment (..))
+import Unison.NameSegment.Internal (NameSegment (..))
 
 -- Orphans for 'Hash'
 instance Hasql.EncodeValue Hash where
@@ -57,7 +57,8 @@ instance Hasql.DecodeValue Hash32 where
     Hasql.decodeValue
       -- We can trust that encoded values are valid,
       -- and skipping validation is a significant performance improvement
-      <&> Hash32.unsafeFromBase32Hex . Base32Hex.UnsafeFromText
+      <&> Hash32.unsafeFromBase32Hex
+      . Base32Hex.UnsafeFromText
 
 instance FromHttpApiData Hash where
   parseUrlPiece txt =
@@ -140,7 +141,7 @@ instance Hasql.EncodeValue ConstructorType where
         EffectConstructor -> 1
 
 -- | Decode a single field as part of a Row
-decodeField :: Hasql.DecodeField a => Decoders.Row a
+decodeField :: (Hasql.DecodeField a) => Decoders.Row a
 decodeField = Decoders.column Hasql.decodeField
 
 instance Hasql.EncodeValue TempEntity where

--- a/src/Share/Postgres/Sync/Conversions.hs
+++ b/src/Share/Postgres/Sync/Conversions.hs
@@ -16,7 +16,8 @@ import U.Codebase.Sqlite.Patch.TypeEdit qualified as PatchFullTypeEdit
 import U.Codebase.TermEdit qualified as V2TermEdit
 import U.Codebase.TypeEdit qualified as V2TypeEdit
 import Unison.Hash (Hash)
-import Unison.NameSegment (NameSegment (..))
+import Unison.NameSegment (NameSegment)
+import Unison.NameSegment.Internal qualified as NameSegment
 import Unison.Util.Map qualified as Map
 
 branchV2ToBF ::
@@ -53,7 +54,7 @@ branchV2ToBF (V2.Branch {terms, types, patches, children}) = do
     convertChildren :: Map NameSegment (V2.CausalBranch m) -> Map Text (Hash, Hash)
     convertChildren =
       Map.bimap
-        (coerce @NameSegment @Text)
+        NameSegment.toUnescapedText
         ((unBranchHash . Causal.valueHash) &&& (unCausalHash . Causal.causalHash))
 
 patchV2ToPF :: V2.Patch -> PatchFull.Patch' Text Hash Hash

--- a/src/Share/Web/Authorization.hs
+++ b/src/Share/Web/Authorization.hs
@@ -94,7 +94,7 @@ import Share.Web.Share.Tickets.Types
 import Servant
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
-import Unison.NameSegment (NameSegment (..))
+import Unison.NameSegment.Internal (NameSegment (..))
 
 -- | Proof that an auth check has been run at some point.
 data AuthZReceipt = AuthZReceipt {getCacheability :: Maybe CachingToken}
@@ -271,7 +271,7 @@ writePath :: Path -> CodebasePermission
 writePath path = UserCodebaseWritePath (Path.toList path)
 
 isPublicPath :: [NameSegment] -> Bool
-isPublicPath ("public" : _) = True
+isPublicPath (NameSegment "public" : _) = True
 isPublicPath _ = False
 
 -- | Requests should only be cached if they're for a public endpoint.

--- a/src/Share/Web/Share/Branches/Impl.hs
+++ b/src/Share/Web/Share/Branches/Impl.hs
@@ -11,6 +11,7 @@ import Data.List.NonEmpty qualified as NonEmpty
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Time (UTCTime)
+import Servant
 import Share.Branch (Branch (..), branchCausals_)
 import Share.Codebase qualified as Codebase
 import Share.IDs (BranchId, BranchShortHand (..), ProjectBranchShortHand (..), ProjectShortHand (..), ProjectSlug (..), UserHandle, UserId)
@@ -38,12 +39,11 @@ import Share.Web.Share.Branches.Types qualified as API
 import Share.Web.Share.CodeBrowsing.API qualified as API
 import Share.Web.Share.Projects.Types (projectToAPI)
 import Share.Web.Share.Types
-import Servant
 import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase.Path qualified as Path
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
-import Unison.NameSegment (NameSegment (..))
+import Unison.NameSegment.Internal (NameSegment (..))
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent

--- a/src/Share/Web/Share/Releases/Impl.hs
+++ b/src/Share/Web/Share/Releases/Impl.hs
@@ -14,6 +14,7 @@ import Control.Monad.Except
 import Control.Monad.Trans.Maybe
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Set qualified as Set
+import Servant
 import Share.Codebase qualified as Codebase
 import Share.IDs
 import Share.IDs qualified as IDs
@@ -42,11 +43,10 @@ import Share.Web.Share.Releases.Types
 import Share.Web.Share.Releases.Types qualified as API
 import Share.Web.Share.Types
 import Share.Web.UCM.Sync.Impl qualified as SyncQ
-import Servant
 import Unison.Codebase.Path qualified as Path
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
-import Unison.NameSegment (NameSegment (NameSegment))
+import Unison.NameSegment.Internal (NameSegment (..))
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent

--- a/src/Unison/Server/NameSearch/Postgres.hs
+++ b/src/Unison/Server/NameSearch/Postgres.hs
@@ -16,7 +16,7 @@ import Unison.Codebase.Path qualified as Path
 import Unison.HashQualified' qualified as HQ'
 import Unison.Name (Name)
 import Unison.Name qualified as Name
-import Unison.NameSegment (NameSegment (..))
+import Unison.NameSegment.Internal (NameSegment (..))
 import Unison.NamesWithHistory (SearchType (..))
 import Unison.Reference qualified as V1
 import Unison.Reference qualified as V1Reference
@@ -123,4 +123,4 @@ nameSearchForPerspective namesPerspective =
 
     -- Fully qualify a name by prepending the current namespace perspective's path
     fullyQualifyName :: Name -> Name
-    fullyQualifyName name = Path.prefixName (Path.Absolute (Path.fromList . coerce $ pathToMountedNameLookup namesPerspective)) name
+    fullyQualifyName name = fromMaybe name $ Path.maybePrefixName (Path.AbsolutePath' . Path.Absolute $ (Path.fromList . fmap NameSegment . coerce @PathSegments @[Text] $ pathToMountedNameLookup namesPerspective)) name

--- a/src/Unison/Server/Share/Docs.hs
+++ b/src/Unison/Server/Share/Docs.hs
@@ -9,6 +9,7 @@ import Share.Prelude
 import Share.Web.Errors (SomeServerError)
 import Unison.HashQualified' qualified as HQ'
 import Unison.Name (Name)
+import Unison.NameSegment.Internal (NameSegment (..))
 import Unison.NamesWithHistory (SearchType (ExactName))
 import Unison.Reference (TermReference)
 import Unison.Referent qualified as V1Referent
@@ -29,7 +30,7 @@ docsForDefinitionName ::
   Name ->
   Codebase.CodebaseM e [TermReference]
 docsForDefinitionName (NameSearch {termSearch}) name = do
-  let potentialDocNames = [name, name Cons.:> "doc"]
+  let potentialDocNames = [name, name Cons.:> NameSegment "doc"]
   refs <-
     potentialDocNames & foldMapM \name ->
       lift $ lookupRelativeHQRefs' termSearch ExactName (HQ'.NameOnly name)

--- a/src/Unison/Server/Share/FuzzyFind.hs
+++ b/src/Unison/Server/Share/FuzzyFind.hs
@@ -19,6 +19,10 @@ import Data.List qualified as List
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Ord qualified as Ord
 import Data.Text qualified as Text
+import Servant
+  ( QueryParam,
+    (:>),
+  )
 import Share.Backend qualified as Backend
 import Share.Codebase qualified as Codebase
 import Share.Codebase.Types (CodebaseM)
@@ -29,15 +33,11 @@ import Share.Postgres.NameLookups.Queries qualified as Q
 import Share.Postgres.NameLookups.Types (NamedRef (..), NamesPerspective (..), PathSegments (..))
 import Share.Postgres.NameLookups.Types qualified as NameLookups
 import Share.Prelude
-import Servant
-  ( QueryParam,
-    (:>),
-  )
 import Unison.Codebase.Editor.DisplayObject
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ShortCausalHash qualified as SCH
 import Unison.Codebase.SqliteCodebase.Conversions qualified as Cv
-import Unison.NameSegment
+import Unison.NameSegment.Internal (NameSegment (..))
 import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.PrettyPrintEnvDecl.Postgres qualified as PPED
 import Unison.Server.Backend (termEntryLabeledDependencies, typeEntryLabeledDependencies)

--- a/src/Unison/Server/Share/NamespaceDetails.hs
+++ b/src/Unison/Server/Share/NamespaceDetails.hs
@@ -9,6 +9,7 @@ import Share.Prelude
 import U.Codebase.Causal qualified as Causal
 import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase.Path qualified as Path
+import Unison.NameSegment.Internal (NameSegment (..))
 import Unison.Server.Share.RenderDoc qualified as RenderDoc
 import Unison.Server.Types
   ( NamespaceDetails (..),
@@ -27,4 +28,4 @@ namespaceDetails runtime namespacePath rootCausalId mayWidth = runMaybeT $ do
   mayReadme <- lift $ RenderDoc.findAndRenderDoc readmeNames runtime namespacePath rootCausalId mayWidth
   pure $ NamespaceDetails namespacePath ("#" <> from @CausalHash @UnisonHash causalHashAtPath) mayReadme
   where
-    readmeNames = Set.fromList ["README", "Readme", "ReadMe", "readme"]
+    readmeNames = Set.fromList $ fmap NameSegment ["README", "Readme", "ReadMe", "readme"]

--- a/src/Unison/Server/Share/RenderDoc.hs
+++ b/src/Unison/Server/Share/RenderDoc.hs
@@ -23,7 +23,7 @@ import Share.Prelude
 import U.Codebase.Causal qualified as V2Causal
 import Unison.Codebase.Path qualified as Path
 import Unison.LabeledDependency qualified as LD
-import Unison.NameSegment (NameSegment (..))
+import Unison.NameSegment.Internal (NameSegment (..))
 import Unison.PrettyPrintEnvDecl.Postgres qualified as PostgresPPE
 import Unison.Server.Doc (Doc)
 import Unison.Server.Doc qualified as Doc


### PR DESCRIPTION
Bumps union to latest trunk

Replaces uses of NameSegment with NameSegment.Internal; this is a quick fix, we should come back and re-visit this later to ensure Share is doing proper escaping when pretty-printing escaped names, but this change is no worse than it was before.