### PR TITLE
update to unison 0.5.24

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -26,7 +26,6 @@ packages:
 - unison/lib/unison-util-bytes
 - unison/lib/unison-util-cache
 - unison/lib/unison-util-file-embed
-- unison/lib/unison-util-nametree
 - unison/lib/unison-util-relation
 - unison/lib/unison-util-rope
 - unison/parser-typechecker


### PR DESCRIPTION
This PR just updates the `unison` submodule to the 0.5.24 tag, and updates `stack.yaml` to match.