### PR TITLE
Contribution defn diffs

### DIFF
--- a/src/Share/Postgres/Causal/Queries.hs
+++ b/src/Share/Postgres/Causal/Queries.hs
@@ -14,8 +14,6 @@ module Share.Postgres.Causal.Queries
     expectPgNamespace,
     savePgNamespace,
     saveCausal,
-    loadNamespaceIdForCausal,
-    expectNamespaceIdForCausal,
     tryGetCachedSquashResult,
     saveSquashResult,
     saveV2BranchShallow,
@@ -384,20 +382,6 @@ expectPgNamespace branchHashId = do
           <&> fmap \(nameSegmentId, branchHashId, causalId) ->
             (nameSegmentId, (branchHashId, causalId))
       pure $ Map.fromList childList
-
-loadNamespaceIdForCausal :: (QueryM m) => CausalId -> m (Maybe BranchHashId)
-loadNamespaceIdForCausal causalId = runMaybeT do
-  MaybeT $
-    query1Col
-      [sql| SELECT namespace_hash_id
-            FROM causals
-              WHERE causals.id = #{causalId}
-    |]
-
-expectNamespaceIdForCausal :: (HasCallStack, QueryM m) => CausalId -> m BranchHashId
-expectNamespaceIdForCausal c = do
-  loadNamespaceIdForCausal c
-    `whenNothingM` unrecoverableError (MissingExpectedEntity $ "Expected namespace id for causal: " <> tShow c)
 
 -- | Crawls the namespace tree to find the causal id mounted at a given path from the provided
 -- root causal.

--- a/src/Share/Web/Share/Contributions/API.hs
+++ b/src/Share/Web/Share/Contributions/API.hs
@@ -46,12 +46,12 @@ type ContributionDiffEndpoint =
 type ContributionDiffTermsEndpoint =
   RequiredQueryParam "oldTerm" Name
     :> RequiredQueryParam "newTerm" Name
-    :> Get '[JSON] ShareTermDiffResponse
+    :> Get '[JSON] (Cached JSON ShareTermDiffResponse)
 
 type ContributionDiffTypesEndpoint =
   RequiredQueryParam "oldType" Name
     :> RequiredQueryParam "newType" Name
-    :> Get '[JSON] ShareTypeDiffResponse
+    :> Get '[JSON] (Cached JSON ShareTypeDiffResponse)
 
 type ListContributionsCursor = (UTCTime, ContributionId)
 

--- a/src/Share/Web/Share/Contributions/API.hs
+++ b/src/Share/Web/Share/Contributions/API.hs
@@ -9,10 +9,12 @@ import Share.Contribution (ContributionStatus)
 import Share.IDs
 import Share.Utils.API
 import Share.Utils.Caching (Cached)
+import Share.Utils.Servant (RequiredQueryParam)
 import Share.Web.Share.Comments.API qualified as Comments
 import Share.Web.Share.Contributions.Types
-import Share.Web.Share.Diffs.Types (ShareNamespaceDiffResponse)
+import Share.Web.Share.Diffs.Types (ShareNamespaceDiffResponse, ShareTermDiffResponse, ShareTypeDiffResponse)
 import Share.Web.Share.Types (UserDisplayInfo)
+import Unison.Name (Name)
 
 type ContributionsByUserAPI = ListContributionsByUserEndpoint
 
@@ -24,7 +26,12 @@ type ContributionsByProjectAPI =
 type ContributionResourceServer =
   ( GetContributionByNumber
       :<|> UpdateContributionByNumber
-      :<|> ("diff" :> ContributionDiffEndpoint)
+      :<|> ( "diff"
+               :> ( ("terms" :> ContributionDiffTermsEndpoint)
+                      :<|> ("types" :> ContributionDiffTypesEndpoint)
+                      :<|> ContributionDiffEndpoint
+                  )
+           )
       :<|> ("merge" :> MergeContribution)
       :<|> ( "timeline"
                :> ( GetContributionTimeline
@@ -35,6 +42,16 @@ type ContributionResourceServer =
 
 type ContributionDiffEndpoint =
   Get '[JSON] (Cached JSON ShareNamespaceDiffResponse)
+
+type ContributionDiffTermsEndpoint =
+  RequiredQueryParam "oldTerm" Name
+    :> RequiredQueryParam "newTerm" Name
+    :> Get '[JSON] ShareTermDiffResponse
+
+type ContributionDiffTypesEndpoint =
+  RequiredQueryParam "oldType" Name
+    :> RequiredQueryParam "newType" Name
+    :> Get '[JSON] ShareTypeDiffResponse
 
 type ListContributionsCursor = (UTCTime, ContributionId)
 

--- a/src/Share/Web/Share/Contributions/Impl.hs
+++ b/src/Share/Web/Share/Contributions/Impl.hs
@@ -62,7 +62,10 @@ contributionsByProjectServer session handle projectSlug =
         addServerTag (Proxy @API.ContributionResourceServer) "contribution-number" (IDs.toText contributionNumber) $
           getContributionByNumberEndpoint session handle projectSlug contributionNumber
             :<|> updateContributionByNumberEndpoint session handle projectSlug contributionNumber
-            :<|> contributionDiffEndpoint session handle projectSlug contributionNumber
+            :<|> ( contributionDiffTermsEndpoint
+                     :<|> contributionDiffTypesEndpoint
+                     :<|> contributionDiffEndpoint session handle projectSlug contributionNumber
+                 )
             :<|> mergeContributionEndpoint session handle projectSlug contributionNumber
             :<|> timelineServer contributionNumber
    in listContributionsByProjectEndpoint session handle projectSlug

--- a/src/Share/Web/Share/Diffs/Impl.hs
+++ b/src/Share/Web/Share/Diffs/Impl.hs
@@ -1,6 +1,8 @@
 module Share.Web.Share.Diffs.Impl
   ( diffNamespaces,
     diffCausals,
+    diffTerms,
+    diffTypes,
   )
 where
 
@@ -12,14 +14,25 @@ import Share.Postgres qualified as PG
 import Share.Postgres.Causal.Queries qualified as CausalQ
 import Share.Postgres.IDs (BranchHashId, CausalId)
 import Share.Postgres.NameLookups.Ops qualified as NLOps
+import Share.Postgres.NameLookups.Ops qualified as NameLookupOps
 import Share.Postgres.NameLookups.Types (NameLookupReceipt)
 import Share.Prelude
 import Share.Web.App
 import Share.Web.Authorization (AuthZReceipt)
+import Share.Web.Errors (EntityMissing (..), ErrorID (..), respondError)
 import U.Codebase.Reference qualified as V2Reference
 import U.Codebase.Referent qualified as V2Referent
-import Unison.Server.Types (TermTag, TypeTag)
+import Unison.Codebase.Path qualified as Path
+import Unison.Name (Name)
+import Unison.PrettyPrintEnvDecl qualified as PPED
+import Unison.PrettyPrintEnvDecl.Postgres qualified as PPEPostgres
+import Unison.Server.Backend.DefinitionDiff qualified as DefinitionDiff
+import Unison.Server.NameSearch.Postgres qualified as PGNameSearch
+import Unison.Server.Share.Definitions qualified as Definitions
+import Unison.Server.Types (DisplayObjectDiff, TermDefinition (..), TermTag, TypeDefinition (..), TypeTag)
 import Unison.ShortHash (ShortHash)
+import Unison.Syntax.Name qualified as Name
+import Unison.Util.Pretty (Width)
 
 diffNamespaces ::
   AuthZReceipt ->
@@ -81,3 +94,51 @@ diffCausals !_authZReceipt oldCausalId newCausalId = do
                   pure $ zip typeTags (refs <&> V2Reference.toShortHash)
               )
     pure diffWithTags
+
+diffTerms ::
+  AuthZReceipt ->
+  (Codebase.CodebaseEnv, BranchHashId, Name) ->
+  (Codebase.CodebaseEnv, BranchHashId, Name) ->
+  WebApp (TermDefinition, TermDefinition, DisplayObjectDiff)
+diffTerms !_authZReceipt old@(_, _, oldName) new@(_, _, newName) =
+  do
+    oldTerm@(TermDefinition {termDefinition = oldDisplayObj}) <- getTermDefinition old `whenNothingM` respondError (EntityMissing (ErrorID "term-not-found") ("'From' term not found: " <> Name.toText oldName))
+    newTerm@(TermDefinition {termDefinition = newDisplayObj}) <- getTermDefinition new `whenNothingM` respondError (EntityMissing (ErrorID "term-not-found") ("'To' term not found: " <> Name.toText newName))
+    let termDiffDisplayObject = DefinitionDiff.diffDisplayObjects oldDisplayObj newDisplayObj
+    pure $ (oldTerm, newTerm, termDiffDisplayObject)
+  where
+    renderWidth :: Width
+    renderWidth = 80
+    getTermDefinition :: (Codebase.CodebaseEnv, BranchHashId, Name) -> WebApp (Maybe TermDefinition)
+    getTermDefinition (codebase, bhId, name) = do
+      let perspective = Path.empty
+      (namesPerspective, Identity relocatedName) <- PG.runTransaction $ NameLookupOps.relocateToNameRoot perspective (Identity name) bhId
+      let ppedBuilder deps = (PPED.biasTo [name]) <$> lift (PPEPostgres.ppedForReferences namesPerspective deps)
+      let nameSearch = PGNameSearch.nameSearchForPerspective namesPerspective
+      rt <- Codebase.codebaseRuntime codebase
+      Codebase.runCodebaseTransaction codebase do
+        Definitions.termDefinitionByName ppedBuilder nameSearch renderWidth rt relocatedName
+
+diffTypes ::
+  AuthZReceipt ->
+  (Codebase.CodebaseEnv, BranchHashId, Name) ->
+  (Codebase.CodebaseEnv, BranchHashId, Name) ->
+  WebApp (TypeDefinition, TypeDefinition, DisplayObjectDiff)
+diffTypes !_authZReceipt old@(_, _, oldTypeName) new@(_, _, newTypeName) =
+  do
+    sourceType@(TypeDefinition {typeDefinition = sourceDisplayObj}) <- getTypeDefinition old `whenNothingM` respondError (EntityMissing (ErrorID "type-not-found") ("'From' Type not found: " <> Name.toText oldTypeName))
+    newType@(TypeDefinition {typeDefinition = newDisplayObj}) <- getTypeDefinition new `whenNothingM` respondError (EntityMissing (ErrorID "type-not-found") ("'To' Type not found: " <> Name.toText newTypeName))
+    let typeDiffDisplayObject = DefinitionDiff.diffDisplayObjects sourceDisplayObj newDisplayObj
+    pure $ (sourceType, newType, typeDiffDisplayObject)
+  where
+    renderWidth :: Width
+    renderWidth = 80
+    getTypeDefinition :: (Codebase.CodebaseEnv, BranchHashId, Name) -> WebApp (Maybe TypeDefinition)
+    getTypeDefinition (codebase, bhId, name) = do
+      let perspective = Path.empty
+      (namesPerspective, Identity relocatedName) <- PG.runTransaction $ NameLookupOps.relocateToNameRoot perspective (Identity name) bhId
+      let ppedBuilder deps = (PPED.biasTo [name]) <$> lift (PPEPostgres.ppedForReferences namesPerspective deps)
+      let nameSearch = PGNameSearch.nameSearchForPerspective namesPerspective
+      rt <- Codebase.codebaseRuntime codebase
+      Codebase.runCodebaseTransaction codebase do
+        Definitions.typeDefinitionByName ppedBuilder nameSearch renderWidth rt relocatedName

--- a/src/Share/Web/Share/Diffs/Impl.hs
+++ b/src/Share/Web/Share/Diffs/Impl.hs
@@ -67,12 +67,12 @@ diffCausals !_authZReceipt oldCausalId newCausalId = do
   -- Ensure name lookups for each thing we're diffing.
   -- We do this in two separate transactions to ensure we can still make progress even if we need to build name lookups.
   (oldBranchHashId, oldBranchNLReceipt) <- PG.runTransaction $ do
-    oldBranchHashId <- CausalQ.expectNamespaceIdForCausal oldCausalId
+    oldBranchHashId <- CausalQ.expectNamespaceIdsByCausalIdsOf id oldCausalId
     oldBranchNLReceipt <- NLOps.ensureNameLookupForBranchId oldBranchHashId
     pure (oldBranchHashId, oldBranchNLReceipt)
 
   (newBranchHashId, newNLReceipt) <- PG.runTransaction $ do
-    newBranchHashId <- CausalQ.expectNamespaceIdForCausal newCausalId
+    newBranchHashId <- CausalQ.expectNamespaceIdsByCausalIdsOf id newCausalId
     newNLReceipt <- NLOps.ensureNameLookupForBranchId newBranchHashId
     pure (newBranchHashId, newNLReceipt)
 

--- a/src/Share/Web/Share/Projects/API.hs
+++ b/src/Share/Web/Share/Projects/API.hs
@@ -10,7 +10,7 @@ import Share.Utils.Caching (Cached)
 import Share.Utils.Servant (RequiredQueryParam)
 import Share.Web.Share.Branches.API (ProjectBranchesAPI)
 import Share.Web.Share.Contributions.API (ContributionsByProjectAPI)
-import Share.Web.Share.Diffs.Types (ShareNamespaceDiffResponse)
+import Share.Web.Share.Diffs.Types (ShareNamespaceDiffResponse, ShareTermDiffResponse, ShareTypeDiffResponse)
 import Share.Web.Share.Projects.Types
 import Share.Web.Share.Releases.API
 import Share.Web.Share.Tickets.API (TicketsByProjectAPI)

--- a/src/Share/Web/Share/Projects/Impl.hs
+++ b/src/Share/Web/Share/Projects/Impl.hs
@@ -22,7 +22,6 @@ import Share.OAuth.Session
 import Share.Postgres qualified as PG
 import Share.Postgres.Causal.Queries qualified as CausalQ
 import Share.Postgres.IDs (BranchHashId, CausalId)
-import Share.Postgres.NameLookups.Ops qualified as NameLookupOps
 import Share.Postgres.Ops qualified as PGO
 import Share.Postgres.Projects.Queries qualified as ProjectsQ
 import Share.Postgres.Queries qualified as Q
@@ -42,23 +41,14 @@ import Share.Web.Errors
 import Share.Web.Share.Branches.Impl (branchesServer, getProjectBranchReadmeEndpoint)
 import Share.Web.Share.Contributions.Impl (contributionsByProjectServer)
 import Share.Web.Share.Diffs.Impl qualified as Diffs
-import Share.Web.Share.Diffs.Types (ShareNamespaceDiffResponse (..))
+import Share.Web.Share.Diffs.Types (ShareNamespaceDiffResponse (..), ShareTermDiffResponse (..), ShareTypeDiffResponse (..))
 import Share.Web.Share.Projects.API qualified as API
 import Share.Web.Share.Projects.Types
 import Share.Web.Share.Releases.Impl (getProjectReleaseReadmeEndpoint, releasesServer)
 import Share.Web.Share.Tickets.Impl (ticketsByProjectServer)
 import Share.Web.Share.Types
-import Unison.Codebase.Path qualified as Path
 import Unison.Name (Name)
-import Unison.PrettyPrintEnvDecl qualified as PPED
-import Unison.PrettyPrintEnvDecl.Postgres qualified as PPEPostgres
-import Unison.Server.Backend.DefinitionDiff qualified as DefinitionDiff
-import Unison.Server.NameSearch.Postgres qualified as PGNameSearch
 import Unison.Server.Orphans ()
-import Unison.Server.Share.Definitions qualified as Definitions
-import Unison.Server.Types (TermDefinition (..), TypeDefinition (..))
-import Unison.Syntax.Name qualified as Name
-import Unison.Util.Pretty (Width)
 
 data ProjectErrors
   = MaintainersAlreadyExist [UserId]
@@ -196,9 +186,10 @@ diffTermsEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug 
     project <- PG.runTransactionOrRespondError do
       Q.projectByShortHand projectShortHand `whenNothingM` throwError (EntityMissing (ErrorID "project-not-found") ("Project not found: " <> IDs.toText @IDs.ProjectShortHand projectShortHand))
     authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectBranchDiff callerUserId project
-    oldTerm@(TermDefinition {termDefinition = oldDisplayObj}) <- getTermDefinition authZReceipt project oldShortHand oldTermName `whenNothingM` respondError (EntityMissing (ErrorID "term-not-found") ("Term not found: " <> IDs.toText oldShortHand <> ":" <> Name.toText oldTermName))
-    newTerm@(TermDefinition {termDefinition = newDisplayObj}) <- getTermDefinition authZReceipt project newShortHand newTermName `whenNothingM` respondError (EntityMissing (ErrorID "term-not-found") ("Term not found: " <> IDs.toText newShortHand <> ":" <> Name.toText newTermName))
-    let termDiffDisplayObject = DefinitionDiff.diffDisplayObjects oldDisplayObj newDisplayObj
+
+    (oldCodebase, _causalId, oldBhId) <- namespaceHashForBranchOrRelease authZReceipt project oldShortHand
+    (newCodebase, _newCausalId, newBhId) <- namespaceHashForBranchOrRelease authZReceipt project newShortHand
+    (oldTerm, newTerm, displayObjectDiff) <- Diffs.diffTerms authZReceipt (oldCodebase, oldBhId, oldTermName) (newCodebase, newBhId, newTermName)
     pure $
       ShareTermDiffResponse
         { project = projectShortHand,
@@ -206,22 +197,9 @@ diffTermsEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug 
           newBranch = newShortHand,
           oldTerm = oldTerm,
           newTerm = newTerm,
-          diff = termDiffDisplayObject
+          diff = displayObjectDiff
         }
   where
-    renderWidth :: Width
-    renderWidth = 80
-    getTermDefinition :: AuthZ.AuthZReceipt -> Project -> IDs.BranchOrReleaseShortHand -> Name -> WebApp (Maybe TermDefinition)
-    getTermDefinition authZReceipt project shorthand name = do
-      (codebase, _causalId, bhId) <- namespaceHashForBranchOrRelease authZReceipt project shorthand
-      let perspective = Path.empty
-      (namesPerspective, Identity relocatedName) <- PG.runTransaction $ NameLookupOps.relocateToNameRoot perspective (Identity name) bhId
-      let ppedBuilder deps = (PPED.biasTo [name]) <$> lift (PPEPostgres.ppedForReferences namesPerspective deps)
-      let nameSearch = PGNameSearch.nameSearchForPerspective namesPerspective
-      rt <- Codebase.codebaseRuntime codebase
-      Codebase.runCodebaseTransaction codebase do
-        Definitions.termDefinitionByName ppedBuilder nameSearch renderWidth rt relocatedName
-
     projectShortHand :: IDs.ProjectShortHand
     projectShortHand = IDs.ProjectShortHand {userHandle, projectSlug}
 
@@ -239,32 +217,20 @@ diffTypesEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug 
     project <- PG.runTransactionOrRespondError do
       Q.projectByShortHand projectShortHand `whenNothingM` throwError (EntityMissing (ErrorID "project-not-found") ("Project not found: " <> IDs.toText @IDs.ProjectShortHand projectShortHand))
     authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectBranchDiff callerUserId project
-    sourceType@(TypeDefinition {typeDefinition = sourceDisplayObj}) <- getTypeDefinition authZReceipt project oldShortHand oldTypeName `whenNothingM` respondError (EntityMissing (ErrorID "type-not-found") ("Type not found: " <> IDs.toText oldShortHand <> ":" <> Name.toText oldTypeName))
-    newType@(TypeDefinition {typeDefinition = newDisplayObj}) <- getTypeDefinition authZReceipt project newShortHand newTypeName `whenNothingM` respondError (EntityMissing (ErrorID "type-not-found") ("Type not found: " <> IDs.toText newShortHand <> ":" <> Name.toText newTypeName))
-    let typeDiffDisplayObject = DefinitionDiff.diffDisplayObjects sourceDisplayObj newDisplayObj
+
+    (oldCodebase, _causalId, oldBhId) <- namespaceHashForBranchOrRelease authZReceipt project oldShortHand
+    (newCodebase, _newCausalId, newBhId) <- namespaceHashForBranchOrRelease authZReceipt project newShortHand
+    (oldType, newType, typeDiffDisplayObject) <- Diffs.diffTypes authZReceipt (oldCodebase, oldBhId, oldTypeName) (newCodebase, newBhId, newTypeName)
     pure $
       ShareTypeDiffResponse
         { project = projectShortHand,
           oldBranch = oldShortHand,
           newBranch = newShortHand,
-          oldType = sourceType,
+          oldType = oldType,
           newType = newType,
           diff = typeDiffDisplayObject
         }
   where
-    renderWidth :: Width
-    renderWidth = 80
-    getTypeDefinition :: AuthZ.AuthZReceipt -> Project -> IDs.BranchOrReleaseShortHand -> Name -> WebApp (Maybe TypeDefinition)
-    getTypeDefinition authZReceipt project shorthand name = do
-      (codebase, _causalId, bhId) <- namespaceHashForBranchOrRelease authZReceipt project shorthand
-      let perspective = Path.empty
-      (namesPerspective, Identity relocatedName) <- PG.runTransaction $ NameLookupOps.relocateToNameRoot perspective (Identity name) bhId
-      let ppedBuilder deps = (PPED.biasTo [name]) <$> lift (PPEPostgres.ppedForReferences namesPerspective deps)
-      let nameSearch = PGNameSearch.nameSearchForPerspective namesPerspective
-      rt <- Codebase.codebaseRuntime codebase
-      Codebase.runCodebaseTransaction codebase do
-        Definitions.typeDefinitionByName ppedBuilder nameSearch renderWidth rt relocatedName
-
     projectShortHand :: IDs.ProjectShortHand
     projectShortHand = IDs.ProjectShortHand {userHandle, projectSlug}
 

--- a/src/Share/Web/Share/Projects/Types.hs
+++ b/src/Share/Web/Share/Projects/Types.hs
@@ -19,7 +19,6 @@ import Share.Project (Project (..), ProjectTag, ProjectVisibility (..))
 import Share.Utils.API
 import Share.Web.Authorization.Types (ProjectMaintainerPermissions)
 import Share.Web.Share.Types (UserDisplayInfo)
-import Unison.Server.Types (DisplayObjectDiff (..), TermDefinition, TypeDefinition)
 
 projectToAPI :: ProjectOwner -> Project -> APIProject
 projectToAPI projectOwner Project {slug, visibility, createdAt, updatedAt, summary, tags} =
@@ -277,70 +276,6 @@ instance ToJSON AddMaintainersResponse where
       [ "maintainers" Aeson..= maintainers
       ]
 
-data ShareTermDiffResponse = ShareTermDiffResponse
-  { project :: ProjectShortHand,
-    oldBranch :: BranchOrReleaseShortHand,
-    newBranch :: BranchOrReleaseShortHand,
-    oldTerm :: TermDefinition,
-    newTerm :: TermDefinition,
-    diff :: DisplayObjectDiff
-  }
-
-instance ToJSON ShareTermDiffResponse where
-  toJSON (ShareTermDiffResponse {diff, project, oldBranch, newBranch, oldTerm, newTerm}) =
-    case diff of
-      DisplayObjectDiff dispDiff ->
-        object
-          [ "diff" .= dispDiff,
-            "diffKind" .= ("diff" :: Text),
-            "project" .= project,
-            "oldBranchRef" .= oldBranch,
-            "newBranchRef" .= newBranch,
-            "oldTerm" .= oldTerm,
-            "newTerm" .= newTerm
-          ]
-      MismatchedDisplayObjects {} ->
-        object
-          [ "diffKind" .= ("mismatched" :: Text),
-            "project" .= project,
-            "oldBranchRef" .= oldBranch,
-            "newBranchRef" .= newBranch,
-            "oldTerm" .= oldTerm,
-            "newTerm" .= newTerm
-          ]
-
-data ShareTypeDiffResponse = ShareTypeDiffResponse
-  { project :: ProjectShortHand,
-    oldBranch :: BranchOrReleaseShortHand,
-    newBranch :: BranchOrReleaseShortHand,
-    oldType :: TypeDefinition,
-    newType :: TypeDefinition,
-    diff :: DisplayObjectDiff
-  }
-
-instance ToJSON ShareTypeDiffResponse where
-  toJSON (ShareTypeDiffResponse {diff, project, oldBranch, newBranch, oldType, newType}) =
-    case diff of
-      DisplayObjectDiff dispDiff ->
-        object
-          [ "diff" .= dispDiff,
-            "diffKind" .= ("diff" :: Text),
-            "project" .= project,
-            "oldBranchRef" .= oldBranch,
-            "newBranchRef" .= newBranch,
-            "oldType" .= oldType,
-            "newType" .= newType
-          ]
-      MismatchedDisplayObjects {} ->
-        object
-          [ "diffKind" .= ("mismatched" :: Text),
-            "project" .= project,
-            "oldBranchRef" .= oldBranch,
-            "newBranchRef" .= newBranch,
-            "oldType" .= oldType,
-            "newType" .= newType
-          ]
-
 data UpdateMaintainersResponse = UpdateMaintainersResponse
   { maintainers :: [Maintainer UserDisplayInfo]
   }
@@ -357,14 +292,14 @@ data Maintainer user = Maintainer
   }
   deriving (Show, Functor, Foldable, Traversable)
 
-instance ToJSON user => ToJSON (Maintainer user) where
+instance (ToJSON user) => ToJSON (Maintainer user) where
   toJSON Maintainer {..} =
     object
       [ "user" Aeson..= user,
         "permissions" Aeson..= permissions
       ]
 
-instance FromJSON user => FromJSON (Maintainer user) where
+instance (FromJSON user) => FromJSON (Maintainer user) where
   parseJSON = Aeson.withObject "Maintainer" $ \o -> do
     user <- o Aeson..: "user"
     permissions <- o Aeson..: "permissions"

--- a/src/Unison/Server/Share/Definitions.hs
+++ b/src/Unison/Server/Share/Definitions.hs
@@ -79,7 +79,7 @@ definitionForHQName ::
   HQ.HashQualified Name ->
   Codebase.CodebaseM e DefinitionDisplayResults
 definitionForHQName perspective rootCausalId renderWidth suffixifyBindings rt perspectiveQuery = do
-  rootBranchNamespaceHashId <- CausalQ.expectNamespaceIdForCausal rootCausalId
+  rootBranchNamespaceHashId <- CausalQ.expectNamespaceIdsByCausalIdsOf id rootCausalId
   (namesPerspective, query) <- NameLookupOps.relocateToNameRoot perspective perspectiveQuery rootBranchNamespaceHashId
   Debug.debugM Debug.Server "definitionForHQName: (namesPerspective, query)" (namesPerspective, query)
   -- Bias towards both relative and absolute path to queries,

--- a/src/Unison/Server/Share/RenderDoc.hs
+++ b/src/Unison/Server/Share/RenderDoc.hs
@@ -14,7 +14,6 @@ import Data.Set qualified as Set
 import Share.Backend qualified as Backend
 import Share.Codebase.Types (CodebaseM, CodebaseRuntime)
 import Share.Postgres.Causal.Queries qualified as CausalQ
-import Share.Postgres.Causal.Queries qualified as HashQ
 import Share.Postgres.IDs (CausalId)
 import Share.Postgres.NameLookups.Ops qualified as NLOps
 import Share.Postgres.NameLookups.Types (PathSegments (..))
@@ -40,7 +39,7 @@ findAndRenderDoc ::
   Maybe Width ->
   CodebaseM e (Maybe Doc)
 findAndRenderDoc docNames runtime namespacePath rootCausalId _mayWidth = runMaybeT do
-  rootNamespaceHashId <- lift $ HashQ.expectNamespaceIdForCausal rootCausalId
+  rootNamespaceHashId <- lift $ CausalQ.expectNamespaceIdsByCausalIdsOf id rootCausalId
   namespaceCausal <- MaybeT $ CausalQ.loadCausalNamespaceAtPath rootCausalId namespacePath
   shallowBranchAtNamespace <- lift $ V2Causal.value namespaceCausal
   namesPerspective <- NLOps.namesPerspectiveForRootAndPath rootNamespaceHashId (coerce $ Path.toList namespacePath)

--- a/transcripts/share-apis/contribution-diffs/contribution-diff.json
+++ b/transcripts/share-apis/contribution-diffs/contribution-diff.json
@@ -453,7 +453,7 @@
     "newRefHash": "#1f9oqkrlfnkhnmfh29c9oiuvlbbta0j29nsmu4me709ber295aji2nuv2t8q7e6pfeji1ge1scdblb4qbg3uvlmcbuiesc8q88e0bqo",
     "oldRef": "diff-start",
     "oldRefHash": "#odojlhcu8m0iaajcjug8mkd84rqib8s273rf46rnn281trtqu56mgkogp2o71ajsmvpvamqo4lvotqj5kare46ci5t26m4oe2vpqjvo",
-    "project": "@transcripts/namespace-diff"
+    "project": "@transcripts/contribution-diff"
   },
   "status": [
     {

--- a/transcripts/share-apis/contribution-diffs/create-contribution-for-diff.json
+++ b/transcripts/share-apis/contribution-diffs/create-contribution-for-diff.json
@@ -11,7 +11,7 @@
     "id": "C-<UUID>",
     "numComments": 0,
     "number": 1,
-    "projectRef": "@transcripts/namespace-diff",
+    "projectRef": "@transcripts/contribution-diff",
     "sourceBranchRef": "diff-end",
     "status": "in_review",
     "targetBranchRef": "diff-start",

--- a/transcripts/share-apis/contribution-diffs/namespace-diff.json
+++ b/transcripts/share-apis/contribution-diffs/namespace-diff.json
@@ -453,7 +453,7 @@
     "newRefHash": "#1f9oqkrlfnkhnmfh29c9oiuvlbbta0j29nsmu4me709ber295aji2nuv2t8q7e6pfeji1ge1scdblb4qbg3uvlmcbuiesc8q88e0bqo",
     "oldRef": "diff-start",
     "oldRefHash": "#odojlhcu8m0iaajcjug8mkd84rqib8s273rf46rnn281trtqu56mgkogp2o71ajsmvpvamqo4lvotqj5kare46ci5t26m4oe2vpqjvo",
-    "project": "@transcripts/namespace-diff"
+    "project": "@transcripts/contribution-diff"
   },
   "status": [
     {

--- a/transcripts/share-apis/contribution-diffs/prelude.md
+++ b/transcripts/share-apis/contribution-diffs/prelude.md
@@ -1,7 +1,7 @@
 ```ucm:hide
-.> project.create-empty namespace-diff
-namespace-diff/main> branch /diff-start
-namespace-diff/diff-start> builtins.mergeio
+.> project.create-empty contribution-diff
+contribution-diff/main> branch /diff-start
+contribution-diff/diff-start> builtins.mergeio
 ```
 
 ```unison
@@ -48,22 +48,22 @@ deleteMeAfterFork = "delete me after fork"
 ```
 
 ```ucm:hide
-namespace-diff/diff-start> add
-namespace-diff/diff-start> push @transcripts/namespace-diff/diff-start
-namespace-diff/diff-start> branch /diff-end
-namespace-diff/diff-end> alias.term termAliasMe aTermAlias
-namespace-diff/diff-end> delete.term termDeleteMe
-namespace-diff/diff-end> alias.type DataAliasMe ATypeAlias
-namespace-diff/diff-end> delete.type DataDeleteMe
-namespace-diff/diff-end> delete.namespace DataDeleteMe
-namespace-diff/diff-end> alias.type AbilityAliasMe AbilityAlias
-namespace-diff/diff-end> delete.type AbilityDeleteMe
-namespace-diff/diff-end> delete.namespace AbilityDeleteMe
-namespace-diff/diff-end> delete.term a.definition.at.path1
-namespace-diff/diff-end> delete.term a.definition.at.path2
-namespace-diff/diff-end> delete.term a.different.path
-namespace-diff/diff-end> delete.term aDoc
-namespace-diff/diff-end> delete.term aTest
+contribution-diff/diff-start> add
+contribution-diff/diff-start> push @transcripts/contribution-diff/diff-start
+contribution-diff/diff-start> branch /diff-end
+contribution-diff/diff-end> alias.term termAliasMe aTermAlias
+contribution-diff/diff-end> delete.term termDeleteMe
+contribution-diff/diff-end> alias.type DataAliasMe ATypeAlias
+contribution-diff/diff-end> delete.type DataDeleteMe
+contribution-diff/diff-end> delete.namespace DataDeleteMe
+contribution-diff/diff-end> alias.type AbilityAliasMe AbilityAlias
+contribution-diff/diff-end> delete.type AbilityDeleteMe
+contribution-diff/diff-end> delete.namespace AbilityDeleteMe
+contribution-diff/diff-end> delete.term a.definition.at.path1
+contribution-diff/diff-end> delete.term a.definition.at.path2
+contribution-diff/diff-end> delete.term a.different.path
+contribution-diff/diff-end> delete.term aDoc
+contribution-diff/diff-end> delete.term aTest
 ```
 
 ```unison
@@ -83,13 +83,13 @@ ability AbilityNew where
 ```
 
 ```ucm
-namespace-diff/diff-end> update
-namespace-diff/diff-end> rename.term termRenameMe renamedTerm
-namespace-diff/diff-end> rename.type DataRenameMe RenamedType
-namespace-diff/diff-end> rename.namespace DataRenameMe RenamedType
-namespace-diff/diff-end> rename.type AbilityRenameMe AbilityRenamed
-namespace-diff/diff-end> rename.namespace AbilityRenameMe AbilityRenamed
-namespace-diff/diff-end> push @transcripts/namespace-diff/diff-end
+contribution-diff/diff-end> update
+contribution-diff/diff-end> rename.term termRenameMe renamedTerm
+contribution-diff/diff-end> rename.type DataRenameMe RenamedType
+contribution-diff/diff-end> rename.namespace DataRenameMe RenamedType
+contribution-diff/diff-end> rename.type AbilityRenameMe AbilityRenamed
+contribution-diff/diff-end> rename.namespace AbilityRenameMe AbilityRenamed
+contribution-diff/diff-end> push @transcripts/contribution-diff/diff-end
 ```
 
 Now we go back to the `diff-start` branch and make some more commits to test that 
@@ -103,7 +103,7 @@ termUpdateMe = "conflicted update"
 ```
 
 ```ucm
-namespace-diff/diff-start> update
-namespace-diff/diff-start> delete.term deleteMeAfterFork
-namespace-diff/diff-start> push @transcripts/namespace-diff/diff-start
+contribution-diff/diff-start> update
+contribution-diff/diff-start> delete.term deleteMeAfterFork
+contribution-diff/diff-start> push @transcripts/contribution-diff/diff-start
 ```

--- a/transcripts/share-apis/contribution-diffs/run.zsh
+++ b/transcripts/share-apis/contribution-diffs/run.zsh
@@ -6,9 +6,9 @@ source "../../transcript_helpers.sh"
 
 transcript_ucm transcript prelude.md
 
-fetch "$transcript_user" GET namespace-diff '/users/transcripts/projects/namespace-diff/diff/namespaces?old=diff-start&new=diff-end'
+fetch "$transcript_user" GET namespace-diff '/users/transcripts/projects/contribution-diff/diff/namespaces?old=diff-start&new=diff-end'
 
-fetch "$transcript_user" POST create-contribution-for-diff '/users/transcripts/projects/namespace-diff/contributions' '{
+fetch "$transcript_user" POST create-contribution-for-diff '/users/transcripts/projects/contribution-diff/contributions' '{
     "title": "My contribution",
     "description": "My description",
     "status": "in_review",
@@ -16,4 +16,10 @@ fetch "$transcript_user" POST create-contribution-for-diff '/users/transcripts/p
     "targetBranchRef": "diff-start"
 }'
 
-fetch "$transcript_user" GET contribution-diff '/users/transcripts/projects/namespace-diff/contributions/1/diff'
+fetch "$transcript_user" GET contribution-diff '/users/transcripts/projects/contribution-diff/contributions/1/diff'
+
+# Diffing a user-defined term against a user-defined term.
+fetch "$transcript_user" GET standard-term-diff '/users/transcripts/projects/contribution-diff/contributions/1/diff/terms?oldTerm=termUpdateMe&newTerm=termUpdateMe'
+
+# Diffing a user-defined type against a user-defined type.
+fetch "$transcript_user" GET standard-type-diff '/users/transcripts/projects/contribution-diff/contributions/1/diff/types?oldType=DataUpdateMe&newType=DataUpdateMe'

--- a/transcripts/share-apis/contribution-diffs/standard-term-diff.json
+++ b/transcripts/share-apis/contribution-diffs/standard-term-diff.json
@@ -1,0 +1,222 @@
+{
+  "body": {
+    "diff": {
+      "contents": [
+        {
+          "diffTag": "both",
+          "elements": [
+            {
+              "annotation": {
+                "contents": "termUpdateMe",
+                "tag": "HashQualifier"
+              },
+              "segment": "termUpdateMe"
+            },
+            {
+              "annotation": {
+                "tag": "TypeAscriptionColon"
+              },
+              "segment": " :"
+            },
+            {
+              "annotation": null,
+              "segment": " "
+            },
+            {
+              "annotation": {
+                "contents": "##Text",
+                "tag": "TypeReference"
+              },
+              "segment": "Text"
+            },
+            {
+              "annotation": null,
+              "segment": "\n"
+            },
+            {
+              "annotation": {
+                "contents": "termUpdateMe",
+                "tag": "HashQualifier"
+              },
+              "segment": "termUpdateMe"
+            },
+            {
+              "annotation": {
+                "tag": "BindingEquals"
+              },
+              "segment": " ="
+            },
+            {
+              "annotation": null,
+              "segment": " "
+            }
+          ]
+        },
+        {
+          "annotation": {
+            "tag": "TextLiteral"
+          },
+          "diffTag": "segmentChange",
+          "fromSegment": "\"original\"",
+          "toSegment": "\"updated\""
+        }
+      ],
+      "tag": "UserObject"
+    },
+    "diffKind": "diff",
+    "newBranchRef": "diff-end",
+    "newTerm": {
+      "bestTermName": "termUpdateMe",
+      "defnTermTag": "Plain",
+      "signature": [
+        {
+          "annotation": {
+            "contents": "##Text",
+            "tag": "TypeReference"
+          },
+          "segment": "Text"
+        }
+      ],
+      "termDefinition": {
+        "contents": [
+          {
+            "annotation": {
+              "contents": "termUpdateMe",
+              "tag": "HashQualifier"
+            },
+            "segment": "termUpdateMe"
+          },
+          {
+            "annotation": {
+              "tag": "TypeAscriptionColon"
+            },
+            "segment": " :"
+          },
+          {
+            "annotation": null,
+            "segment": " "
+          },
+          {
+            "annotation": {
+              "contents": "##Text",
+              "tag": "TypeReference"
+            },
+            "segment": "Text"
+          },
+          {
+            "annotation": null,
+            "segment": "\n"
+          },
+          {
+            "annotation": {
+              "contents": "termUpdateMe",
+              "tag": "HashQualifier"
+            },
+            "segment": "termUpdateMe"
+          },
+          {
+            "annotation": {
+              "tag": "BindingEquals"
+            },
+            "segment": " ="
+          },
+          {
+            "annotation": null,
+            "segment": " "
+          },
+          {
+            "annotation": {
+              "tag": "TextLiteral"
+            },
+            "segment": "\"updated\""
+          }
+        ],
+        "tag": "UserObject"
+      },
+      "termDocs": [],
+      "termNames": [
+        "termUpdateMe"
+      ]
+    },
+    "oldBranchRef": "diff-start",
+    "oldTerm": {
+      "bestTermName": "termUpdateMe",
+      "defnTermTag": "Plain",
+      "signature": [
+        {
+          "annotation": {
+            "contents": "##Text",
+            "tag": "TypeReference"
+          },
+          "segment": "Text"
+        }
+      ],
+      "termDefinition": {
+        "contents": [
+          {
+            "annotation": {
+              "contents": "termUpdateMe",
+              "tag": "HashQualifier"
+            },
+            "segment": "termUpdateMe"
+          },
+          {
+            "annotation": {
+              "tag": "TypeAscriptionColon"
+            },
+            "segment": " :"
+          },
+          {
+            "annotation": null,
+            "segment": " "
+          },
+          {
+            "annotation": {
+              "contents": "##Text",
+              "tag": "TypeReference"
+            },
+            "segment": "Text"
+          },
+          {
+            "annotation": null,
+            "segment": "\n"
+          },
+          {
+            "annotation": {
+              "contents": "termUpdateMe",
+              "tag": "HashQualifier"
+            },
+            "segment": "termUpdateMe"
+          },
+          {
+            "annotation": {
+              "tag": "BindingEquals"
+            },
+            "segment": " ="
+          },
+          {
+            "annotation": null,
+            "segment": " "
+          },
+          {
+            "annotation": {
+              "tag": "TextLiteral"
+            },
+            "segment": "\"original\""
+          }
+        ],
+        "tag": "UserObject"
+      },
+      "termDocs": [],
+      "termNames": [
+        "termUpdateMe"
+      ]
+    },
+    "project": "@transcripts/contribution-diff"
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/contribution-diffs/standard-type-diff.json
+++ b/transcripts/share-apis/contribution-diffs/standard-type-diff.json
@@ -1,0 +1,178 @@
+{
+  "body": {
+    "diff": {
+      "contents": [
+        {
+          "diffTag": "both",
+          "elements": [
+            {
+              "annotation": {
+                "tag": "DataTypeKeyword"
+              },
+              "segment": "type"
+            },
+            {
+              "annotation": null,
+              "segment": " "
+            },
+            {
+              "annotation": {
+                "contents": "DataUpdateMe",
+                "tag": "HashQualifier"
+              },
+              "segment": "DataUpdateMe"
+            },
+            {
+              "annotation": {
+                "tag": "DelimiterChar"
+              },
+              "segment": " = "
+            }
+          ]
+        },
+        {
+          "diffTag": "old",
+          "elements": [
+            {
+              "annotation": {
+                "contents": "#fhc8jn2bhvfdnfr89dv2jf7tekuesna7gvje4ck6lfheh9rb184q4ddd29vm9mvfm6u1a98kpgditn8vb09durtel67rpof1c62535o#d0",
+                "tag": "TermReference"
+              },
+              "segment": "D"
+            }
+          ]
+        },
+        {
+          "diffTag": "new",
+          "elements": [
+            {
+              "annotation": {
+                "contents": "#qnblpurkqedrq0kae95ep7b8f6uh5b7igefp21r1nvl22agjoup5e7aunua4q8ku8mb532fh3lst4mj3m2bsb3kluchc3fuau5cllr0#d0",
+                "tag": "TermReference"
+              },
+              "segment": "D2"
+            },
+            {
+              "annotation": null,
+              "segment": " "
+            },
+            {
+              "annotation": {
+                "contents": "##Nat",
+                "tag": "TypeReference"
+              },
+              "segment": "Nat"
+            }
+          ]
+        }
+      ],
+      "tag": "UserObject"
+    },
+    "diffKind": "diff",
+    "newBranchRef": "diff-end",
+    "newType": {
+      "bestTypeName": "DataUpdateMe",
+      "defnTypeTag": "Data",
+      "typeDefinition": {
+        "contents": [
+          {
+            "annotation": {
+              "tag": "DataTypeKeyword"
+            },
+            "segment": "type"
+          },
+          {
+            "annotation": null,
+            "segment": " "
+          },
+          {
+            "annotation": {
+              "contents": "DataUpdateMe",
+              "tag": "HashQualifier"
+            },
+            "segment": "DataUpdateMe"
+          },
+          {
+            "annotation": {
+              "tag": "DelimiterChar"
+            },
+            "segment": " = "
+          },
+          {
+            "annotation": {
+              "contents": "#qnblpurkqedrq0kae95ep7b8f6uh5b7igefp21r1nvl22agjoup5e7aunua4q8ku8mb532fh3lst4mj3m2bsb3kluchc3fuau5cllr0#d0",
+              "tag": "TermReference"
+            },
+            "segment": "D2"
+          },
+          {
+            "annotation": null,
+            "segment": " "
+          },
+          {
+            "annotation": {
+              "contents": "##Nat",
+              "tag": "TypeReference"
+            },
+            "segment": "Nat"
+          }
+        ],
+        "tag": "UserObject"
+      },
+      "typeDocs": [],
+      "typeNames": [
+        "DataUpdateMe"
+      ]
+    },
+    "oldBranchRef": "diff-start",
+    "oldType": {
+      "bestTypeName": "DataUpdateMe",
+      "defnTypeTag": "Data",
+      "typeDefinition": {
+        "contents": [
+          {
+            "annotation": {
+              "tag": "DataTypeKeyword"
+            },
+            "segment": "type"
+          },
+          {
+            "annotation": null,
+            "segment": " "
+          },
+          {
+            "annotation": {
+              "contents": "DataUpdateMe",
+              "tag": "HashQualifier"
+            },
+            "segment": "DataUpdateMe"
+          },
+          {
+            "annotation": {
+              "tag": "DelimiterChar"
+            },
+            "segment": " = "
+          },
+          {
+            "annotation": {
+              "contents": "#fhc8jn2bhvfdnfr89dv2jf7tekuesna7gvje4ck6lfheh9rb184q4ddd29vm9mvfm6u1a98kpgditn8vb09durtel67rpof1c62535o#d0",
+              "tag": "TermReference"
+            },
+            "segment": "D"
+          }
+        ],
+        "tag": "UserObject"
+      },
+      "typeDocs": [],
+      "typeNames": [
+        "DataUpdateMe"
+      ]
+    },
+    "project": "@transcripts/contribution-diff"
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}


### PR DESCRIPTION
## Overview

A small wrapper around the existing term and type diff apis which is scoped to contributions. This will allow us to use the best common ancestor for definition diffs, solving the bug we have where the diff of a PR changes unexpected when it's merged.

## Implementation

Adds two new endpoints:

* `/users/<handle>/projects/<slug>/contributions/<n>/diff/terms?oldTerm=old.name&newTerm=new.name`
* `/users/<handle>/projects/<slug>/contributions/<n>/diff/terms?oldType=old.name&newType=new.name`

These behave identically to the existing definition diff endpoints except that they use the best-common-ancestor that's saved on the contribution as the diff base.