### PR TITLE
Pipeline a bunch of sync operations

### DIFF
--- a/src/Share/Backend.hs
+++ b/src/Share/Backend.hs
@@ -142,7 +142,7 @@ mkTermDefinition termPPED width r docs tm = do
           docs
 
 termListEntry ::
-  (PG.QueryM m) =>
+  (PG.QueryM m e) =>
   Type Symbol Ann ->
   ExactName NameSegment V2Referent.Referent ->
   m (Backend.TermEntry Symbol Ann)
@@ -160,7 +160,7 @@ termListEntry typ (ExactName nameSegment ref) = do
       }
 
 typeListEntry ::
-  (PG.QueryM m) =>
+  (PG.QueryM m e) =>
   ExactName NameSegment Reference ->
   m Backend.TypeEntry
 typeListEntry (ExactName nameSegment ref) = do
@@ -176,7 +176,7 @@ typeListEntry (ExactName nameSegment ref) = do
       }
 
 getTermTag ::
-  (PG.QueryM m, Var v) =>
+  (PG.QueryM m e, Var v) =>
   V2Referent.Referent ->
   Type v Ann ->
   m TermTag
@@ -199,7 +199,7 @@ getTermTag r termType = do
       | otherwise -> Plain
 
 getTypeTag ::
-  (PG.QueryM m) =>
+  (PG.QueryM m e) =>
   Reference.TypeReference ->
   m TypeTag
 getTypeTag r = do

--- a/src/Share/Codebase.hs
+++ b/src/Share/Codebase.hs
@@ -278,10 +278,10 @@ expectTypeOfReferents :: Traversal s t V2.Referent (V1.Type Symbol Ann) -> s -> 
 expectTypeOfReferents trav s = do
   s & trav %%~ expectTypeOfReferent
 
-expectDeclKind :: (PG.QueryM m) => Reference.TypeReference -> m CT.ConstructorType
+expectDeclKind :: (PG.QueryM m e) => Reference.TypeReference -> m CT.ConstructorType
 expectDeclKind r = loadDeclKind r `whenNothingM` (unrecoverableError (InternalServerError "missing-decl-kind" $ "Couldn't find the decl kind of " <> tShow r))
 
-expectDeclKindsOf :: (PG.QueryM m) => Traversal s t Reference.TypeReference CT.ConstructorType -> s -> m t
+expectDeclKindsOf :: (PG.QueryM m e) => Traversal s t Reference.TypeReference CT.ConstructorType -> s -> m t
 expectDeclKindsOf trav s = do
   s
     & unsafePartsOf trav %%~ \refs -> do
@@ -290,10 +290,10 @@ expectDeclKindsOf trav s = do
         (r, Nothing) -> unrecoverableError (InternalServerError "missing-decl-kind" $ "Couldn't find the decl kind of " <> tShow r)
         (_, Just ct) -> pure ct
 
-loadDeclKind :: (PG.QueryM m) => V2.TypeReference -> m (Maybe CT.ConstructorType)
+loadDeclKind :: (PG.QueryM m e) => V2.TypeReference -> m (Maybe CT.ConstructorType)
 loadDeclKind = loadDeclKindsOf id
 
-loadDeclKindsOf :: (PG.QueryM m) => Traversal s t Reference.TypeReference (Maybe CT.ConstructorType) -> s -> m t
+loadDeclKindsOf :: (PG.QueryM m e) => Traversal s t Reference.TypeReference (Maybe CT.ConstructorType) -> s -> m t
 loadDeclKindsOf trav s =
   s
     & unsafePartsOf trav %%~ \refs -> do

--- a/src/Share/Postgres/NameLookups/Conversions.hs
+++ b/src/Share/Postgres/NameLookups/Conversions.hs
@@ -39,84 +39,84 @@ import Unison.LabeledDependency qualified as LD
 import Unison.Reference qualified as V1
 import Unison.Referent qualified as V1
 
-reference1ToPG :: PG.QueryM m => V1.Reference -> m PGReference
+reference1ToPG :: (PG.QueryM m e) => V1.Reference -> m PGReference
 reference1ToPG = fmap runIdentity . references1ToPG . Identity
 
-references1ToPG :: (Traversable t, PG.QueryM m) => t V1.Reference -> m (t PGReference)
+references1ToPG :: (Traversable t, PG.QueryM m e) => t V1.Reference -> m (t PGReference)
 references1ToPG refs =
   refs
     & fmap Cv.reference1to2
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
     & unsafePartsOf (traversed . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-reference2ToPG :: PG.QueryM m => V2.Reference -> m PGReference
+reference2ToPG :: (PG.QueryM m e) => V2.Reference -> m PGReference
 reference2ToPG = fmap runIdentity . references2ToPG . Identity
 
-references2ToPG :: (Traversable t, PG.QueryM m) => t V2.Reference -> m (t PGReference)
+references2ToPG :: (Traversable t, PG.QueryM m e) => t V2.Reference -> m (t PGReference)
 references2ToPG refs =
   refs
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
     & unsafePartsOf (traversed . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-referent1ToPG :: PG.QueryM m => V1.Referent -> m PGReferent
+referent1ToPG :: (PG.QueryM m e) => V1.Referent -> m PGReferent
 referent1ToPG = fmap runIdentity . referents1ToPG . Identity
 
-referents1ToPG :: (Traversable t, PG.QueryM m) => t V1.Referent -> m (t PGReferent)
+referents1ToPG :: (Traversable t, PG.QueryM m e) => t V1.Referent -> m (t PGReferent)
 referents1ToPG refs =
   refs
     & fmap Cv.referent1to2
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
     & unsafePartsOf (traversed . V2.refs_ . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-referent2ToPG :: PG.QueryM m => V2.Referent -> m PGReferent
+referent2ToPG :: (PG.QueryM m e) => V2.Referent -> m PGReferent
 referent2ToPG = fmap runIdentity . referents2ToPG . Identity
 
-referents2ToPG :: (Traversable t, PG.QueryM m) => t V2.Referent -> m (t PGReferent)
+referents2ToPG :: (Traversable t, PG.QueryM m e) => t V2.Referent -> m (t PGReferent)
 referents2ToPG refs =
   refs
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
     & unsafePartsOf (traversed . V2.refs_ . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-referencePGTo1 :: PG.QueryM m => PGReference -> m V1.Reference
+referencePGTo1 :: (PG.QueryM m e) => PGReference -> m V1.Reference
 referencePGTo1 = fmap runIdentity . referencesPGTo1 . Identity
 
-referencesPGTo1 :: (PG.QueryM m, Traversable t) => t PGReference -> m (t V1.Reference)
+referencesPGTo1 :: (PG.QueryM m e, Traversable t) => t PGReference -> m (t V1.Reference)
 referencesPGTo1 refs =
   refs
     -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
     & unsafePartsOf (traversed . V2.h_) %%~ fmap coerce . Hashes.expectComponentHashesOf traversed
     <&> fmap Cv.reference2to1
 
-referencePGTo2 :: PG.QueryM m => PGReference -> m V2.Reference
+referencePGTo2 :: (PG.QueryM m e) => PGReference -> m V2.Reference
 referencePGTo2 = referencesPGTo2Of id
 
-referencesPGTo2Of :: (PG.QueryM m) => Traversal s t PGReference V2.Reference -> s -> m t
+referencesPGTo2Of :: (PG.QueryM m e) => Traversal s t PGReference V2.Reference -> s -> m t
 referencesPGTo2Of trav s =
   s
     -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
     & unsafePartsOf (trav . V2.h_) %%~ fmap coerce . Hashes.expectComponentHashesOf traversed
 
-referentPGTo1UsingCT :: (PG.QueryM m, HasCallStack) => (PGReferent, Maybe V2.ConstructorType) -> m V1.Referent
+referentPGTo1UsingCT :: (PG.QueryM m e, HasCallStack) => (PGReferent, Maybe V2.ConstructorType) -> m V1.Referent
 referentPGTo1UsingCT = fmap runIdentity . referentsPGTo1UsingCT . Identity
 
-referentsPGTo1UsingCT :: (PG.QueryM m, Traversable t, HasCallStack) => t (PGReferent, Maybe V2.ConstructorType) -> m (t V1.Referent)
+referentsPGTo1UsingCT :: (PG.QueryM m e, Traversable t, HasCallStack) => t (PGReferent, Maybe V2.ConstructorType) -> m (t V1.Referent)
 referentsPGTo1UsingCT refs =
   refs
     -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
     & unsafePartsOf (traversed . _1 . V2.refs_ . V2.h_) %%~ (fmap coerce . Hashes.expectComponentHashesOf traversed)
     <&> fmap (\(ref, mayCT) -> Cv.referent2to1UsingCT (fromMaybe (error "referentsPGTo1UsingCT: missing Constructor Type") mayCT) ref)
 
-referentPGTo2 :: PG.QueryM m => PGReferent -> m V2.Referent
+referentPGTo2 :: (PG.QueryM m e) => PGReferent -> m V2.Referent
 referentPGTo2 = referentsPGTo2Of id
 
-referentsPGTo2Of :: (PG.QueryM m) => Traversal s t PGReferent V2.Referent -> s -> m t
+referentsPGTo2Of :: (PG.QueryM m e) => Traversal s t PGReferent V2.Referent -> s -> m t
 referentsPGTo2Of trav s =
   s
     -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
     & unsafePartsOf (trav . V2.refs_ . V2.h_) %%~ (fmap coerce . Hashes.expectComponentHashesOf traversed)
 
 -- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferentsWithCT2ToPG :: PG.QueryM m => [NamedRef (V2.Referent, Maybe V2.ConstructorType)] -> m [NamedRef (PGReferent, Maybe V2.ConstructorType)]
+namedReferentsWithCT2ToPG :: (PG.QueryM m e) => [NamedRef (V2.Referent, Maybe V2.ConstructorType)] -> m [NamedRef (PGReferent, Maybe V2.ConstructorType)]
 namedReferentsWithCT2ToPG refs =
   refs
     &
@@ -125,7 +125,7 @@ namedReferentsWithCT2ToPG refs =
       %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
 -- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferents2ToPG :: PG.QueryM m => [NamedRef V2.Referent] -> m [NamedRef PGReferent]
+namedReferents2ToPG :: (PG.QueryM m e) => [NamedRef V2.Referent] -> m [NamedRef PGReferent]
 namedReferents2ToPG refs =
   refs
     &
@@ -134,7 +134,7 @@ namedReferents2ToPG refs =
       %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
 -- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferences2ToPG :: PG.QueryM m => [NamedRef V2.Reference] -> m [NamedRef PGReference]
+namedReferences2ToPG :: (PG.QueryM m e) => [NamedRef V2.Reference] -> m [NamedRef PGReference]
 namedReferences2ToPG refs =
   refs
     &
@@ -142,7 +142,7 @@ namedReferences2ToPG refs =
     unsafePartsOf (traversed . ref_ . V2.h_)
       %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-labeledDependencies1ToPG :: PG.QueryM m => [LD.LabeledDependency] -> m [Either (V1.Referent, PGReferent) (V1.Reference, PGReference)]
+labeledDependencies1ToPG :: (PG.QueryM m e) => [LD.LabeledDependency] -> m [Either (V1.Referent, PGReferent) (V1.Reference, PGReference)]
 labeledDependencies1ToPG refs =
   refs
     & map \case

--- a/src/Share/Postgres/NameLookups/Queries.hs
+++ b/src/Share/Postgres/NameLookups/Queries.hs
@@ -41,7 +41,7 @@ import Unison.Util.Monoid qualified as Monoid
 
 -- | Get the list of term names and suffixifications for a given Referent within a given namespace.
 -- Considers one level of dependencies, but not transitive dependencies.
-termNamesForRefWithinNamespace :: (PG.QueryM m) => NameLookupReceipt -> BranchHashId -> PathSegments -> PGReferent -> Maybe ReversedName -> m [(ReversedName, ReversedName)]
+termNamesForRefWithinNamespace :: (PG.QueryM m e) => NameLookupReceipt -> BranchHashId -> PathSegments -> PGReferent -> Maybe ReversedName -> m [(ReversedName, ReversedName)]
 termNamesForRefWithinNamespace !_nameLookupReceipt bhId namespaceRoot ref maySuffix = do
   let namespacePrefix = toNamespacePrefix namespaceRoot
   let reversedNamePrefix = case maySuffix of
@@ -123,7 +123,7 @@ termNamesForRefWithinNamespace !_nameLookupReceipt bhId namespaceRoot ref maySuf
 
 -- | Get the list of type names for a given Reference within a given namespace.
 -- Considers one level of dependencies, but not transitive dependencies.
-typeNamesForRefWithinNamespace :: (PG.QueryM m) => NameLookupReceipt -> BranchHashId -> PathSegments -> PGReference -> Maybe ReversedName -> m [(ReversedName, ReversedName)]
+typeNamesForRefWithinNamespace :: (PG.QueryM m e) => NameLookupReceipt -> BranchHashId -> PathSegments -> PGReference -> Maybe ReversedName -> m [(ReversedName, ReversedName)]
 typeNamesForRefWithinNamespace !_nameLookupReceipt bhId namespaceRoot ref maySuffix = do
   let namespacePrefix = toNamespacePrefix namespaceRoot
   let reversedNamePrefix = case maySuffix of
@@ -224,7 +224,7 @@ transitiveDependenciesSql rootBranchHashId =
 -- id. It's the caller's job to select the correct name lookup for your exact name.
 --
 -- See termRefsForExactName in U.Codebase.Sqlite.Operations
-termRefsForExactName :: (PG.QueryM m) => NameLookupReceipt -> BranchHashId -> ReversedName -> m [NamedRef (PGReferent, Maybe ConstructorType)]
+termRefsForExactName :: (PG.QueryM m e) => NameLookupReceipt -> BranchHashId -> ReversedName -> m [NamedRef (PGReferent, Maybe ConstructorType)]
 termRefsForExactName !_nameLookupReceipt bhId reversedName = do
   results :: [NamedRef (PGReferent PG.:. PG.Only (Maybe ConstructorType))] <-
     PG.queryListRows
@@ -243,7 +243,7 @@ termRefsForExactName !_nameLookupReceipt bhId reversedName = do
 -- id. It's the caller's job to select the correct name lookup for your exact name.
 --
 -- See termRefsForExactName in U.Codebase.Sqlite.Operations
-typeRefsForExactName :: (PG.QueryM m) => NameLookupReceipt -> BranchHashId -> ReversedName -> m [NamedRef PGReference]
+typeRefsForExactName :: (PG.QueryM m e) => NameLookupReceipt -> BranchHashId -> ReversedName -> m [NamedRef PGReference]
 typeRefsForExactName !_nameLookupReceipt bhId reversedName = do
   PG.queryListRows
     [PG.sql|
@@ -254,7 +254,7 @@ typeRefsForExactName !_nameLookupReceipt bhId reversedName = do
     |]
 
 -- | Check if we've already got an index for the desired root branch hash.
-checkBranchHashNameLookupExists :: (PG.QueryM m) => BranchHashId -> m Bool
+checkBranchHashNameLookupExists :: (PG.QueryM m e) => BranchHashId -> m Bool
 checkBranchHashNameLookupExists hashId = do
   PG.queryExpect1Col
     [PG.sql|
@@ -288,7 +288,7 @@ deleteNameLookupsExceptFor hashIds = do
         |]
 
 -- | Fetch the name lookup mounts for a given name lookup index.
-listNameLookupMounts :: (PG.QueryM m) => NameLookupReceipt -> BranchHashId -> m [(PathSegments, BranchHashId)]
+listNameLookupMounts :: (PG.QueryM m e) => NameLookupReceipt -> BranchHashId -> m [(PathSegments, BranchHashId)]
 listNameLookupMounts !_nameLookupReceipt rootBranchHashId =
   do
     PG.queryListRows
@@ -308,7 +308,7 @@ type FuzzySearchScore = (Bool, Bool, Int64, Int64)
 -- | Searches for all names within the given name lookup which contain the provided list of segments
 -- in order.
 -- Search is case insensitive.
-fuzzySearchTerms :: (PG.QueryM m) => NameLookupReceipt -> Bool -> BranchHashId -> Int64 -> PathSegments -> NonEmpty Text -> m [(FuzzySearchScore, NamedRef (PGReferent, Maybe ConstructorType))]
+fuzzySearchTerms :: (PG.QueryM m e) => NameLookupReceipt -> Bool -> BranchHashId -> Int64 -> PathSegments -> NonEmpty Text -> m [(FuzzySearchScore, NamedRef (PGReferent, Maybe ConstructorType))]
 fuzzySearchTerms !_nameLookupReceipt includeDependencies bhId limit namespace querySegments = do
   fmap unRow
     <$> PG.queryListRows
@@ -368,7 +368,7 @@ fuzzySearchTerms !_nameLookupReceipt includeDependencies bhId limit namespace qu
 -- in order.
 --
 -- Search is case insensitive.
-fuzzySearchTypes :: (PG.QueryM m) => NameLookupReceipt -> Bool -> BranchHashId -> Int64 -> PathSegments -> NonEmpty Text -> m [(FuzzySearchScore, NamedRef PGReference)]
+fuzzySearchTypes :: (PG.QueryM m e) => NameLookupReceipt -> Bool -> BranchHashId -> Int64 -> PathSegments -> NonEmpty Text -> m [(FuzzySearchScore, NamedRef PGReference)]
 fuzzySearchTypes !_nameLookupReceipt includeDependencies bhId limit namespace querySegments = do
   fmap unRow
     <$> PG.queryListRows

--- a/src/Share/Postgres/Patches/Queries.hs
+++ b/src/Share/Postgres/Patches/Queries.hs
@@ -27,7 +27,7 @@ import Unison.Hashing.V2 qualified as H
 import Unison.Reference qualified as Reference
 import Unison.Util.Map qualified as Map
 
-loadPatch :: forall m. QueryM m => PatchId -> m (Maybe V2.Patch)
+loadPatch :: forall m e. (QueryM m e) => PatchId -> m (Maybe V2.Patch)
 loadPatch patchId = runMaybeT do
   termMappings <- lift $ getTermMappings patchId
   constructorMappings <- lift $ getConstructorMappings patchId
@@ -128,7 +128,7 @@ loadPatch patchId = runMaybeT do
             )
         <&> Map.unionsWith (Set.union)
 
-expectPatch :: (HasCallStack, QueryM m) => PatchId -> m V2.Patch
+expectPatch :: (HasCallStack, QueryM m e) => PatchId -> m V2.Patch
 expectPatch patchId = do
   mayPatch <- loadPatch patchId
   case mayPatch of

--- a/src/Share/Postgres/Queries.hs
+++ b/src/Share/Postgres/Queries.hs
@@ -42,13 +42,13 @@ import Share.Web.Share.Releases.Types (ReleaseStatusFilter (..), StatusUpdate (.
 import Unison.Util.List qualified as Utils
 import Unison.Util.Monoid (intercalateMap)
 
-expectUserByUserId :: (PG.QueryM m) => UserId -> m User
+expectUserByUserId :: (PG.QueryM m e) => UserId -> m User
 expectUserByUserId uid = do
   userByUserId uid >>= \case
     Just user -> pure user
     Nothing -> unrecoverableError $ EntityMissing (ErrorID "user:missing") ("User with id " <> IDs.toText uid <> " not found")
 
-userByUserId :: (PG.QueryM m) => UserId -> m (Maybe User)
+userByUserId :: (PG.QueryM m e) => UserId -> m (Maybe User)
 userByUserId uid = do
   PG.query1Row
     [PG.sql|
@@ -729,7 +729,7 @@ createBranch !_nlReceipt projectId branchName contributorId causalId mergeTarget
       |]
 
 createRelease ::
-  (PG.QueryM m) =>
+  (PG.QueryM m e) =>
   NameLookupReceipt ->
   ProjectId ->
   ReleaseVersion ->

--- a/src/Share/Postgres/Search/DefinitionSearch/Queries.hs
+++ b/src/Share/Postgres/Search/DefinitionSearch/Queries.hs
@@ -52,7 +52,7 @@ instance Logging.Loggable DefinitionSearchError where
       Logging.textLog ("Failed to decode metadata: " <> tShow v <> " " <> err)
         & Logging.withSeverity Logging.Error
 
-submitReleaseToBeSynced :: (QueryM m) => ReleaseId -> m ()
+submitReleaseToBeSynced :: (QueryM m e) => ReleaseId -> m ()
 submitReleaseToBeSynced releaseId = do
   execute_
     [sql|

--- a/src/Unison/PrettyPrintEnvDecl/Postgres.hs
+++ b/src/Unison/PrettyPrintEnvDecl/Postgres.hs
@@ -18,7 +18,7 @@ import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.Reference qualified as V1
 import Unison.Referent qualified as V1
 
-ppedForReferences :: forall m. (PG.QueryM m) => NamesPerspective -> Set LabeledDependency -> m PPED.PrettyPrintEnvDecl
+ppedForReferences :: forall m e. (PG.QueryM m e) => NamesPerspective -> Set LabeledDependency -> m PPED.PrettyPrintEnvDecl
 ppedForReferences namesPerspective refs = do
   withPGRefs <-
     Set.toList refs


### PR DESCRIPTION
Adds PG pipelining to a bunch of sync operations in the hope it could speed things up.

I tested this out on staging by pulling the latest base release on each version.

main: 
* 28.4 s (cpu), 25.5 s (system)

this branch:
* 29.1 s (cpu), 25.3 s (system)

No perceptible difference AT ALL, so that suggests query latency isn't any significant bottleneck for pull, bummer.