### PR TITLE
Fast Forward Merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,7 +240,7 @@ jobs:
 
           # Install ucm
           mkdir ucm
-          curl -L https://github.com/unisonweb/unison/releases/download/release%2F0.5.23/ucm-linux.tar.gz | tar -xz -C ucm
+          curl -L https://github.com/unisonweb/unison/releases/download/release%2F0.5.25/ucm-linux.tar.gz | tar -xz -C ucm
           export PATH=$PWD/ucm:$PATH
 
           # Clean up old postgres data if it exists.

--- a/src/Share/Branch.hs
+++ b/src/Share/Branch.hs
@@ -5,14 +5,16 @@ module Share.Branch
     defaultBranchName,
     defaultBranchShorthand,
     branchCausals_,
+    branchCodebaseUser,
   )
 where
 
 import Control.Lens
 import Data.Time (UTCTime)
+import Hasql.Interpolate qualified as Hasql
 import Share.IDs
 import Share.Postgres qualified as PG
-import Hasql.Interpolate qualified as Hasql
+import Share.Prelude
 
 -- | We don't track default branches in the database at the moment,
 -- and haven't decided yet whether we will.
@@ -55,3 +57,6 @@ instance (Hasql.DecodeValue causal) => Hasql.DecodeRow (Branch causal) where
 
 branchCausals_ :: Traversal (Branch causal) (Branch causal') causal causal'
 branchCausals_ f Branch {..} = (\causal -> Branch {causal, ..}) <$> f causal
+
+branchCodebaseUser :: Branch causal -> UserId
+branchCodebaseUser Branch {..} = fromMaybe creatorId contributorId

--- a/src/Share/Codebase.hs
+++ b/src/Share/Codebase.hs
@@ -165,7 +165,7 @@ instance Logging.Loggable CodebaseError where
 shorthashLength :: Int
 shorthashLength = 10
 
--- | Construct a CodebaseEnv allowsing you to run transactions against a given codebase.
+-- | Construct a CodebaseEnv allowing you to run transactions against a given codebase.
 codebaseEnv :: AuthZReceipt -> CodebaseLocation -> CodebaseEnv
 codebaseEnv !_authZReceipt codebaseLoc = do
   let codebaseOwner = Codebase.codebaseOwnerUserId codebaseLoc

--- a/src/Share/Contribution.hs
+++ b/src/Share/Contribution.hs
@@ -61,6 +61,13 @@ instance Hasql.DecodeValue ContributionStatus where
       "merged" -> Right Merged
       _ -> Left "Invalid contribution status"
 
+instance From ContributionStatus Text where
+  from = \case
+    Draft -> "draft"
+    InReview -> "in_review"
+    Closed -> "closed"
+    Merged -> "merged"
+
 data Contribution = Contribution
   { contributionId :: ContributionId,
     projectId :: ProjectId,

--- a/src/Share/Contribution.hs
+++ b/src/Share/Contribution.hs
@@ -4,13 +4,13 @@ module Share.Contribution where
 
 import Data.Aeson qualified as Aeson
 import Data.Time (UTCTime)
+import Hasql.Decoders qualified as Hasql
+import Hasql.Interpolate qualified as Hasql
+import Servant (FromHttpApiData (..))
 import Share.IDs
 import Share.Postgres qualified as PG
 import Share.Postgres.IDs (CausalId)
 import Share.Prelude
-import Hasql.Decoders qualified as Hasql
-import Hasql.Interpolate qualified as Hasql
-import Servant (FromHttpApiData (..))
 
 data ContributionStatus
   = Draft

--- a/src/Share/Postgres/Causal/Queries.hs
+++ b/src/Share/Postgres/Causal/Queries.hs
@@ -890,9 +890,6 @@ isFastForward fromCausalId toCausalId = do
   -- though...
   WITH RECURSIVE causal_history(causal_id) AS (
       SELECT #{toCausalId}
-      FROM causals causal
-          JOIN branch_hashes bh ON causal.namespace_hash_id = bh.id
-          WHERE causal.id = causal_id
       UNION
       SELECT ca.ancestor_id
       FROM causal_history h

--- a/src/Share/Postgres/Causal/Queries.hs
+++ b/src/Share/Postgres/Causal/Queries.hs
@@ -24,6 +24,7 @@ module Share.Postgres.Causal.Queries
     importCausalIntoCodebase,
     hashCausal,
     bestCommonAncestor,
+    isFastForward,
   )
 where
 
@@ -878,3 +879,26 @@ bestCommonAncestor a b = do
   query1Col
     [sql| SELECT best_common_causal_ancestor(#{a}, #{b}) as causal_id
     |]
+
+isFastForward :: (QueryM m) => CausalId -> CausalId -> m Bool
+isFastForward fromCausalId toCausalId = do
+  queryExpect1Col
+    [sql|
+  -- It's probably faster in _most_ situations to actually check FORWARDS from the old causal
+  -- to find the new one, but in the worst case there are ANY number of descendents from a
+  -- given causal so it's a bit riskier. Still probably fine to try if this gets slow
+  -- though...
+  WITH RECURSIVE causal_history(causal_id) AS (
+      SELECT #{toCausalId}
+      FROM causals causal
+          JOIN branch_hashes bh ON causal.namespace_hash_id = bh.id
+          WHERE causal.id = causal_id
+      UNION
+      SELECT ca.ancestor_id
+      FROM causal_history h
+          JOIN causal_ancestors ca ON h.causal_id = ca.causal_id
+  ) SELECT EXISTS (
+      SELECT FROM causal_history history
+        WHERE history.causal_id = #{fromCausalId}
+  );
+  |]

--- a/src/Share/Postgres/Contributions/Queries.hs
+++ b/src/Share/Postgres/Contributions/Queries.hs
@@ -499,7 +499,8 @@ contributionStateTokenById contributionId = do
           contribution.source_branch,
           contribution.target_branch,
           source_causal.hash,
-          target_causal.hash
+          target_causal.hash,
+          contribution.status
         FROM contributions contribution
           JOIN project_branches AS source_branch ON source_branch.id = contribution.source_branch
           JOIN project_branches AS target_branch ON target_branch.id = contribution.target_branch

--- a/src/Share/Postgres/Contributions/Queries.hs
+++ b/src/Share/Postgres/Contributions/Queries.hs
@@ -16,6 +16,7 @@ module Share.Postgres.Contributions.Queries
     getPagedShareContributionTimelineByProjectIdAndNumber,
     performMergesAndBCAUpdatesFromBranchPush,
     rebaseContributionsFromMergedBranches,
+    contributionStateTokenById,
   )
 where
 
@@ -488,3 +489,21 @@ rebaseContributionsFromMergedBranches mergedContributions = do
         RETURNING contr.id
     |]
     <&> Set.fromList
+
+contributionStateTokenById :: ContributionId -> PG.Transaction e ContributionStateToken
+contributionStateTokenById contributionId = do
+  PG.queryExpect1Row @ContributionStateToken
+    [PG.sql|
+        SELECT
+          contribution.id,
+          contribution.source_branch,
+          contribution.target_branch,
+          source_causal.hash,
+          target_causal.hash,
+        FROM contributions contribution
+          JOIN project_branches AS source_branch ON source_branch.id = contribution.source_branch
+          JOIN project_branches AS target_branch ON target_branch.id = contribution.target_branch
+          JOIN causals source_causal ON source_causal.id = source_branch.causal_id
+          JOIN causals target_causal ON target_causal.id = target_branch.causal_id
+        WHERE contribution.id = #{contributionId}
+      |]

--- a/src/Share/Postgres/Contributions/Queries.hs
+++ b/src/Share/Postgres/Contributions/Queries.hs
@@ -499,7 +499,7 @@ contributionStateTokenById contributionId = do
           contribution.source_branch,
           contribution.target_branch,
           source_causal.hash,
-          target_causal.hash,
+          target_causal.hash
         FROM contributions contribution
           JOIN project_branches AS source_branch ON source_branch.id = contribution.source_branch
           JOIN project_branches AS target_branch ON target_branch.id = contribution.target_branch

--- a/src/Share/Utils/API.hs
+++ b/src/Share/Utils/API.hs
@@ -273,4 +273,5 @@ instance (ToJSON a, TypeLits.KnownSymbol key) => ToJSON (AtKey key a) where
 
 instance (FromJSON a, TypeLits.KnownSymbol key) => FromJSON (AtKey key a) where
   parseJSON = withObject "AtKey" $ \obj -> do
-    obj .: String.fromString (TypeLits.symbolVal (Proxy @key))
+    (innerVal :: a) <- (obj .: String.fromString (TypeLits.symbolVal (Proxy @key)))
+    pure $ AtKey innerVal

--- a/src/Share/Utils/Logging.hs
+++ b/src/Share/Utils/Logging.hs
@@ -32,6 +32,7 @@ module Share.Utils.Logging
     runLoggerTEnv,
 
     -- * Other
+    ShowLoggable (..),
     module X,
   )
 where
@@ -81,6 +82,15 @@ runLoggerT minSeverity l reqTags ft (LoggerT m) = runReaderT m (l, ft, minSeveri
 runLoggerTEnv :: Env.Env reqCtx -> Map Text Text -> LoggerT m a -> m a
 runLoggerTEnv (Env.Env {Env.timeCache, Env.logger, Env.minLogSeverity}) tags m =
   runLoggerT minLogSeverity logger tags timeCache $ m
+
+newtype ShowLoggable (severity :: Severity) a = ShowLoggable a
+
+instance (Show a, GetSeverity severity) => Loggable (ShowLoggable severity a) where
+  toLog (ShowLoggable a) =
+    a
+      & tShow
+      & textLog
+      & withSeverity (getSeverity $ Proxy @severity)
 
 class Loggable msg where
   toLog :: msg -> LogMsg

--- a/src/Share/Utils/Logging/Types.hs
+++ b/src/Share/Utils/Logging/Types.hs
@@ -1,7 +1,15 @@
-module Share.Utils.Logging.Types where
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
 
-import Share.Prelude
+module Share.Utils.Logging.Types
+  ( LogMsg (..),
+    Severity (..),
+    GetSeverity (..),
+  )
+where
+
 import GHC.Stack (CallStack)
+import Share.Prelude
 import Prelude hiding (log)
 
 data LogMsg = LogMsg
@@ -18,3 +26,19 @@ data Severity
     UserFault
   | Error
   deriving (Show, Eq, Ord)
+
+-- | Severity Singleton class for deriving via instances.
+class GetSeverity (s :: Severity) where
+  getSeverity :: Proxy s -> Severity
+
+instance GetSeverity 'Debug where
+  getSeverity _ = Debug
+
+instance GetSeverity 'Info where
+  getSeverity _ = Info
+
+instance GetSeverity 'UserFault where
+  getSeverity _ = UserFault
+
+instance GetSeverity 'Error where
+  getSeverity _ = Error

--- a/src/Share/Web/Share/Contributions/API.hs
+++ b/src/Share/Web/Share/Contributions/API.hs
@@ -108,7 +108,7 @@ type MergeContributionEndpoint =
 
 -- | Check if a contribution can be merged
 type CheckMergeContributionEndpoint =
-  Post '[JSON] CheckMergeContributionResponse
+  Get '[JSON] CheckMergeContributionResponse
 
 type ContributionTimelineCursor = UTCTime
 

--- a/src/Share/Web/Share/Contributions/API.hs
+++ b/src/Share/Web/Share/Contributions/API.hs
@@ -41,12 +41,18 @@ data TimelineRoutes mode = TimelineRoutes
   }
   deriving stock (Generic)
 
+data MergeRoutes mode = MergeRoutes
+  { mergeContribution :: mode :- MergeContributionEndpoint,
+    checkMergeContribution :: mode :- "check" :> CheckMergeContributionEndpoint
+  }
+  deriving stock (Generic)
+
 data ContributionResourceRoutes mode
   = ContributionResourceRoutes
   { getContributionByNumber :: mode :- GetContributionByNumber,
     updateContributionByNumber :: mode :- UpdateContributionByNumber,
     diff :: mode :- "diff" :> NamedRoutes DiffRoutes,
-    merge :: mode :- "merge" :> MergeContribution,
+    merge :: mode :- "merge" :> NamedRoutes MergeRoutes,
     timeline :: mode :- "timeline" :> NamedRoutes TimelineRoutes
   }
   deriving stock (Generic)
@@ -96,8 +102,13 @@ type UpdateContributionByNumber =
   ReqBody '[JSON] UpdateContributionRequest
     :> Patch '[JSON] (ShareContribution UserDisplayInfo)
 
-type MergeContribution =
-  Post '[JSON] ()
+-- | Merged a contribution
+type MergeContributionEndpoint =
+  Post '[JSON] MergeContributionResponse
+
+-- | Check if a contribution can be merged
+type CheckMergeContributionEndpoint =
+  Post '[JSON] CheckMergeContributionResponse
 
 type ContributionTimelineCursor = UTCTime
 

--- a/src/Share/Web/Share/Contributions/API.hs
+++ b/src/Share/Web/Share/Contributions/API.hs
@@ -104,7 +104,8 @@ type UpdateContributionByNumber =
 
 -- | Merged a contribution
 type MergeContributionEndpoint =
-  Post '[JSON] MergeContributionResponse
+  ReqBody '[JSON] (AtKey "contributionStateToken" ContributionStateToken)
+    :> Post '[JSON] MergeContributionResponse
 
 -- | Check if a contribution can be merged
 type CheckMergeContributionEndpoint =

--- a/src/Share/Web/Share/Contributions/API.hs
+++ b/src/Share/Web/Share/Contributions/API.hs
@@ -96,7 +96,7 @@ type CreateContribution =
   ReqBody '[JSON] CreateContributionRequest
     :> Post '[JSON] (ShareContribution UserDisplayInfo)
 
-type GetContributionByNumber = Get '[JSON] (ShareContribution UserDisplayInfo)
+type GetContributionByNumber = Get '[JSON] (ShareContribution UserDisplayInfo :++ AtKey "contributionStateToken" ContributionStateToken)
 
 type UpdateContributionByNumber =
   ReqBody '[JSON] UpdateContributionRequest

--- a/src/Share/Web/Share/Contributions/Types.hs
+++ b/src/Share/Web/Share/Contributions/Types.hs
@@ -236,8 +236,7 @@ instance ToJSON MergeContributionResponse where
 -- We don't bother signing these, so don't use it for Auth or w/e
 --
 -- E.g. A new commit is pushed in between loading the page and clicking 'merge'
-data ContributionStateToken
-  = ContributionStateToken
+data ContributionStateToken = ContributionStateToken
   { contributionId :: ContributionId,
     sourceBranchId :: BranchId,
     targetBranchId :: BranchId,

--- a/src/Share/Web/Share/Contributions/Types.hs
+++ b/src/Share/Web/Share/Contributions/Types.hs
@@ -266,3 +266,21 @@ instance FromHttpApiData ContributionStateToken where
         targetCausalHash <- CausalHash <$> maybeToEither "Invalid target causal hash" (Hash.fromBase32HexText targetCausalHash)
         pure ContributionStateToken {..}
       _ -> Left "Invalid contribution state token"
+
+instance ToJSON ContributionStateToken where
+  toJSON ContributionStateToken {..} = String (toQueryParam ContributionStateToken {..})
+
+instance FromJSON ContributionStateToken where
+  parseJSON = withText "ContributionStateToken" \t ->
+    case parseQueryParam t of
+      Left err -> fail (Text.unpack err)
+      Right token -> pure token
+
+instance PG.DecodeRow ContributionStateToken where
+  decodeRow = do
+    contributionId <- PG.decodeField
+    sourceBranchId <- PG.decodeField
+    targetBranchId <- PG.decodeField
+    sourceCausalHash <- PG.decodeField
+    targetCausalHash <- PG.decodeField
+    pure ContributionStateToken {..}

--- a/src/Share/Web/Share/Contributions/Types.hs
+++ b/src/Share/Web/Share/Contributions/Types.hs
@@ -17,6 +17,8 @@ import Share.IDs qualified as IDs
 import Share.Postgres qualified as PG
 import Share.Prelude
 import Share.Utils.API (NullableUpdate, parseNullableUpdate)
+import Share.Utils.Logging qualified as Logging
+import Share.Web.Errors qualified as Err
 import Share.Web.Share.Comments (CommentEvent (..), commentEventTimestamp)
 import Share.Web.Share.Types (UserDisplayInfo)
 import U.Codebase.HashTags (CausalHash (..))
@@ -284,3 +286,11 @@ instance PG.DecodeRow ContributionStateToken where
     sourceCausalHash <- PG.decodeField
     targetCausalHash <- PG.decodeField
     pure ContributionStateToken {..}
+
+data ContributionStateChangedError = ContributionStateChangedError
+  { expectedStateToken :: ContributionStateToken,
+    actualStateToken :: ContributionStateToken
+  }
+  deriving stock (Show)
+  deriving (Logging.Loggable) via (Logging.ShowLoggable 'Logging.Error ContributionStateChangedError)
+  deriving (Err.ToServerError) via Err.SimpleServerError 417 "contribution:state-changed" "Contribution state changed from what was expected" ContributionStateChangedError

--- a/transcripts/run-transcripts.zsh
+++ b/transcripts/run-transcripts.zsh
@@ -11,6 +11,7 @@ source "$(realpath "$(dirname "$0")")/transcript_helpers.sh"
 
 typeset -A transcripts
 transcripts=(
+    contribution-merge transcripts/share-apis/contribution-merge/
     search transcripts/share-apis/search/
     users transcripts/share-apis/users/
     contribution-diffs transcripts/share-apis/contribution-diffs/

--- a/transcripts/share-apis/contribution-merge/contribution-after-merge.json
+++ b/transcripts/share-apis/contribution-merge/contribution-after-merge.json
@@ -1,0 +1,27 @@
+{
+  "body": {
+    "author": {
+      "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+      "handle": "transcripts",
+      "name": "Transcript User",
+      "userId": "U-<UUID>"
+    },
+    "contributionStateToken": "C-<UUID>:B-<UUID>:B-<UUID>:glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8:glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8",
+    "createdAt": "<TIMESTAMP>",
+    "description": "My description",
+    "id": "C-<UUID>",
+    "numComments": 0,
+    "number": 1,
+    "projectRef": "@transcripts/merge",
+    "sourceBranchRef": "fast-forward-feature",
+    "status": "merged",
+    "targetBranchRef": "main",
+    "title": "Fast Forward Contribution",
+    "updatedAt": "<TIMESTAMP>"
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/contribution-merge/contribution-after-merge.json
+++ b/transcripts/share-apis/contribution-merge/contribution-after-merge.json
@@ -6,7 +6,7 @@
       "name": null,
       "userId": "U-<UUID>"
     },
-    "contributionStateToken": "C-<UUID>:B-<UUID>:B-<UUID>:glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8:glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8",
+    "contributionStateToken": "C-<UUID>:B-<UUID>:B-<UUID>:glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8:glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8:merged",
     "createdAt": "<TIMESTAMP>",
     "description": "My description",
     "id": "C-<UUID>",

--- a/transcripts/share-apis/contribution-merge/contribution-after-merge.json
+++ b/transcripts/share-apis/contribution-merge/contribution-after-merge.json
@@ -1,9 +1,9 @@
 {
   "body": {
     "author": {
-      "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
-      "handle": "transcripts",
-      "name": "Transcript User",
+      "avatarUrl": null,
+      "handle": "test",
+      "name": null,
       "userId": "U-<UUID>"
     },
     "contributionStateToken": "C-<UUID>:B-<UUID>:B-<UUID>:glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8:glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8",
@@ -13,7 +13,7 @@
     "numComments": 0,
     "number": 1,
     "projectRef": "@transcripts/merge",
-    "sourceBranchRef": "fast-forward-feature",
+    "sourceBranchRef": "@test/fast-forward-feature",
     "status": "merged",
     "targetBranchRef": "main",
     "title": "Fast Forward Contribution",

--- a/transcripts/share-apis/contribution-merge/contribution-check-merge.json
+++ b/transcripts/share-apis/contribution-merge/contribution-check-merge.json
@@ -1,6 +1,6 @@
 {
   "body": {
-    "mergability": {
+    "mergeability": {
       "kind": "fast_forward"
     }
   },

--- a/transcripts/share-apis/contribution-merge/contribution-check-merge.json
+++ b/transcripts/share-apis/contribution-merge/contribution-check-merge.json
@@ -1,0 +1,8 @@
+{
+  "body": "Something went wrong, please try again later",
+  "status": [
+    {
+      "status_code": 500
+    }
+  ]
+}

--- a/transcripts/share-apis/contribution-merge/contribution-check-merge.json
+++ b/transcripts/share-apis/contribution-merge/contribution-check-merge.json
@@ -1,8 +1,12 @@
 {
-  "body": "Something went wrong, please try again later",
+  "body": {
+    "mergability": {
+      "kind": "fast_forward"
+    }
+  },
   "status": [
     {
-      "status_code": 500
+      "status_code": 200
     }
   ]
 }

--- a/transcripts/share-apis/contribution-merge/contribution-create-contribution.json
+++ b/transcripts/share-apis/contribution-merge/contribution-create-contribution.json
@@ -1,9 +1,9 @@
 {
   "body": {
     "author": {
-      "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
-      "handle": "transcripts",
-      "name": "Transcript User",
+      "avatarUrl": null,
+      "handle": "test",
+      "name": null,
       "userId": "U-<UUID>"
     },
     "createdAt": "<TIMESTAMP>",
@@ -12,7 +12,7 @@
     "numComments": 0,
     "number": 1,
     "projectRef": "@transcripts/merge",
-    "sourceBranchRef": "fast-forward-feature",
+    "sourceBranchRef": "@test/fast-forward-feature",
     "status": "in_review",
     "targetBranchRef": "main",
     "title": "Fast Forward Contribution",

--- a/transcripts/share-apis/contribution-merge/contribution-create-contribution.json
+++ b/transcripts/share-apis/contribution-merge/contribution-create-contribution.json
@@ -1,0 +1,26 @@
+{
+  "body": {
+    "author": {
+      "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+      "handle": "transcripts",
+      "name": "Transcript User",
+      "userId": "U-<UUID>"
+    },
+    "createdAt": "<TIMESTAMP>",
+    "description": "My description",
+    "id": "C-<UUID>",
+    "numComments": 0,
+    "number": 1,
+    "projectRef": "@transcripts/merge",
+    "sourceBranchRef": "fast-forward-feature",
+    "status": "in_review",
+    "targetBranchRef": "main",
+    "title": "Fast Forward Contribution",
+    "updatedAt": "<TIMESTAMP>"
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/contribution-merge/contribution-merge.json
+++ b/transcripts/share-apis/contribution-merge/contribution-merge.json
@@ -1,0 +1,12 @@
+{
+  "body": {
+    "result": {
+      "kind": "success"
+    }
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/contribution-merge/contribution-setup.md
+++ b/transcripts/share-apis/contribution-merge/contribution-setup.md
@@ -1,22 +1,9 @@
+Add a change to a contributor branch, based on the main branch.
+
 ```ucm:hide
-scratch/main> project.create-empty merge
+scratch/main> clone @transcripts/merge/main
+@transcripts/merge/main> branch @test/fast-forward-feature
 ```
-
-Create a main branch.
-
-```unison:hide
-term = "start"
-```
-
-Push it.
-
-```ucm
-merge/main> add
-merge/main> push @transcripts/merge/main
-merge/main> branch /fast-forward-feature
-```
-
-Add a change to a feature branch, based on the main branch.
 
 ```unison:hide
 term = "feature"
@@ -25,6 +12,6 @@ term = "feature"
 Push the feature branch.
 
 ```ucm
-merge/fast-forward-feature> update
-merge/fast-forward-feature> push @transcripts/merge/fast-forward-feature
+@transcripts/merge/@test/fast-forward-feature> update
+@transcripts/merge/@test/fast-forward-feature> push @transcripts/merge/@test/fast-forward-feature
 ```

--- a/transcripts/share-apis/contribution-merge/contribution-setup.md
+++ b/transcripts/share-apis/contribution-merge/contribution-setup.md
@@ -1,0 +1,30 @@
+```ucm:hide
+scratch/main> project.create-empty merge
+```
+
+Create a main branch.
+
+```unison:hide
+term = "start"
+```
+
+Push it.
+
+```ucm
+merge/main> add
+merge/main> push @transcripts/merge/main
+merge/main> branch /fast-forward-feature
+```
+
+Add a change to a feature branch, based on the main branch.
+
+```unison:hide
+term = "feature"
+```
+
+Push the feature branch.
+
+```ucm
+merge/fast-forward-feature> update
+merge/fast-forward-feature> push @transcripts/merge/fast-forward-feature
+```

--- a/transcripts/share-apis/contribution-merge/contribution-setup.output.md
+++ b/transcripts/share-apis/contribution-merge/contribution-setup.output.md
@@ -1,0 +1,58 @@
+Create a main branch.
+
+``` unison
+term = "start"
+```
+
+Push it.
+
+``` ucm
+merge/main> add
+
+  ⍟ I've added these definitions:
+  
+    term : ##Text
+
+merge/main> push @transcripts/merge/main
+
+  Uploaded 3 entities.
+
+  I just created @transcripts/merge on http://localhost:5424
+
+  View it here: @transcripts/merge/main on http://localhost:5424
+
+merge/main> branch /fast-forward-feature
+
+  Done. I've created the fast-forward-feature branch based off
+  of main.
+  
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /fast-forward-feature`.
+
+```
+Add a change to a feature branch, based on the main branch.
+
+``` unison
+term = "feature"
+```
+
+Push the feature branch.
+
+``` ucm
+merge/fast-forward-feature> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+merge/fast-forward-feature> push @transcripts/merge/fast-forward-feature
+
+  Uploaded 3 entities.
+
+  I just created @transcripts/merge/fast-forward-feature on
+  http://localhost:5424
+
+  View it here: @transcripts/merge/fast-forward-feature on http://localhost:5424
+
+```

--- a/transcripts/share-apis/contribution-merge/contribution-setup.output.md
+++ b/transcripts/share-apis/contribution-merge/contribution-setup.output.md
@@ -1,36 +1,4 @@
-Create a main branch.
-
-``` unison
-term = "start"
-```
-
-Push it.
-
-``` ucm
-merge/main> add
-
-  ⍟ I've added these definitions:
-  
-    term : ##Text
-
-merge/main> push @transcripts/merge/main
-
-  Uploaded 3 entities.
-
-  I just created @transcripts/merge on http://localhost:5424
-
-  View it here: @transcripts/merge/main on http://localhost:5424
-
-merge/main> branch /fast-forward-feature
-
-  Done. I've created the fast-forward-feature branch based off
-  of main.
-  
-  Tip: To merge your work back into the main branch, first
-       `switch /main` then `merge /fast-forward-feature`.
-
-```
-Add a change to a feature branch, based on the main branch.
+Add a change to a contributor branch, based on the main branch.
 
 ``` unison
 term = "feature"
@@ -39,20 +7,20 @@ term = "feature"
 Push the feature branch.
 
 ``` ucm
-merge/fast-forward-feature> update
+@transcripts/merge/@test/fast-forward-feature> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-merge/fast-forward-feature> push @transcripts/merge/fast-forward-feature
+@transcripts/merge/@test/fast-forward-feature> push @transcripts/merge/@test/fast-forward-feature
 
   Uploaded 3 entities.
 
-  I just created @transcripts/merge/fast-forward-feature on
-  http://localhost:5424
+  I just created @transcripts/merge/@test/fast-forward-feature
+  on http://localhost:5424
 
-  View it here: @transcripts/merge/fast-forward-feature on http://localhost:5424
+  View it here: @transcripts/merge/@test/fast-forward-feature on http://localhost:5424
 
 ```

--- a/transcripts/share-apis/contribution-merge/main-after-merge.json
+++ b/transcripts/share-apis/contribution-merge/main-after-merge.json
@@ -1,0 +1,27 @@
+{
+  "body": {
+    "branchRef": "main",
+    "causalHash": "#glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8",
+    "contributions": [],
+    "createdAt": "<TIMESTAMP>",
+    "project": {
+      "createdAt": "<TIMESTAMP>",
+      "owner": {
+        "handle": "@transcripts",
+        "name": "Transcript User",
+        "type": "user"
+      },
+      "slug": "merge",
+      "summary": null,
+      "tags": [],
+      "updatedAt": "<TIMESTAMP>",
+      "visibility": "private"
+    },
+    "updatedAt": "<TIMESTAMP>"
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/contribution-merge/main-after-merge.json
+++ b/transcripts/share-apis/contribution-merge/main-after-merge.json
@@ -15,7 +15,7 @@
       "summary": null,
       "tags": [],
       "updatedAt": "<TIMESTAMP>",
-      "visibility": "private"
+      "visibility": "public"
     },
     "updatedAt": "<TIMESTAMP>"
   },

--- a/transcripts/share-apis/contribution-merge/main-before-merge.json
+++ b/transcripts/share-apis/contribution-merge/main-before-merge.json
@@ -1,0 +1,27 @@
+{
+  "body": {
+    "branchRef": "main",
+    "causalHash": "#rl08e4s9jm58fhj7uslg0qlndg2qhlp6gdd2thjicgpakqbkeumgeo220hgrh27jcd3kqh1o9b24dimpssr9eq2pe2icdu7nffkabsg",
+    "contributions": [],
+    "createdAt": "<TIMESTAMP>",
+    "project": {
+      "createdAt": "<TIMESTAMP>",
+      "owner": {
+        "handle": "@transcripts",
+        "name": "Transcript User",
+        "type": "user"
+      },
+      "slug": "merge",
+      "summary": null,
+      "tags": [],
+      "updatedAt": "<TIMESTAMP>",
+      "visibility": "private"
+    },
+    "updatedAt": "<TIMESTAMP>"
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/contribution-merge/main-before-merge.json
+++ b/transcripts/share-apis/contribution-merge/main-before-merge.json
@@ -15,7 +15,7 @@
       "summary": null,
       "tags": [],
       "updatedAt": "<TIMESTAMP>",
-      "visibility": "private"
+      "visibility": "public"
     },
     "updatedAt": "<TIMESTAMP>"
   },

--- a/transcripts/share-apis/contribution-merge/make-project-public.json
+++ b/transcripts/share-apis/contribution-merge/make-project-public.json
@@ -1,0 +1,8 @@
+{
+  "body": [],
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/contribution-merge/merge-contribution-branches.md
+++ b/transcripts/share-apis/contribution-merge/merge-contribution-branches.md
@@ -1,0 +1,7 @@
+```ucm
+.> clone @transcripts/bca-updates/main
+.> clone @transcripts/bca-updates/feature-one
+-- Merge the feature branch, then push the merged branch to main
+@transcripts/bca-updates/main> merge /feature-one
+@transcripts/bca-updates/main> push @transcripts/bca-updates/main
+```

--- a/transcripts/share-apis/contribution-merge/merge-contribution-branches.output.md
+++ b/transcripts/share-apis/contribution-merge/merge-contribution-branches.output.md
@@ -1,0 +1,26 @@
+```ucm
+.> clone @transcripts/bca-updates/main
+
+  Downloaded 3 entities.
+
+  Cloned @transcripts/bca-updates/main.
+
+.> clone @transcripts/bca-updates/feature-one
+
+  Downloaded 3 entities.
+
+  Cloned @transcripts/bca-updates/feature-one.
+
+-- Merge the feature branch, then push the merged branch to main
+@transcripts/bca-updates/main> merge /feature-one
+
+  I fast-forward merged @transcripts/bca-updates/feature-one
+  into @transcripts/bca-updates/main.
+
+@transcripts/bca-updates/main> push @transcripts/bca-updates/main
+
+  Uploaded 1 entities.
+
+  View it here: @transcripts/bca-updates/main on http://localhost:5424
+
+```

--- a/transcripts/share-apis/contribution-merge/project-setup.md
+++ b/transcripts/share-apis/contribution-merge/project-setup.md
@@ -1,0 +1,16 @@
+```ucm:hide
+scratch/main> project.create-empty merge
+```
+
+Create a main branch.
+
+```unison:hide
+term = "start"
+```
+
+Push it.
+
+```ucm
+merge/main> update
+merge/main> push @transcripts/merge/main
+```

--- a/transcripts/share-apis/contribution-merge/project-setup.output.md
+++ b/transcripts/share-apis/contribution-merge/project-setup.output.md
@@ -1,0 +1,25 @@
+Create a main branch.
+
+``` unison
+term = "start"
+```
+
+Push it.
+
+``` ucm
+merge/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+merge/main> push @transcripts/merge/main
+
+  Uploaded 3 entities.
+
+  I just created @transcripts/merge on http://localhost:5424
+
+  View it here: @transcripts/merge/main on http://localhost:5424
+
+```

--- a/transcripts/share-apis/contribution-merge/pull-after-merge.md
+++ b/transcripts/share-apis/contribution-merge/pull-after-merge.md
@@ -1,0 +1,4 @@
+```ucm
+scratch/main> clone @transcripts/merge/main
+@transcripts/merge/main> view term
+```

--- a/transcripts/share-apis/contribution-merge/pull-after-merge.output.md
+++ b/transcripts/share-apis/contribution-merge/pull-after-merge.output.md
@@ -1,0 +1,13 @@
+``` ucm
+scratch/main> clone @transcripts/merge/main
+
+  Downloaded 6 entities.
+
+  Cloned @transcripts/merge/main.
+
+@transcripts/merge/main> view term
+
+  term : ##Text
+  term = "feature"
+
+```

--- a/transcripts/share-apis/contribution-merge/run.zsh
+++ b/transcripts/share-apis/contribution-merge/run.zsh
@@ -16,5 +16,25 @@ fetch "$transcript_user" POST contribution-create-contribution '/users/transcrip
     "targetBranchRef": "main"
 }'
 
+# And the main branch should be set to the branch's head
+fetch "$transcript_user" GET 'main-before-merge' '/users/transcripts/projects/merge/branches/main'
+fetch_data "$transcript_user" GET 'feature-branch' '/users/transcripts/projects/merge/branches/fast-forward-feature'
+
+# Get the contribution and its contribution state token
+contribution_state_token=$(fetch_data "$transcript_user" GET 'contribution' '/users/transcripts/projects/merge/contributions/1' 2>/dev/null | jq -r '.contributionStateToken')
+echo "$contribution_state_token"
+
 # Check whether we can merge the contribution
-fetch "$transcript_user" GET contribution-check-merge '/users/transcripts/projects/merge/contributions/1/merge/check'
+fetch "$transcript_user" GET 'contribution-check-merge' '/users/transcripts/projects/merge/contributions/1/merge/check'
+
+# Actually merge the contribution
+fetch "$transcript_user" POST 'contribution-merge' '/users/transcripts/projects/merge/contributions/1/merge' "{
+    \"contributionStateToken\": \"${contribution_state_token}\"
+}
+"
+
+# Contribution should now be merged
+fetch "$transcript_user" GET 'contribution-after-merge' '/users/transcripts/projects/merge/contributions/1'
+
+# And the main branch should be set to the branch's head
+fetch "$transcript_user" GET 'main-after-merge' '/users/transcripts/projects/merge/branches/main'

--- a/transcripts/share-apis/contribution-merge/run.zsh
+++ b/transcripts/share-apis/contribution-merge/run.zsh
@@ -5,20 +5,30 @@ set -e
 source "../../transcript_helpers.sh"
 
 # Create a main branch and feature branch to merge into it.
-transcript_ucm transcript contribution-setup.md
+
+login_user_for_ucm 'transcripts'
+transcript_ucm transcript 'project-setup.md'
+
+fetch "$transcript_user" PATCH make-project-public '/users/transcripts/projects/merge' '{
+    "summary": null,
+    "visibility": "public"
+}'
+
+login_user_for_ucm 'test'
+transcript_ucm transcript 'contribution-setup.md'
 
 ## Create a contribution
-fetch "$transcript_user" POST contribution-create-contribution '/users/transcripts/projects/merge/contributions' '{
+fetch "$test_user" POST contribution-create-contribution '/users/transcripts/projects/merge/contributions' '{
     "title": "Fast Forward Contribution",
     "description": "My description",
     "status": "in_review",
-    "sourceBranchRef": "fast-forward-feature",
+    "sourceBranchRef": "@test/fast-forward-feature",
     "targetBranchRef": "main"
 }'
 
 # And the main branch should be set to the branch's head
 fetch "$transcript_user" GET 'main-before-merge' '/users/transcripts/projects/merge/branches/main'
-fetch_data "$transcript_user" GET 'feature-branch' '/users/transcripts/projects/merge/branches/fast-forward-feature'
+fetch_data "$transcript_user" GET 'feature-branch' '/users/transcripts/projects/merge/branches/%40test%2Ffast-forward-feature'
 
 # Get the contribution and its contribution state token
 contribution_state_token=$(fetch_data "$transcript_user" GET 'contribution' '/users/transcripts/projects/merge/contributions/1' 2>/dev/null | jq -r '.contributionStateToken')
@@ -38,3 +48,6 @@ fetch "$transcript_user" GET 'contribution-after-merge' '/users/transcripts/proj
 
 # And the main branch should be set to the branch's head
 fetch "$transcript_user" GET 'main-after-merge' '/users/transcripts/projects/merge/branches/main'
+
+login_user_for_ucm 'transcripts'
+transcript_ucm transcript 'pull-after-merge.md'

--- a/transcripts/share-apis/contribution-merge/run.zsh
+++ b/transcripts/share-apis/contribution-merge/run.zsh
@@ -1,0 +1,20 @@
+#!/usr/bin/env zsh
+
+set -e
+
+source "../../transcript_helpers.sh"
+
+# Create a main branch and feature branch to merge into it.
+transcript_ucm transcript contribution-setup.md
+
+## Create a contribution
+fetch "$transcript_user" POST contribution-create-contribution '/users/transcripts/projects/merge/contributions' '{
+    "title": "Fast Forward Contribution",
+    "description": "My description",
+    "status": "in_review",
+    "sourceBranchRef": "fast-forward-feature",
+    "targetBranchRef": "main"
+}'
+
+# Check whether we can merge the contribution
+fetch "$transcript_user" GET contribution-check-merge '/users/transcripts/projects/merge/contributions/1/merge/check'

--- a/transcripts/share-apis/contributions/contribution-get.json
+++ b/transcripts/share-apis/contributions/contribution-get.json
@@ -6,6 +6,7 @@
       "name": "Transcript User",
       "userId": "U-<UUID>"
     },
+    "contributionStateToken": "C-<UUID>:B-<UUID>:B-<UUID>:sg60bvjo91fsoo7pkh9gejbn0qgc95vra87ap6l5d35ri0lkaudl7bs12d71sf3fh6p23teemuor7mk1i9n567m50ibakcghjec5ajg:sg60bvjo91fsoo7pkh9gejbn0qgc95vra87ap6l5d35ri0lkaudl7bs12d71sf3fh6p23teemuor7mk1i9n567m50ibakcghjec5ajg:closed",
     "createdAt": "<TIMESTAMP>",
     "description": "Updated description",
     "id": "C-<UUID>",

--- a/transcripts/share-apis/contributions/merged-contribution.json
+++ b/transcripts/share-apis/contributions/merged-contribution.json
@@ -6,6 +6,7 @@
       "name": "Transcript User",
       "userId": "U-<UUID>"
     },
+    "contributionStateToken": "C-<UUID>:B-<UUID>:B-<UUID>:7shvkj0gn9mfne1pemp3oudmo23vio4d8ualvbah6avr7m5471rssu9cd4o6i4pn91bgc62vgnm0oper0itgtmopqmff7c0b40ui1s0:7shvkj0gn9mfne1pemp3oudmo23vio4d8ualvbah6avr7m5471rssu9cd4o6i4pn91bgc62vgnm0oper0itgtmopqmff7c0b40ui1s0:merged",
     "createdAt": "<TIMESTAMP>",
     "description": "description",
     "id": "C-<UUID>",

--- a/transcripts/share-apis/contributions/transitive-contribution.json
+++ b/transcripts/share-apis/contributions/transitive-contribution.json
@@ -6,6 +6,7 @@
       "name": "Transcript User",
       "userId": "U-<UUID>"
     },
+    "contributionStateToken": "C-<UUID>:B-<UUID>:B-<UUID>:ktjspqi8s5ngg129a6lt7i9kd488isfoq8hqmsv54f327de28dq9u0n1dp1vlbgs8jdc6bqss3h46ep9241405ml19nr0gekel56pig:7shvkj0gn9mfne1pemp3oudmo23vio4d8ualvbah6avr7m5471rssu9cd4o6i4pn91bgc62vgnm0oper0itgtmopqmff7c0b40ui1s0:in_review",
     "createdAt": "<TIMESTAMP>",
     "description": "description",
     "id": "C-<UUID>",


### PR DESCRIPTION
## Overview

Implements server-side merges on Share.

We plan to implement more complex merges too, but that's a lot of extra work and fast-forward merges are still a big win so we're starting with that.

Here's the intended flow:

1. The frontend loads a contribution, and notes the `contributionStateToken` field on the response (as an opaque string token)
2. The frontend fetches `GET /users/<handle>/projects/<slug>/contributions/<number>/merge/check`
Which responds:
```
{
    "mergability": {
      "kind": "fast_forward"
    }
  }
```

Currently possible `kind`s are:
* `fast_forward`
* `cant_merge`

We'll add more as we support them.

3. If the check says it's a fast_forward, then we can enable the merge button for authorized users.
4. If the user clicks the button, the fronend calls:
```
POST /users/<handle>/projects/<slug>/contributions/<number>/merge
{
  "contributionStateToken": "<token-from-earlier>"
}
```

If the state of the contribution hasn't meaningfully changed since the user loaded the page then the merge will succeed with a 200; otherwise it will fail with a `417 - Expectation failed` and the user will need to re-fresh the page to try again.

Note: currently the `merge/check` endpoint DOES check that the caller actually has permission to merge it, and will 403 if not; we may wish to relax this in the future so we can indicate to the contributor that something is or isn't mergable even if they don't have the permission to hit the button.

## Implementation notes

* Adds the two new endpoints for merge and merge/check on contributions
* When merging, checks if the target branch (usually `main`) is an ancestor of the source branch (a.k.a. `feature`). If yes, simply sets the the new head of `main` to point at the causal from `feature` and imports any new code into the project's codebase. If it's not a Fast Forward, fail with an error.

## Test coverage

Added a transcript for the happy path.
