### PR TITLE
Use custom fork of hasql-pool for better exception handling for Postgres Connections

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -50,7 +50,14 @@ extra-deps:
 
 # Bumping hasql up to get Pipelining mode
 - hasql-1.8
-- hasql-pool-1.2.0.2
+# Forked version of hasql-pool which doesn't return
+# connections to the pool when an exception occurs.
+# This is the `reset-connections-on-exception` branch.
+#
+# See: https://github.com/nikita-volkov/hasql-pool/issues/46
+# Previously: - hasql-pool-1.2.0.2
+- github: ChrisPenner/hasql-pool
+  commit: 3910e71505c80f944c201e2b981e9830494e1dbb
 - hasql-interpolate-1.0.1.0
 - postgresql-binary-0.14@sha256:3f3518f841cf80b107862800715bc64f43c2c71696c4129f63404c1ff61cc919,4025
 - postgresql-libpq-0.10.1.0@sha256:6a45edff0a9e30b32cda6e443107950492322622c4fbefc8fb4dcf6452dcf0b4,3203

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -75,12 +75,16 @@ packages:
   original:
     hackage: hasql-1.8
 - completed:
-    hackage: hasql-pool-1.2.0.2@sha256:621e3997d701b424a777fc6cd0218e385c89dff9417a933305d19b03820deb3f,2389
+    name: hasql-pool
     pantry-tree:
-      sha256: 8dd1ee8e3a41894266708e28076a902c8d51b275af22c3f182d6bfe219ea7fa7
-      size: 982
+      sha256: 3f2da91d2be6c2dfb082d0454ca0571dcb5e56ff76cef919f3800f62f26f0da6
+      size: 1518
+    sha256: 293b48e94da99a2fb218c136d026e84414a8994506f09b1021e503ed622a4390
+    size: 30457
+    url: https://github.com/ChrisPenner/hasql-pool/archive/3910e71505c80f944c201e2b981e9830494e1dbb.tar.gz
+    version: 1.2.0.2
   original:
-    hackage: hasql-pool-1.2.0.2
+    url: https://github.com/ChrisPenner/hasql-pool/archive/3910e71505c80f944c201e2b981e9830494e1dbb.tar.gz
 - completed:
     hackage: hasql-interpolate-1.0.1.0@sha256:07980986467ed196e812a54c2762a42ceca56ca899cb4ef3cdb4f4191b07d338,3298
     pantry-tree:


### PR DESCRIPTION
## Overview

hasql-pool returns connections with in-progress transactions to the connection pool if a non-session exception or async exception is triggered :'(

This has recently caused share outages as one exception triggers more exceptions and the connection never gets reset.

This switches to an upstream fork which changes the defaults to drop connections which encounter exceptions, see: https://github.com/ChrisPenner/hasql-pool/pull/1

Issue for discussing how to upstream this is here: https://github.com/nikita-volkov/hasql-pool/issues/46

# Tests

I tested the behaviour w/r to async and sync exceptions in a local branch, otherwise the transcripts should be sufficient.