### PR TITLE
Fix project slug prefix search

### DIFF
--- a/sql/2024-09-04-00-00_project_slug_indexes.sql
+++ b/sql/2024-09-04-00-00_project_slug_indexes.sql
@@ -1,0 +1,6 @@
+-- Drop the old indexes and re-make them with the text_pattern_ops operator class for better searching over slug.
+DROP INDEX project_user_slug;
+DROP INDEX project_slug;
+
+CREATE UNIQUE INDEX project_user_slug ON projects(owner_user_id, slug text_pattern_ops);
+CREATE INDEX project_slug ON projects(slug text_pattern_ops);

--- a/transcripts/share-apis/code-browse/search.json
+++ b/transcripts/share-apis/code-browse/search.json
@@ -5,12 +5,6 @@
       "handle": "test",
       "name": null,
       "tag": "User"
-    },
-    {
-      "projectRef": "@test/publictestproject",
-      "summary": "test project summary",
-      "tag": "Project",
-      "visibility": "public"
     }
   ],
   "status": 200

--- a/transcripts/share-apis/projects-flow/project-search-by-prefix.json
+++ b/transcripts/share-apis/projects-flow/project-search-by-prefix.json
@@ -1,0 +1,15 @@
+{
+  "body": [
+    {
+      "projectRef": "@test/publictestproject",
+      "summary": "test project summary",
+      "tag": "Project",
+      "visibility": "public"
+    }
+  ],
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/projects-flow/run.zsh
+++ b/transcripts/share-apis/projects-flow/run.zsh
@@ -78,6 +78,9 @@ fetch "$transcript_user" GET project-catalog-get '/catalog'
 # Should find projects we have access to (e.g. Unison's private project), but none that we don't.
 fetch "$transcript_user" GET project-search '/search?query=test'
 
+# Should find projects we have access to (e.g. Unison's private project), but none that we don't.
+fetch "$transcript_user" GET project-search-by-prefix '/search?query=@publicte'
+
 # Should filter project search by user if provided a full valid handle:
 fetch "$transcript_user" GET project-search-with-user-and-project-query '/search?query=@test/public'
 


### PR DESCRIPTION
## Overview

Project search would weirdly not actually perform a proper prefix search on slugs, only a prefix search on stemmed ts_vector tokens, which meant `statef` wouldn't match `stateful` because `stateful` gets stemmed to `state` but `statef` isn't a prefix of `state` 🙃 

This ditches the web-search syntax since nobody uses it, and adds a simple OR with a prefix search on slug.