### PR TITLE
Batched background diffs

### DIFF
--- a/share-api.cabal
+++ b/share-api.cabal
@@ -28,6 +28,8 @@ library
       Share.App
       Share.Backend
       Share.BackgroundJobs
+      Share.BackgroundJobs.Diffs.ContributionDiffs
+      Share.BackgroundJobs.Diffs.Queries
       Share.BackgroundJobs.Errors
       Share.BackgroundJobs.Monad
       Share.BackgroundJobs.Search.DefinitionSync

--- a/share-utils/package.yaml
+++ b/share-utils/package.yaml
@@ -42,6 +42,7 @@ default-extensions:
   - FlexibleContexts
   - FlexibleInstances
   - GeneralizedNewtypeDeriving
+  - InstanceSigs
   - LambdaCase
   - MultiParamTypeClasses
   - NamedFieldPuns

--- a/share-utils/share-utils.cabal
+++ b/share-utils/share-utils.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -25,6 +25,7 @@ source-repository head
 library
   exposed-modules:
       Share.Debug
+      Share.Utils.Aeson
       Share.Utils.Binary
       Share.Utils.Deployment
       Share.Utils.IDs

--- a/share-utils/share-utils.cabal
+++ b/share-utils/share-utils.cabal
@@ -51,6 +51,7 @@ library
       FlexibleContexts
       FlexibleInstances
       GeneralizedNewtypeDeriving
+      InstanceSigs
       LambdaCase
       MultiParamTypeClasses
       NamedFieldPuns

--- a/share-utils/src/Share/Utils/Aeson.hs
+++ b/share-utils/src/Share/Utils/Aeson.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE InstanceSigs #-}
+
+module Share.Utils.Aeson (MaybeEncoded (..), PreEncoded (..)) where
+
+import Data.Aeson (ToJSON (..))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Encoding qualified as Encoding
+import Data.Binary.Builder qualified as Builder
+import Data.Text.Lazy qualified as TL
+import Data.Text.Lazy.Encoding qualified as TL
+import GHC.Stack (HasCallStack)
+
+data MaybeEncoded a
+  = IsEncoded TL.Text
+  | NotEncoded a
+  deriving stock (Show, Eq, Ord)
+
+instance (ToJSON a) => ToJSON (MaybeEncoded a) where
+  toJSON :: (HasCallStack) => MaybeEncoded a -> Aeson.Value
+  toJSON (IsEncoded _txt) = error "Tried to encode a MaybeEncoded value back into a Value. Ensure you're using toEncoding instead."
+  toJSON (NotEncoded a) = Aeson.toJSON a
+
+  toEncoding :: (HasCallStack) => MaybeEncoded a -> Aeson.Encoding
+  toEncoding (IsEncoded txt) = Aeson.toEncoding (PreEncoded txt)
+  toEncoding (NotEncoded a) = Aeson.toEncoding a
+
+newtype PreEncoded = PreEncoded TL.Text
+  deriving stock (Show, Eq, Ord)
+
+instance ToJSON PreEncoded where
+  toJSON :: (HasCallStack) => PreEncoded -> Aeson.Value
+  toJSON (PreEncoded _txt) = error "Tried to encode a PreEncoded value back into a Value. Ensure you're using toEncoding instead."
+
+  toEncoding :: (HasCallStack) => PreEncoded -> Aeson.Encoding
+  toEncoding (PreEncoded txt) = Encoding.unsafeToEncoding $ Builder.fromLazyByteString $ TL.encodeUtf8 txt

--- a/share-utils/src/Share/Utils/Aeson.hs
+++ b/share-utils/src/Share/Utils/Aeson.hs
@@ -7,6 +7,9 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Encoding qualified as Encoding
 import Data.Binary.Builder qualified as Builder
 import Data.ByteString.Lazy.Char8 qualified as BL
+import Data.Maybe (fromMaybe)
+import Data.Proxy (Proxy (..))
+import Data.Typeable (Typeable, typeRep)
 import GHC.Stack (HasCallStack)
 
 data MaybeEncoded a
@@ -14,21 +17,24 @@ data MaybeEncoded a
   | NotEncoded a
   deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
 
-instance (ToJSON a) => ToJSON (MaybeEncoded a) where
+instance (Typeable a, ToJSON a) => ToJSON (MaybeEncoded a) where
   toJSON :: (HasCallStack) => MaybeEncoded a -> Aeson.Value
-  toJSON (IsEncoded _txt) = error "Tried to encode a MaybeEncoded value back into a Value. Ensure you're using toEncoding instead."
+  toJSON (IsEncoded txt) = Aeson.toJSON (PreEncoded @a txt)
   toJSON (NotEncoded a) = Aeson.toJSON a
 
   toEncoding :: (HasCallStack) => MaybeEncoded a -> Aeson.Encoding
-  toEncoding (IsEncoded txt) = Aeson.toEncoding (PreEncoded txt)
+  toEncoding (IsEncoded txt) = Aeson.toEncoding (PreEncoded @a txt)
   toEncoding (NotEncoded a) = Aeson.toEncoding a
 
 newtype PreEncoded a = PreEncoded BL.ByteString
   deriving stock (Show, Eq, Ord)
 
-instance ToJSON (PreEncoded a) where
+instance (Typeable a) => ToJSON (PreEncoded a) where
   toJSON :: (HasCallStack) => PreEncoded a -> Aeson.Value
-  toJSON (PreEncoded _txt) = error "Tried to encode a PreEncoded value back into a Value. Ensure you're using toEncoding instead."
+  toJSON (PreEncoded txt) =
+    -- It's regrettable we have to do this, but seemingly it's required when building values
+    -- with @@object [key .= val]@@ syntax.
+    fromMaybe (error $ "Invalid PreEncoded JSON for type: " <> show (typeRep (Proxy @a))) $ Aeson.decode txt
 
   toEncoding :: (HasCallStack) => PreEncoded a -> Aeson.Encoding
   toEncoding (PreEncoded txt) = Encoding.unsafeToEncoding . Builder.fromLazyByteString $ txt

--- a/share-utils/src/Share/Utils/Aeson.hs
+++ b/share-utils/src/Share/Utils/Aeson.hs
@@ -13,7 +13,7 @@ import GHC.Stack (HasCallStack)
 data MaybeEncoded a
   = IsEncoded TL.Text
   | NotEncoded a
-  deriving stock (Show, Eq, Ord)
+  deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
 
 instance (ToJSON a) => ToJSON (MaybeEncoded a) where
   toJSON :: (HasCallStack) => MaybeEncoded a -> Aeson.Value

--- a/share-utils/src/Share/Utils/Aeson.hs
+++ b/share-utils/src/Share/Utils/Aeson.hs
@@ -6,12 +6,11 @@ import Data.Aeson (ToJSON (..))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Encoding qualified as Encoding
 import Data.Binary.Builder qualified as Builder
-import Data.Text.Lazy qualified as TL
-import Data.Text.Lazy.Encoding qualified as TL
+import Data.ByteString.Lazy.Char8 qualified as BL
 import GHC.Stack (HasCallStack)
 
 data MaybeEncoded a
-  = IsEncoded TL.Text
+  = IsEncoded BL.ByteString
   | NotEncoded a
   deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
 
@@ -24,12 +23,12 @@ instance (ToJSON a) => ToJSON (MaybeEncoded a) where
   toEncoding (IsEncoded txt) = Aeson.toEncoding (PreEncoded txt)
   toEncoding (NotEncoded a) = Aeson.toEncoding a
 
-newtype PreEncoded = PreEncoded TL.Text
+newtype PreEncoded a = PreEncoded BL.ByteString
   deriving stock (Show, Eq, Ord)
 
-instance ToJSON PreEncoded where
-  toJSON :: (HasCallStack) => PreEncoded -> Aeson.Value
+instance ToJSON (PreEncoded a) where
+  toJSON :: (HasCallStack) => PreEncoded a -> Aeson.Value
   toJSON (PreEncoded _txt) = error "Tried to encode a PreEncoded value back into a Value. Ensure you're using toEncoding instead."
 
-  toEncoding :: (HasCallStack) => PreEncoded -> Aeson.Encoding
-  toEncoding (PreEncoded txt) = Encoding.unsafeToEncoding $ Builder.fromLazyByteString $ TL.encodeUtf8 txt
+  toEncoding :: (HasCallStack) => PreEncoded a -> Aeson.Encoding
+  toEncoding (PreEncoded txt) = Encoding.unsafeToEncoding . Builder.fromLazyByteString $ txt

--- a/share-utils/src/Share/Utils/URI.hs
+++ b/share-utils/src/Share/Utils/URI.hs
@@ -22,12 +22,12 @@ import Data.Map qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
-import Share.Utils.Show (tShow)
 import Hasql.Decoders qualified as Decoders
 import Hasql.Interpolate qualified as Hasql
 import Network.HTTP.Types (parseQuery, renderQuery)
 import Network.URI qualified as URI
 import Servant
+import Share.Utils.Show (tShow)
 
 -- | Helper type to provide additional instances for URIs.
 newtype URIParam = URIParam {unpackURI :: URI}

--- a/sql/2024-11-19-00-00_namespace_diffs.sql
+++ b/sql/2024-11-19-00-00_namespace_diffs.sql
@@ -19,7 +19,5 @@ CREATE TABLE namespace_diffs (
 -- Table of all contributions which have been updated and may need their diffs re-computed
 CREATE TABLE contribution_diff_queue (
   contribution_id UUID PRIMARY KEY REFERENCES contributions(id) ON DELETE CASCADE,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-
-  PRIMARY KEY (contribution_id)
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/sql/2024-11-19-00-00_namespace_diffs.sql
+++ b/sql/2024-11-19-00-00_namespace_diffs.sql
@@ -5,8 +5,8 @@ CREATE TABLE namespace_diffs (
     right_namespace_id INTEGER NOT NULL REFERENCES branch_hashes(id) ON DELETE CASCADE,
 
     -- Since different codebases can have different variable names and such we also need to sandbox diffs by codebase owner
-    left_codebase_owner_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    right_codebase_owner_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE
+    left_codebase_owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    right_codebase_owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
 
     diff JSONB NOT NULL,
 

--- a/sql/2024-11-19-00-00_namespace_diffs.sql
+++ b/sql/2024-11-19-00-00_namespace_diffs.sql
@@ -1,0 +1,14 @@
+-- Adds tables for storing pre-computed namespace diffs
+
+CREATE TABLE namespace_diffs (
+    left_namespace_id INTEGER NOT NULL REFERENCES branch_hashes(id) ON DELETE CASCADE,
+    right_namespace_id INTEGER NOT NULL REFERENCES branch_hashes(id) ON DELETE CASCADE,
+
+    -- Since different codebases can have different variable names and such we also need to sandbox diffs by codebase owner
+    left_codebase_owner_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    right_codebase_owner_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE
+
+    diff JSONB NOT NULL,
+
+    PRIMARY KEY (left_namespace_id, right_namespace_id, left_codebase_owner_user_id, right_codebase_owner_user_id)
+);

--- a/sql/2024-11-19-00-00_namespace_diffs.sql
+++ b/sql/2024-11-19-00-00_namespace_diffs.sql
@@ -12,3 +12,14 @@ CREATE TABLE namespace_diffs (
 
     PRIMARY KEY (left_namespace_id, right_namespace_id, left_codebase_owner_user_id, right_codebase_owner_user_id)
 );
+
+
+-- New table for coordinating background job for pre-computing diffs
+
+-- Table of all contributions which have been updated and may need their diffs re-computed
+CREATE TABLE contribution_diff_queue (
+  contribution_id UUID PRIMARY KEY REFERENCES contributions(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (contribution_id)
+);

--- a/src/Share/BackgroundJobs.hs
+++ b/src/Share/BackgroundJobs.hs
@@ -1,6 +1,7 @@
 module Share.BackgroundJobs (startWorkers) where
 
 import Ki.Unlifted qualified as Ki
+import Share.BackgroundJobs.Diffs.ContributionDiffs qualified as ContributionDiffs
 import Share.BackgroundJobs.Monad (Background)
 import Share.BackgroundJobs.Search.DefinitionSync qualified as DefnSearch
 

--- a/src/Share/BackgroundJobs.hs
+++ b/src/Share/BackgroundJobs.hs
@@ -8,3 +8,4 @@ import Share.BackgroundJobs.Search.DefinitionSync qualified as DefnSearch
 startWorkers :: Ki.Scope -> Background ()
 startWorkers scope = do
   DefnSearch.worker scope
+  ContributionDiffs.worker scope

--- a/src/Share/BackgroundJobs/Diffs/ContributionDiffs.hs
+++ b/src/Share/BackgroundJobs/Diffs/ContributionDiffs.hs
@@ -1,0 +1,61 @@
+module Share.BackgroundJobs.Diffs.ContributionDiffs (worker) where
+
+import Control.Lens
+import Ki.Unlifted qualified as Ki
+import Share.BackgroundJobs.Diffs.Queries qualified as DQ
+import Share.BackgroundJobs.Monad (Background)
+import Share.BackgroundJobs.Workers (newWorker)
+import Share.Branch (Branch (..))
+import Share.Codebase qualified as Codebase
+import Share.Contribution (Contribution (..))
+import Share.IDs
+import Share.Metrics qualified as Metrics
+import Share.Postgres qualified as PG
+import Share.Postgres.Contributions.Queries qualified as ContributionsQ
+import Share.Postgres.Queries qualified as Q
+import Share.Prelude
+import Share.Project (Project (..))
+import Share.Utils.Logging qualified as Logging
+import Share.Web.Authorization qualified as AuthZ
+import Share.Web.Errors (EntityMissing (..), ErrorID (..))
+import Share.Web.Share.Diffs.Impl qualified as Diffs
+import UnliftIO.Concurrent qualified as UnliftIO
+
+pollingIntervalSeconds :: Int
+pollingIntervalSeconds = 10
+
+worker :: Ki.Scope -> Background ()
+worker scope = do
+  authZReceipt <- AuthZ.backgroundJobAuthZ
+  newWorker scope "diffs:contributions" $ forever do
+    processDiffs authZReceipt
+    liftIO $ UnliftIO.threadDelay $ pollingIntervalSeconds * 1000000
+
+processDiffs :: AuthZ.AuthZReceipt -> Background ()
+processDiffs authZReceipt = do
+  mayContributionId <- Metrics.recordContributionDiffDuration $ PG.runTransactionMode PG.ReadCommitted PG.ReadWrite $ do
+    mayContributionId <- DQ.claimContributionToDiff
+    for_ mayContributionId (diffContribution authZReceipt)
+    pure mayContributionId
+  case mayContributionId of
+    Just contributionId -> do
+      Logging.textLog ("Recomputed contribution diff: " <> tShow contributionId)
+        & Logging.withTag ("contribution-id", tShow contributionId)
+        & Logging.withSeverity Logging.Info
+        & Logging.logMsg
+      -- Keep processing releases until we run out of them.
+      processDiffs authZReceipt
+    Nothing -> pure ()
+
+type DiffContributionError = EntityMissing
+
+diffContribution :: AuthZ.AuthZReceipt -> ContributionId -> WebApp ()
+diffContribution authZReceipt contributionId = do
+  Contribution {sourceBranchId = newBranchId, targetBranchId = oldBranchId, projectId} <- ContributionsQ.contributionById contributionId `whenNothingM` throwError (EntityMissing (ErrorID "contribution:missing") "Contribution not found")
+  project <- Q.projectById projectId `whenNothingM` throwError (EntityMissing (ErrorID "project:missing") "Project not found")
+  newBranch@Branch {causal = newBranchCausalId, branchId = newBranchId} <- Q.branchById newBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
+  oldBranch@Branch {causal = oldBranchCausalId, branchId = oldBranchId} <- Q.branchById oldBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
+  let oldCodebase = Codebase.codebaseForProjectBranch authZReceipt project oldBranch
+  let newCodebase = Codebase.codebaseForProjectBranch authZReceipt project newBranch
+  _ <- Diffs.diffCausals authZReceipt (oldCodebase, oldBranchCausalId) (newCodebase, newBranchCausalId)
+  pure ()

--- a/src/Share/BackgroundJobs/Diffs/ContributionDiffs.hs
+++ b/src/Share/BackgroundJobs/Diffs/ContributionDiffs.hs
@@ -63,5 +63,6 @@ diffContribution authZReceipt contributionId = do
     pure (project, newBranch, oldBranch)
   let oldCodebase = Codebase.codebaseForProjectBranch authZReceipt project oldBranch
   let newCodebase = Codebase.codebaseForProjectBranch authZReceipt project newBranch
+  -- This method saves the diff so it'll be there when we need it, so we don't need to do anything with it.
   _ <- Diffs.diffCausals authZReceipt (oldCodebase, oldBranchCausalId) (newCodebase, newBranchCausalId)
   pure ()

--- a/src/Share/BackgroundJobs/Diffs/Queries.hs
+++ b/src/Share/BackgroundJobs/Diffs/Queries.hs
@@ -1,0 +1,35 @@
+module Share.BackgroundJobs.Diffs.Queries
+  ( submitContributionToBeDiffed,
+    claimContributionToDiff,
+  )
+where
+
+import Share.IDs
+import Share.Postgres
+
+submitContributionToBeDiffed :: (QueryM m) => ContributionId -> m ()
+submitContributionToBeDiffed contributionId = do
+  execute_
+    [sql|
+    INSERT INTO contribution_diff_queue (contribution_id)
+    VALUES (#{contributionId})
+    |]
+
+-- | Claim the oldest contribution in the queue to be diffed.
+claimContributionToDiff :: Transaction e (Maybe ContributionId)
+claimContributionToDiff = do
+  query1Col
+    [sql|
+    WITH chosen_contribution(contribution_id) AS (
+      SELECT q.contribution_id
+      FROM contribution_diff_queue q
+      ORDER BY q.created_at ASC
+      LIMIT 1
+      -- Skip any that are being synced by other workers.
+      FOR UPDATE SKIP LOCKED
+    )
+    DELETE FROM contribution_diff_queue
+      USING chosen_contribution
+      WHERE contribution_diff_queue.contribution_id = chosen_contribution.contribution_id
+    RETURNING chosen_contribution.contribution_id
+    |]

--- a/src/Share/BackgroundJobs/Diffs/Queries.hs
+++ b/src/Share/BackgroundJobs/Diffs/Queries.hs
@@ -8,9 +8,11 @@ import Data.Foldable (toList)
 import Data.Set (Set)
 import Share.IDs
 import Share.Postgres
+import Unison.Debug qualified as Debug
 
 submitContributionsToBeDiffed :: (QueryM m) => Set ContributionId -> m ()
 submitContributionsToBeDiffed contributions = do
+  Debug.debugM Debug.Temp "Submitting contributions to be diffed: " contributions
   execute_
     [sql|
     WITH new_contributions(contribution_id) AS (

--- a/src/Share/Metrics.hs
+++ b/src/Share/Metrics.hs
@@ -10,6 +10,7 @@ module Share.Metrics
     tickUserSignup,
     recordBackgroundImportDuration,
     recordDefinitionSearchIndexDuration,
+    recordContributionDiffDuration,
   )
 where
 
@@ -398,6 +399,18 @@ definitionSearchIndexDurationSeconds =
         "definition_search_indexing_duration_seconds"
         "The time it took to index a release for definition search"
 
+{-# NOINLINE contributionDiffDurationSeconds #-}
+contributionDiffDurationSeconds :: Prom.Vector Prom.Label2 Prom.Histogram
+contributionDiffDurationSeconds =
+  Prom.unsafeRegister $
+    Prom.vector ("deployment", "service") $
+      Prom.histogram info Prom.defaultBuckets
+  where
+    info =
+      Prom.Info
+        "contribution_diff_duration_seconds"
+        "The time it took to compute a contribution diff"
+
 timeActionIntoHistogram :: (Prom.Label l, MonadUnliftIO m) => (Prom.Vector l Prom.Histogram) -> l -> m c -> m c
 timeActionIntoHistogram histogram l m = do
   UnliftIO.bracket start end \_ -> m
@@ -416,3 +429,6 @@ recordBackgroundImportDuration = timeActionIntoHistogram backgroundImportDuratio
 -- | Record the duration of a background import.
 recordDefinitionSearchIndexDuration :: (MonadUnliftIO m) => m r -> m r
 recordDefinitionSearchIndexDuration = timeActionIntoHistogram definitionSearchIndexDurationSeconds (deployment, service)
+
+recordContributionDiffDuration :: (MonadUnliftIO m) => m r -> m r
+recordContributionDiffDuration = timeActionIntoHistogram contributionDiffDurationSeconds (deployment, service)

--- a/src/Share/NamespaceDiffs.hs
+++ b/src/Share/NamespaceDiffs.hs
@@ -215,7 +215,9 @@ namespaceTreeDiffTermDiffs_ = traversed . traversed . diffAtPathTermDiffs_
 namespaceTreeDiffTypeDiffs_ :: (Ord typeDiff', Ord reference) => Traversal (NamespaceTreeDiff referent reference termDiff typeDiff) (NamespaceTreeDiff referent reference termDiff typeDiff') typeDiff typeDiff'
 namespaceTreeDiffTypeDiffs_ = traversed . traversed . diffAtPathTypeDiffs_
 
-data NamespaceDiffError = ImpossibleError Text
+data NamespaceDiffError
+  = ImpossibleError Text
+  | MissingEntityError EntityMissing
   deriving stock (Eq, Show)
 
 instance ToServerError NamespaceDiffError where

--- a/src/Share/NamespaceDiffs.hs
+++ b/src/Share/NamespaceDiffs.hs
@@ -13,6 +13,12 @@ module Share.NamespaceDiffs
     namespaceTreeDiffReferents_,
     namespaceTreeDiffTermDiffs_,
     namespaceTreeDiffTypeDiffs_,
+    definitionDiffRendered_,
+    definitionDiffRefs_,
+    definitionDiffDiffs_,
+    definitionDiffKindRefs_,
+    definitionDiffKindDiffs_,
+    definitionDiffKindRendered_,
   )
 where
 
@@ -20,7 +26,6 @@ import Control.Comonad.Cofree (Cofree)
 import Control.Comonad.Cofree qualified as Cofree
 import Control.Lens hiding ((:<))
 import Data.Align (Semialign (..))
-import Data.Bifoldable (Bifoldable (..))
 import Data.Either (partitionEithers)
 import Data.Foldable qualified as Foldable
 import Data.List.NonEmpty qualified as NEList
@@ -69,59 +74,60 @@ data DefinitionDiffs name r = DefinitionDiffs
   }
   deriving stock (Eq, Show)
 
-data DefinitionDiff r diff = DefinitionDiff
-  { kind :: DefinitionDiffKind r diff,
+data DefinitionDiff r rendered diff = DefinitionDiff
+  { kind :: DefinitionDiffKind r rendered diff,
     -- The fully qualified name of the definition we're concerned with.
     fqn :: Name
   }
-  deriving stock (Eq, Show, Ord, Functor, Foldable, Traversable)
+  deriving stock (Eq, Show, Ord)
 
-instance Bifunctor DefinitionDiff where
-  bimap f g (DefinitionDiff k n) = DefinitionDiff (bimap f g k) n
+definitionDiffRefs_ :: Traversal (DefinitionDiff r rendered diff) (DefinitionDiff r' rendered diff) r r'
+definitionDiffRefs_ f (DefinitionDiff k n) = DefinitionDiff <$> definitionDiffKindRefs_ f k <*> pure n
 
-instance Bifoldable DefinitionDiff where
-  bifoldMap f g (DefinitionDiff k _n) = bifoldMap f g k
+definitionDiffDiffs_ :: Traversal (DefinitionDiff r rendered diff) (DefinitionDiff r rendered diff') diff diff'
+definitionDiffDiffs_ f (DefinitionDiff k n) = DefinitionDiff <$> definitionDiffKindDiffs_ f k <*> pure n
 
-instance Bitraversable DefinitionDiff where
-  bitraverse f g (DefinitionDiff k n) = DefinitionDiff <$> bitraverse f g k <*> pure n
+definitionDiffRendered_ :: Traversal (DefinitionDiff r rendered diff) (DefinitionDiff r rendered' diff) rendered rendered'
+definitionDiffRendered_ f (DefinitionDiff k n) = DefinitionDiff <$> definitionDiffKindRendered_ f k <*> pure n
 
 -- | Information about a single definition which is different.
-data DefinitionDiffKind r diff
-  = Added r
-  | NewAlias r (NESet Name {- existing names -})
-  | Removed r
+data DefinitionDiffKind r rendered diff
+  = Added r rendered
+  | NewAlias r (NESet Name {- existing names -}) rendered
+  | Removed r rendered
   | Updated r {- old -} r {- new -} diff
   | -- This definition was removed away from this location and added at the provided names.
-    RenamedTo r (NESet Name)
+    RenamedTo r (NESet Name) rendered
   | -- This definition was added at this location and removed from the provided names.
-    RenamedFrom r (NESet Name)
-  deriving stock (Eq, Show, Ord, Functor, Foldable, Traversable)
+    RenamedFrom r (NESet Name) rendered
+  deriving stock (Eq, Show, Ord)
 
-definitionDiffKindRefs_ :: Traversal (DefinitionDiffKind r diff) (DefinitionDiffKind r' diff) r r'
-definitionDiffKindRefs_ f = traverseOf (\f -> bitraverse f pure) f
+definitionDiffKindRefs_ :: Traversal (DefinitionDiffKind r rendered diff) (DefinitionDiffKind r' rendered diff) r r'
+definitionDiffKindRefs_ f = \case
+  Added r rendered -> Added <$> f r <*> pure rendered
+  NewAlias r ns rendered -> NewAlias <$> f r <*> pure ns <*> pure rendered
+  Removed r rendered -> Removed <$> f r <*> pure rendered
+  Updated old new diff -> Updated <$> f old <*> f new <*> pure diff
+  RenamedTo r old rendered -> RenamedTo <$> f r <*> pure old <*> pure rendered
+  RenamedFrom r old rendered -> RenamedFrom <$> f r <*> pure old <*> pure rendered
 
-definitionDiffKindDiffs_ :: Traversal (DefinitionDiffKind r diff) (DefinitionDiffKind r diff') diff diff'
-definitionDiffKindDiffs_ = traverse
+definitionDiffKindDiffs_ :: Traversal (DefinitionDiffKind r rendered diff) (DefinitionDiffKind r rendered diff') diff diff'
+definitionDiffKindDiffs_ f = \case
+  Added r rendered -> Added r <$> pure rendered
+  NewAlias r ns rendered -> NewAlias r ns <$> pure rendered
+  Removed r rendered -> Removed r <$> pure rendered
+  Updated old new diff -> Updated old new <$> f diff
+  RenamedTo r old rendered -> RenamedTo r old <$> pure rendered
+  RenamedFrom r old rendered -> RenamedFrom r old <$> pure rendered
 
-instance Bifunctor DefinitionDiffKind where
-  bimap f g v =
-    v
-      & definitionDiffKindRefs_ %~ f
-      & definitionDiffKindDiffs_ %~ g
-
-instance Bifoldable DefinitionDiffKind where
-  bifoldMap f g v =
-    foldMapOf definitionDiffKindRefs_ f v
-      <> foldMapOf definitionDiffKindDiffs_ g v
-
-instance Bitraversable DefinitionDiffKind where
-  bitraverse f g = \case
-    Added r -> Added <$> f r
-    NewAlias r ns -> NewAlias <$> f r <*> pure ns
-    Removed r -> Removed <$> f r
-    Updated r1 r2 d -> Updated <$> f r1 <*> f r2 <*> g d
-    RenamedTo r ns -> RenamedTo <$> f r <*> pure ns
-    RenamedFrom r ns -> RenamedFrom <$> f r <*> pure ns
+definitionDiffKindRendered_ :: Traversal (DefinitionDiffKind r rendered diff) (DefinitionDiffKind r rendered' diff) rendered rendered'
+definitionDiffKindRendered_ f = \case
+  Added r rendered -> Added r <$> f rendered
+  NewAlias r ns rendered -> NewAlias r ns <$> f rendered
+  Removed r rendered -> Removed r <$> f rendered
+  Updated old new diff -> Updated old new <$> pure diff
+  RenamedTo r old rendered -> RenamedTo r old <$> f rendered
+  RenamedFrom r old rendered -> RenamedFrom r old <$> f rendered
 
 instance (Ord r) => Semigroup (DefinitionDiffs Name r) where
   d1 <> d2 =
@@ -164,56 +170,56 @@ instance (Ord r) => Monoid (DefinitionDiffs Name r) where
 --    ├── c = DiffAtPath
 --    └── x = DiffAtPath
 -- @@
-type NamespaceTreeDiff referent reference termDiff typeDiff = Cofree (Map Path) (Map NameSegment (DiffAtPath referent reference termDiff typeDiff))
+type NamespaceTreeDiff referent reference renderedTerm renderedType termDiff typeDiff = Cofree (Map Path) (Map NameSegment (DiffAtPath referent reference renderedTerm renderedType termDiff typeDiff))
 
 -- | The differences at a specific path in the namespace tree.
-data DiffAtPath referent reference termDiff typeDiff = DiffAtPath
-  { termDiffsAtPath :: Set (DefinitionDiff referent termDiff),
-    typeDiffsAtPath :: Set (DefinitionDiff reference typeDiff)
+data DiffAtPath referent reference renderedTerm renderedType termDiff typeDiff = DiffAtPath
+  { termDiffsAtPath :: Set (DefinitionDiff referent renderedTerm termDiff),
+    typeDiffsAtPath :: Set (DefinitionDiff reference renderedType typeDiff)
   }
   deriving stock (Eq, Show)
 
 -- | A traversal over all the referents in a `DiffAtPath`.
-diffAtPathReferents_ :: (Ord referent', Ord termDiff) => Traversal (DiffAtPath referent reference termDiff typeDiff) (DiffAtPath referent' reference termDiff typeDiff) referent referent'
+diffAtPathReferents_ :: (Ord referent', Ord termDiff, Ord renderedTerm) => Traversal (DiffAtPath referent reference renderedTerm renderedType termDiff typeDiff) (DiffAtPath referent' reference renderedTerm renderedType termDiff typeDiff) referent referent'
 diffAtPathReferents_ f (DiffAtPath {termDiffsAtPath, typeDiffsAtPath}) =
   termDiffsAtPath
-    & (Set.traverse . traverseFirst) %%~ f
+    & (Set.traverse . definitionDiffRefs_) %%~ f
     & fmap \termDiffsAtPath -> DiffAtPath {typeDiffsAtPath, termDiffsAtPath}
 
 -- | A traversal over all the references in a `DiffAtPath`.
-diffAtPathReferences_ :: (Ord reference', Ord typeDiff) => Traversal (DiffAtPath referent reference termDiff typeDiff) (DiffAtPath referent reference' termDiff typeDiff) reference reference'
+diffAtPathReferences_ :: (Ord reference', Ord typeDiff, Ord renderedType) => Traversal (DiffAtPath referent reference renderedTerm renderedType termDiff typeDiff) (DiffAtPath referent reference' renderedTerm renderedType termDiff typeDiff) reference reference'
 diffAtPathReferences_ f (DiffAtPath {termDiffsAtPath, typeDiffsAtPath}) =
   typeDiffsAtPath
-    & (Set.traverse . traverseFirst) %%~ f
+    & (Set.traverse . definitionDiffRefs_) %%~ f
     & fmap \typeDiffsAtPath -> DiffAtPath {typeDiffsAtPath, termDiffsAtPath}
 
 -- | A traversal over all the term diffs in a `DiffAtPath`.
-diffAtPathTermDiffs_ :: (Ord termDiff', Ord referent) => Traversal (DiffAtPath referent reference termDiff typeDiff) (DiffAtPath referent reference termDiff' typeDiff) termDiff termDiff'
+diffAtPathTermDiffs_ :: (Ord termDiff', Ord referent, Ord renderedTerm) => Traversal (DiffAtPath referent reference renderedTerm renderedType termDiff typeDiff) (DiffAtPath referent reference renderedTerm renderedType termDiff' typeDiff) termDiff termDiff'
 diffAtPathTermDiffs_ f (DiffAtPath {termDiffsAtPath, typeDiffsAtPath}) =
   termDiffsAtPath
-    & (Set.traverse . traverse) %%~ f
+    & (Set.traverse . definitionDiffDiffs_) %%~ f
     <&> \termDiffsAtPath -> DiffAtPath {typeDiffsAtPath, termDiffsAtPath}
 
 -- | A traversal over all the type diffs in a `DiffAtPath`.
-diffAtPathTypeDiffs_ :: (Ord typeDiff', Ord reference) => Traversal (DiffAtPath referent reference termDiff typeDiff) (DiffAtPath referent reference termDiff typeDiff') typeDiff typeDiff'
+diffAtPathTypeDiffs_ :: (Ord typeDiff', Ord reference, Ord renderedType) => Traversal (DiffAtPath referent reference renderedTerm renderedType termDiff typeDiff) (DiffAtPath referent reference renderedTerm renderedType termDiff typeDiff') typeDiff typeDiff'
 diffAtPathTypeDiffs_ f (DiffAtPath {termDiffsAtPath, typeDiffsAtPath}) =
   typeDiffsAtPath
-    & (Set.traverse . traverse) %%~ f
+    & (Set.traverse . definitionDiffDiffs_) %%~ f
     <&> \typeDiffsAtPath -> DiffAtPath {typeDiffsAtPath, termDiffsAtPath}
 
 -- | Traversal over all the referents in a `NamespaceTreeDiff`.
-namespaceTreeDiffReferents_ :: (Ord referent', Ord termDiff) => Traversal (NamespaceTreeDiff referent reference termDiff typeDiff) (NamespaceTreeDiff referent' reference termDiff typeDiff) referent referent'
+namespaceTreeDiffReferents_ :: (Ord referent', Ord termDiff, Ord renderedTerm) => Traversal (NamespaceTreeDiff referent reference renderedTerm renderedType termDiff typeDiff) (NamespaceTreeDiff referent' reference renderedTerm renderedType termDiff typeDiff) referent referent'
 namespaceTreeDiffReferents_ =
   traversed . traversed . diffAtPathReferents_
 
 -- | Traversal over all the references in a `NamespaceTreeDiff`.
-namespaceTreeDiffReferences_ :: (Ord reference', Ord typeDiff) => Traversal (NamespaceTreeDiff referent reference termDiff typeDiff) (NamespaceTreeDiff referent reference' termDiff typeDiff) reference reference'
+namespaceTreeDiffReferences_ :: (Ord reference', Ord typeDiff, Ord renderedType) => Traversal (NamespaceTreeDiff referent reference renderedTerm renderedType termDiff typeDiff) (NamespaceTreeDiff referent reference' renderedTerm renderedType termDiff typeDiff) reference reference'
 namespaceTreeDiffReferences_ = traversed . traversed . diffAtPathReferences_
 
-namespaceTreeDiffTermDiffs_ :: (Ord termDiff', Ord referent) => Traversal (NamespaceTreeDiff referent reference termDiff typeDiff) (NamespaceTreeDiff referent reference termDiff' typeDiff) termDiff termDiff'
+namespaceTreeDiffTermDiffs_ :: (Ord termDiff', Ord referent, Ord renderedTerm) => Traversal (NamespaceTreeDiff referent reference renderedTerm renderedType termDiff typeDiff) (NamespaceTreeDiff referent reference renderedTerm renderedType termDiff' typeDiff) termDiff termDiff'
 namespaceTreeDiffTermDiffs_ = traversed . traversed . diffAtPathTermDiffs_
 
-namespaceTreeDiffTypeDiffs_ :: (Ord typeDiff', Ord reference) => Traversal (NamespaceTreeDiff referent reference termDiff typeDiff) (NamespaceTreeDiff referent reference termDiff typeDiff') typeDiff typeDiff'
+namespaceTreeDiffTypeDiffs_ :: (Ord typeDiff', Ord reference, Ord renderedType) => Traversal (NamespaceTreeDiff referent reference renderedTerm renderedType termDiff typeDiff) (NamespaceTreeDiff referent reference renderedTerm renderedType termDiff typeDiff') typeDiff typeDiff'
 namespaceTreeDiffTypeDiffs_ = traversed . traversed . diffAtPathTypeDiffs_
 
 data NamespaceDiffError
@@ -235,7 +241,7 @@ instance Logging.Loggable NamespaceDiffError where
 
 -- | Compute the tree of differences between two namespace hashes.
 -- Note: This ignores all dependencies in the lib namespace.
-diffTreeNamespaces :: (BranchHashId, NameLookupReceipt) -> (BranchHashId, NameLookupReceipt) -> (PG.Transaction e (Either NamespaceDiffError (NamespaceTreeDiff V2.Referent V2.Reference Name Name)))
+diffTreeNamespaces :: (BranchHashId, NameLookupReceipt) -> (BranchHashId, NameLookupReceipt) -> (PG.Transaction e (Either NamespaceDiffError (NamespaceTreeDiff V2.Referent V2.Reference Name Name Name Name)))
 diffTreeNamespaces (oldBHId, oldNLReceipt) (newBHId, newNLReceipt) = do
   ((oldTerms, newTerms), (oldTypes, newTypes)) <- PG.pipelined do
     terms <- ND.getRelevantTermsForDiff oldNLReceipt oldBHId newBHId
@@ -256,7 +262,7 @@ diffTreeNamespacesHelper ::
   (Ord referent, Ord reference) =>
   (Relation Name referent, Relation Name referent) ->
   (Relation Name reference, Relation Name reference) ->
-  Either NamespaceDiffError (NamespaceTreeDiff referent reference Name Name)
+  Either NamespaceDiffError (NamespaceTreeDiff referent reference Name Name Name Name)
 diffTreeNamespacesHelper (oldTerms, newTerms) (oldTypes, newTypes) = do
   termTree <- computeDefinitionDiff oldTerms newTerms <&> definitionDiffsToTree
   typeTree <- computeDefinitionDiff oldTypes newTypes <&> definitionDiffsToTree
@@ -265,12 +271,12 @@ diffTreeNamespacesHelper (oldTerms, newTerms) (oldTypes, newTypes) = do
           & compressNameTree
   pure compressed
   where
-    combineTermsAndTypes :: These (Map NameSegment (Set (DefinitionDiff referent Name))) (Map NameSegment (Set (DefinitionDiff reference Name))) -> Map NameSegment (DiffAtPath referent reference Name Name)
+    combineTermsAndTypes :: These (Map NameSegment (Set (DefinitionDiff referent Name Name))) (Map NameSegment (Set (DefinitionDiff reference Name Name))) -> Map NameSegment (DiffAtPath referent reference Name Name Name Name)
     combineTermsAndTypes = \case
       This termsMap -> termsMap <&> \termDiffsAtPath -> DiffAtPath {termDiffsAtPath, typeDiffsAtPath = mempty}
       That typesMap -> typesMap <&> \typeDiffsAtPath -> DiffAtPath {typeDiffsAtPath, termDiffsAtPath = mempty}
       These trms typs -> alignWith combineNode trms typs
-    combineNode :: These (Set (DefinitionDiff referent Name)) (Set (DefinitionDiff reference Name)) -> DiffAtPath referent reference Name Name
+    combineNode :: These (Set (DefinitionDiff referent Name Name)) (Set (DefinitionDiff reference Name Name)) -> DiffAtPath referent reference Name Name Name Name
     combineNode = \case
       This termDiffsAtPath -> DiffAtPath {termDiffsAtPath, typeDiffsAtPath = mempty}
       That typeDiffsAtPath -> DiffAtPath {typeDiffsAtPath, termDiffsAtPath = mempty}
@@ -395,21 +401,21 @@ computeDefinitionDiff old new =
       )
 
 -- | Convert a `DefinitionDiffs` into a tree of differences.
-definitionDiffsToTree :: forall ref. (Ord ref) => DefinitionDiffs Name ref -> Cofree (Map NameSegment) (Map NameSegment (Set (DefinitionDiff ref Name)))
+definitionDiffsToTree :: forall ref. (Ord ref) => DefinitionDiffs Name ref -> Cofree (Map NameSegment) (Map NameSegment (Set (DefinitionDiff ref Name Name)))
 definitionDiffsToTree dd =
   let DefinitionDiffs {added, removed, updated, renamed, newAliases} = dd
-      expandedAliases :: Map Name (Set (DefinitionDiffKind ref Name))
+      expandedAliases :: Map Name (Set (DefinitionDiffKind ref Name Name))
       expandedAliases =
         newAliases
           & Map.toList
           & foldMap
             ( \(r, (existingNames, newNames)) ->
                 ( Foldable.toList newNames
-                    <&> \newName -> Map.singleton newName (Set.singleton (NewAlias r existingNames))
+                    <&> \newName -> Map.singleton newName (Set.singleton (NewAlias r existingNames newName))
                 )
             )
           & Map.unionsWith (<>)
-      expandedRenames :: Map Name (Set (DefinitionDiffKind ref Name))
+      expandedRenames :: Map Name (Set (DefinitionDiffKind ref Name Name))
       expandedRenames =
         renamed
           & Map.toList
@@ -421,21 +427,21 @@ definitionDiffsToTree dd =
               --   )
               -- <>
               ( Foldable.toList newNames
-                  <&> \newName -> Map.singleton newName (Set.singleton (RenamedFrom r oldNames))
+                  <&> \newName -> Map.singleton newName (Set.singleton (RenamedFrom r oldNames newName))
               )
             )
               & Map.unionsWith (<>)
-      diffTree :: Map Name (Set (DefinitionDiffKind ref Name))
+      diffTree :: Map Name (Set (DefinitionDiffKind ref Name Name))
       diffTree =
         Map.unionsWith
           (<>)
-          [ (added <&> Set.singleton . Added),
+          [ (added & Map.mapWithKey \n r -> Set.singleton $ Added r n),
             expandedAliases,
-            (removed <&> Set.singleton . Removed),
+            (removed & Map.mapWithKey \n r -> Set.singleton $ Removed r n),
             (updated & Map.mapWithKey \name (oldR, newR) -> Set.singleton $ Updated oldR newR name),
             expandedRenames
           ]
-      includeFQNs :: Map Name (Set (DefinitionDiffKind ref Name)) -> Map Name (Set (DefinitionDiff ref Name))
+      includeFQNs :: Map Name (Set (DefinitionDiffKind ref Name Name)) -> Map Name (Set (DefinitionDiff ref Name Name))
       includeFQNs m = m & imap \n ds -> (ds & Set.map \d -> DefinitionDiff {kind = d, fqn = n})
    in diffTree
         & includeFQNs

--- a/src/Share/Postgres/Projects/Queries.hs
+++ b/src/Share/Postgres/Projects/Queries.hs
@@ -10,7 +10,7 @@ module Share.Postgres.Projects.Queries
 where
 
 import Control.Lens
-import Control.Monad.Except (MonadError (..), runExceptT)
+import Control.Monad.Except (runExceptT)
 import Share.IDs
 import Share.Postgres
 import Share.Prelude

--- a/src/Share/Prelude.hs
+++ b/src/Share/Prelude.hs
@@ -47,6 +47,7 @@ module Share.Prelude
     MaybeT (..),
     hoistMaybe,
     traverseFirst,
+    throwError,
   )
 where
 
@@ -54,6 +55,7 @@ import Control.Applicative as X
 import Control.Arrow ((&&&))
 import Control.Category hiding (id, (.))
 import Control.Monad as X
+import Control.Monad.Except (throwError)
 import Control.Monad.Reader as X
 import Control.Monad.State as X
 import Control.Monad.Trans.Maybe

--- a/src/Share/Prelude.hs
+++ b/src/Share/Prelude.hs
@@ -46,6 +46,7 @@ module Share.Prelude
     Exception (..),
     MaybeT (..),
     hoistMaybe,
+    traverseFirst,
   )
 where
 
@@ -209,3 +210,6 @@ partitionMap f xs =
 
 unifyEither :: Either a a -> a
 unifyEither = either id id
+
+traverseFirst :: (Bitraversable t, Applicative f) => (a -> f b) -> t a x -> f (t b x)
+traverseFirst f = bitraverse f pure

--- a/src/Share/Utils/Caching.hs
+++ b/src/Share/Utils/Caching.hs
@@ -12,6 +12,10 @@ module Share.Utils.Caching
   )
 where
 
+import Data.Aeson (FromJSON, ToJSON (..))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Encoding qualified as Aeson
+import Data.Binary.Builder qualified as Builder
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy.Char8 qualified as BL
 import Data.Text.Encoding qualified as Text
@@ -30,6 +34,11 @@ data Cached ct a
 instance MimeRender JSON (Cached JSON a) where
   mimeRender _proxy = \case
     Cached bs -> BL.fromStrict bs
+
+instance (FromJSON a, ToJSON a) => ToJSON (Cached JSON a) where
+  toJSON (Cached bs) = toJSON $ Aeson.decode @a $ BL.fromStrict bs
+
+  toEncoding (Cached bs) = Aeson.unsafeToEncoding $ Builder.fromLazyByteString $ BL.fromStrict bs
 
 -- | Wrap a response in caching.
 -- This combinator knows whether a given access is privileged or not and will _not_ cache

--- a/src/Share/Utils/Logging.hs
+++ b/src/Share/Utils/Logging.hs
@@ -37,6 +37,7 @@ module Share.Utils.Logging
   )
 where
 
+import Control.Monad.Except (ExceptT)
 import Control.Monad.Reader
 import Data.Char qualified as Char
 import Data.Map qualified as Map
@@ -115,6 +116,12 @@ class (Monad m) => MonadLogger m where
   logMsg :: LogMsg -> m ()
 
 instance (MonadLogger m) => MonadLogger (ReaderT r m) where
+  logMsg = lift . logMsg
+
+instance (MonadLogger m) => MonadLogger (ExceptT e m) where
+  logMsg = lift . logMsg
+
+instance (MonadLogger m) => MonadLogger (MaybeT m) where
   logMsg = lift . logMsg
 
 textLog :: Text -> LogMsg

--- a/src/Share/Web/Errors.hs
+++ b/src/Share/Web/Errors.hs
@@ -68,7 +68,7 @@ import Unison.Sync.Types qualified as Sync
 import UnliftIO qualified
 
 newtype ErrorID = ErrorID Text
-  deriving stock (Show)
+  deriving stock (Show, Eq, Ord)
   deriving (IsString) via Text
 
 class ToServerError e where
@@ -208,7 +208,7 @@ instance ToServerError (InternalServerError a) where
   toServerError InternalServerError {errorId} = (ErrorID errorId, internalServerError)
 
 data EntityMissing = EntityMissing {entityMissingErrorID :: ErrorID, errorMsg :: Text}
-  deriving stock (Show)
+  deriving stock (Show, Eq, Ord)
 
 instance Loggable EntityMissing where
   toLog EntityMissing {errorMsg} = withSeverity UserFault $ textLog errorMsg

--- a/src/Share/Web/Errors.hs
+++ b/src/Share/Web/Errors.hs
@@ -7,6 +7,7 @@
 
 module Share.Web.Errors
   ( respondError,
+    respondExceptT,
     reportError,
     ToServerError (..),
     SimpleServerError (..),
@@ -165,6 +166,9 @@ respondError e = do
   let (_, serverErr) = toServerError e
   reportError e
   UnliftIO.throwIO serverErr
+
+respondExceptT :: (HasCallStack, ToServerError e, Loggable e) => ExceptT e WebApp a -> WebApp a
+respondExceptT m = runExceptT m >>= either respondError pure
 
 -- | Logs the error with a call stack, but doesn't abort the request or render an error to the client.
 reportError :: (HasCallStack, ToServerError e, Loggable e) => e -> WebApp ()

--- a/src/Share/Web/Share/Comments/Impl.hs
+++ b/src/Share/Web/Share/Comments/Impl.hs
@@ -21,7 +21,6 @@ import Share.Web.Errors
 import Share.Web.Share.Comments
 import Share.Web.Share.Comments.Types
 import Share.Web.Share.Types
-import Servant
 
 createCommentEndpoint ::
   Maybe Session ->

--- a/src/Share/Web/Share/Contributions/Impl.hs
+++ b/src/Share/Web/Share/Contributions/Impl.hs
@@ -13,7 +13,7 @@ module Share.Web.Share.Contributions.Impl
   )
 where
 
-import Control.Lens
+import Control.Lens hiding ((.=))
 import Servant
 import Servant.Server.Generic (AsServerT)
 import Share.Branch (Branch (..))

--- a/src/Share/Web/Share/Contributions/Impl.hs
+++ b/src/Share/Web/Share/Contributions/Impl.hs
@@ -276,7 +276,7 @@ contributionDiffEndpoint (AuthN.MaybeAuthedUserID mayCallerUserId) userHandle pr
   let oldCausalId = fromMaybe oldBranchCausalId bestCommonAncestorCausalId
   let cacheKeys = [IDs.toText contributionId, IDs.toText newPBSH, IDs.toText oldPBSH, Caching.causalIdCacheKey newBranchCausalId, Caching.causalIdCacheKey oldCausalId]
   Caching.cachedResponse authZReceipt "contribution-diff" cacheKeys do
-    namespaceDiff <- Diffs.diffCausals authZReceipt (oldCodebase, oldCausalId) (newCodebase, newBranchCausalId)
+    namespaceDiff <- respondExceptT (Diffs.diffCausals authZReceipt (oldCodebase, oldCausalId) (newCodebase, newBranchCausalId))
     (newBranchCausalHash, oldCausalHash) <- PG.runTransaction $ do
       newBranchCausalHash <- CausalQ.expectCausalHashesByIdsOf id newBranchCausalId
       oldCausalHash <- CausalQ.expectCausalHashesByIdsOf id oldCausalId
@@ -324,7 +324,7 @@ contributionDiffTermsEndpoint (AuthN.MaybeAuthedUserID mayCallerUserId) userHand
     let cacheKeys = [IDs.toText contributionId, IDs.toText newPBSH, IDs.toText oldPBSH, Caching.causalIdCacheKey newBranchCausalId, Caching.causalIdCacheKey oldCausalId, Name.toText oldTermName, Name.toText newTermName]
     Caching.cachedResponse authZReceipt "contribution-diff-terms" cacheKeys do
       (oldBranchHashId, newBranchHashId) <- PG.runTransaction $ CausalQ.expectNamespaceIdsByCausalIdsOf both (oldCausalId, newBranchCausalId)
-      termDiff <- Diffs.diffTerms authZReceipt (oldCodebase, oldBranchHashId, oldTermName) (newCodebase, newBranchHashId, newTermName)
+      termDiff <- respondExceptT (Diffs.diffTerms authZReceipt (oldCodebase, oldBranchHashId, oldTermName) (newCodebase, newBranchHashId, newTermName))
       pure $
         ShareTermDiffResponse
           { project = projectShorthand,
@@ -369,7 +369,7 @@ contributionDiffTypesEndpoint (AuthN.MaybeAuthedUserID mayCallerUserId) userHand
     let cacheKeys = [IDs.toText contributionId, IDs.toText newPBSH, IDs.toText oldPBSH, Caching.causalIdCacheKey newBranchCausalId, Caching.causalIdCacheKey oldCausalId, Name.toText oldTypeName, Name.toText newTypeName]
     Caching.cachedResponse authZReceipt "contribution-diff-types" cacheKeys do
       (oldBranchHashId, newBranchHashId) <- PG.runTransaction $ CausalQ.expectNamespaceIdsByCausalIdsOf both (oldCausalId, newBranchCausalId)
-      typeDiff <- Diffs.diffTypes authZReceipt (oldCodebase, oldBranchHashId, oldTypeName) (newCodebase, newBranchHashId, newTypeName)
+      typeDiff <- respondExceptT (Diffs.diffTypes authZReceipt (oldCodebase, oldBranchHashId, oldTypeName) (newCodebase, newBranchHashId, newTypeName))
       pure $
         ShareTypeDiffResponse
           { project = projectShorthand,

--- a/src/Share/Web/Share/Contributions/MergeDetection.hs
+++ b/src/Share/Web/Share/Contributions/MergeDetection.hs
@@ -3,6 +3,7 @@ module Share.Web.Share.Contributions.MergeDetection
   )
 where
 
+import Share.BackgroundJobs.Diffs.Queries qualified as DiffsQ
 import Share.IDs
 import Share.Postgres qualified as PG
 import Share.Postgres.Contributions.Queries qualified as ContributionQ
@@ -13,4 +14,5 @@ updateContributionsFromBranchUpdate :: UserId -> BranchId -> PG.Transaction e ()
 updateContributionsFromBranchUpdate callerUserId branchId = do
   updatedContributions <- ContributionQ.performMergesAndBCAUpdatesFromBranchPush callerUserId branchId
   _rebasedContributions <- ContributionQ.rebaseContributionsFromMergedBranches updatedContributions
+  DiffsQ.submitContributionsToBeDiffed updatedContributions
   pure ()

--- a/src/Share/Web/Share/Diffs/Types.hs
+++ b/src/Share/Web/Share/Diffs/Types.hs
@@ -2,17 +2,12 @@
 
 module Share.Web.Share.Diffs.Types where
 
-import Control.Comonad.Cofree qualified as Cofree
 import Data.Aeson
-import Data.Foldable qualified as Foldable
-import Data.Map qualified as Map
 import Share.IDs
-import Share.NamespaceDiffs (DefinitionDiff (..), DefinitionDiffKind (..), DiffAtPath (..), NamespaceTreeDiff)
+import Share.NamespaceDiffs (NamespaceTreeDiff)
 import Share.Postgres.IDs (CausalHash)
 import Share.Prelude
-import Share.Utils.Aeson (MaybeEncoded)
-import Unison.Name (Name)
-import Unison.NameSegment (NameSegment)
+import Share.Utils.Aeson (PreEncoded)
 import Unison.Server.Types (DisplayObjectDiff (..), TermDefinition, TermDefinitionDiff (..), TermTag, TypeDefinition, TypeDefinitionDiff (..), TypeTag)
 import Unison.ShortHash (ShortHash)
 
@@ -24,13 +19,13 @@ data ShareNamespaceDiffResponse = ShareNamespaceDiffResponse
     oldRefHash :: Maybe (PrefixedHash "#" CausalHash),
     newRef :: BranchOrReleaseShortHand,
     newRefHash :: Maybe (PrefixedHash "#" CausalHash),
-    diff :: MaybeEncoded ShareNamespaceDiff
+    diff :: PreEncoded ShareNamespaceDiff
   }
 
 instance ToJSON ShareNamespaceDiffResponse where
   toJSON (ShareNamespaceDiffResponse {diff, project, oldRef, newRef, oldRefHash, newRefHash}) =
     object
-      [ "diff" .= (namespaceTreeDiffJSON <$> diff),
+      [ "diff" .= diff,
         "project" .= project,
         "oldRef" .= oldRef,
         "oldRefHash" .= oldRefHash,
@@ -38,70 +33,6 @@ instance ToJSON ShareNamespaceDiffResponse where
         "newRefHash" .= newRefHash
       ]
     where
-      text :: Text -> Text
-      text t = t
-      hqNameJSON :: Name -> NameSegment -> ShortHash -> Value
-      hqNameJSON fqn name sh = object ["hash" .= sh, "shortName" .= name, "fullName" .= fqn]
-      -- The preferred frontend format is a bit clunky to calculate here:
-      diffDataJSON :: (ToJSON tag) => NameSegment -> DefinitionDiff (tag, ShortHash) Value -> (tag, Value)
-      diffDataJSON shortName (DefinitionDiff {fqn, kind}) = case kind of
-        Added (defnTag, r) -> (defnTag, object ["tag" .= text "Added", "contents" .= hqNameJSON fqn shortName r])
-        NewAlias (defnTag, r) existingNames ->
-          let contents = object ["hash" .= r, "aliasShortName" .= shortName, "aliasFullName" .= fqn, "otherNames" .= toList existingNames]
-           in (defnTag, object ["tag" .= text "Aliased", "contents" .= contents])
-        Removed (defnTag, r) -> (defnTag, object ["tag" .= text "Removed", "contents" .= hqNameJSON fqn shortName r])
-        Updated (oldTag, oldRef) (newTag, newRef) diffVal ->
-          let contents = object ["oldHash" .= oldRef, "newHash" .= newRef, "shortName" .= shortName, "fullName" .= fqn, "oldTag" .= oldTag, "newTag" .= newTag, "diff" .= diffVal]
-           in (newTag, object ["tag" .= text "Updated", "contents" .= contents])
-        RenamedTo (defnTag, r) newNames ->
-          let contents = object ["oldShortName" .= shortName, "oldFullName" .= fqn, "newNames" .= newNames, "hash" .= r]
-           in (defnTag, object ["tag" .= text "RenamedTo", "contents" .= contents])
-        RenamedFrom (defnTag, r) oldNames ->
-          let contents = object ["oldNames" .= oldNames, "newShortName" .= shortName, "newFullName" .= fqn, "hash" .= r]
-           in (defnTag, object ["tag" .= text "RenamedFrom", "contents" .= contents])
-
-      displayObjectDiffToJSON :: DisplayObjectDiff -> Value
-      displayObjectDiffToJSON = \case
-        DisplayObjectDiff dispDiff ->
-          object ["diff" .= dispDiff, "diffKind" .= ("diff" :: Text)]
-        MismatchedDisplayObjects {} ->
-          object ["diffKind" .= ("mismatched" :: Text)]
-
-      termDefinitionDiffToJSON :: TermDefinitionDiff -> Value
-      termDefinitionDiffToJSON (TermDefinitionDiff {left, right, diff}) = object ["left" .= left, "right" .= right, "diff" .= displayObjectDiffToJSON diff]
-
-      typeDefinitionDiffToJSON :: TypeDefinitionDiff -> Value
-      typeDefinitionDiffToJSON (TypeDefinitionDiff {left, right, diff}) = object ["left" .= left, "right" .= right, "diff" .= displayObjectDiffToJSON diff]
-      namespaceTreeDiffJSON :: NamespaceTreeDiff (TermTag, ShortHash) (TypeTag, ShortHash) TermDefinitionDiff TypeDefinitionDiff -> Value
-      namespaceTreeDiffJSON (diffs Cofree.:< children) =
-        let changesJSON =
-              diffs
-                & Map.toList
-                & foldMap
-                  ( \(name, DiffAtPath {termDiffsAtPath, typeDiffsAtPath}) ->
-                      ( Foldable.toList termDiffsAtPath
-                          <&> fmap termDefinitionDiffToJSON
-                          & fmap (diffDataJSON name)
-                          & fmap (\(tag, dJSON) -> object ["tag" .= tag, "contents" .= dJSON])
-                      )
-                        <> ( Foldable.toList typeDiffsAtPath
-                               <&> fmap typeDefinitionDiffToJSON
-                               & fmap (diffDataJSON name)
-                               & fmap (\(tag, dJSON) -> object ["tag" .= tag, "contents" .= dJSON])
-                           )
-                  )
-                & toJSON @([Value])
-            childrenJSON =
-              children
-                & Map.toList
-                & fmap
-                  ( \(path, childNode) ->
-                      object ["path" .= path, "contents" .= namespaceTreeDiffJSON childNode]
-                  )
-         in object
-              [ "changes" .= changesJSON,
-                "children" .= childrenJSON
-              ]
 
 data ShareTermDiffResponse = ShareTermDiffResponse
   { project :: ProjectShortHand,

--- a/src/Share/Web/Share/Diffs/Types.hs
+++ b/src/Share/Web/Share/Diffs/Types.hs
@@ -11,7 +11,7 @@ import Share.Utils.Aeson (PreEncoded)
 import Unison.Server.Types (DisplayObjectDiff (..), TermDefinition, TermDefinitionDiff (..), TermTag, TypeDefinition, TypeDefinitionDiff (..), TypeTag)
 import Unison.ShortHash (ShortHash)
 
-type ShareNamespaceDiff = NamespaceTreeDiff (TermTag, ShortHash) (TypeTag, ShortHash) TermDefinitionDiff TypeDefinitionDiff
+type ShareNamespaceDiff = NamespaceTreeDiff (TermTag, ShortHash) (TypeTag, ShortHash) TermDefinition TypeDefinition TermDefinitionDiff TypeDefinitionDiff
 
 data ShareNamespaceDiffResponse = ShareNamespaceDiffResponse
   { project :: ProjectShortHand,

--- a/src/Share/Web/Share/Diffs/Types.hs
+++ b/src/Share/Web/Share/Diffs/Types.hs
@@ -10,6 +10,7 @@ import Share.IDs
 import Share.NamespaceDiffs (DefinitionDiff (..), DefinitionDiffKind (..), DiffAtPath (..), NamespaceTreeDiff)
 import Share.Postgres.IDs (CausalHash)
 import Share.Prelude
+import Share.Utils.Aeson (MaybeEncoded)
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
 import Unison.Server.Types (DisplayObjectDiff (..), TermDefinition, TermDefinitionDiff (..), TermTag, TypeDefinition, TypeDefinitionDiff (..), TypeTag)
@@ -23,13 +24,13 @@ data ShareNamespaceDiffResponse = ShareNamespaceDiffResponse
     oldRefHash :: Maybe (PrefixedHash "#" CausalHash),
     newRef :: BranchOrReleaseShortHand,
     newRefHash :: Maybe (PrefixedHash "#" CausalHash),
-    diff :: ShareNamespaceDiff
+    diff :: MaybeEncoded ShareNamespaceDiff
   }
 
 instance ToJSON ShareNamespaceDiffResponse where
   toJSON (ShareNamespaceDiffResponse {diff, project, oldRef, newRef, oldRefHash, newRefHash}) =
     object
-      [ "diff" .= namespaceTreeDiffJSON diff,
+      [ "diff" .= (namespaceTreeDiffJSON <$> diff),
         "project" .= project,
         "oldRef" .= oldRef,
         "oldRefHash" .= oldRefHash,

--- a/src/Share/Web/Share/Projects/Impl.hs
+++ b/src/Share/Web/Share/Projects/Impl.hs
@@ -162,7 +162,7 @@ diffNamespacesEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle project
       ancestorCausalId <- fromMaybe oldCausalId <$> CausalQ.bestCommonAncestor oldCausalId newCausalId
       (ancestorCausalHash, newCausalHash) <- CausalQ.expectCausalHashesByIdsOf both (ancestorCausalId, newCausalId)
       pure (ancestorCausalId, ancestorCausalHash, newCausalHash)
-    namespaceDiff <- Diffs.diffCausals authZReceipt (oldCodebase, ancestorCausalId) (newCodebase, newCausalId)
+    namespaceDiff <- respondExceptT (Diffs.diffCausals authZReceipt (oldCodebase, ancestorCausalId) (newCodebase, newCausalId))
     pure $
       ShareNamespaceDiffResponse
         { project = projectShortHand,
@@ -195,7 +195,7 @@ projectDiffTermsEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle proje
 
     let cacheKeys = [IDs.toText projectId, IDs.toText oldShortHand, IDs.toText newShortHand, Caching.branchIdCacheKey oldBhId, Caching.branchIdCacheKey newBhId, Name.toText oldTermName, Name.toText newTermName]
     Caching.cachedResponse authZReceipt "project-diff-terms" cacheKeys do
-      termDiff <- Diffs.diffTerms authZReceipt (oldCodebase, oldBhId, oldTermName) (newCodebase, newBhId, newTermName)
+      termDiff <- respondExceptT (Diffs.diffTerms authZReceipt (oldCodebase, oldBhId, oldTermName) (newCodebase, newBhId, newTermName))
       pure $
         ShareTermDiffResponse
           { project = projectShortHand,
@@ -229,7 +229,7 @@ projectDiffTypesEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle proje
 
     let cacheKeys = [IDs.toText projectId, IDs.toText oldShortHand, IDs.toText newShortHand, Caching.branchIdCacheKey oldBhId, Caching.branchIdCacheKey newBhId, Name.toText oldTypeName, Name.toText newTypeName]
     Caching.cachedResponse authZReceipt "project-diff-types" cacheKeys do
-      typeDiff <- Diffs.diffTypes authZReceipt (oldCodebase, oldBhId, oldTypeName) (newCodebase, newBhId, newTypeName)
+      typeDiff <- respondExceptT (Diffs.diffTypes authZReceipt (oldCodebase, oldBhId, oldTypeName) (newCodebase, newBhId, newTypeName))
       pure $
         ShareTypeDiffResponse
           { project = projectShortHand,

--- a/transcripts/share-apis/contribution-diffs/contribution-diff.json
+++ b/transcripts/share-apis/contribution-diffs/contribution-diff.json
@@ -10,7 +10,51 @@
               "hash": "#bbsbe7lolqunqrftm9jeg299caa91r2mlviqic54toilse443ljup5eojm1et3lqv6ni5gsu9l9hpldptga3cp5e0qffhg36gv5u2jo",
               "otherNames": [
                 "DataAliasMe"
-              ]
+              ],
+              "rendered": {
+                "bestTypeName": "ATypeAlias",
+                "defnTypeTag": "Data",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "type"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "ATypeAlias",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "ATypeAlias"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": " = "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#bbsbe7lolqunqrftm9jeg299caa91r2mlviqic54toilse443ljup5eojm1et3lqv6ni5gsu9l9hpldptga3cp5e0qffhg36gv5u2jo#d0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "B"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "ATypeAlias",
+                  "DataAliasMe"
+                ]
+              }
             },
             "tag": "Aliased"
           },
@@ -24,7 +68,95 @@
               "hash": "#qfgn5crplnhh308pepplqtleojiqhlpveimv0htug2mqbvhnia7qjfcravqlfb8ooos56jo5qq6brr99gg5kj0g5bgllvgn1nesv608",
               "otherNames": [
                 "AbilityAliasMe"
-              ]
+              ],
+              "rendered": {
+                "bestTypeName": "AbilityAlias",
+                "defnTypeTag": "Ability",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "ability"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "AbilityAlias",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "AbilityAlias"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "ControlKeyword"
+                      },
+                      "segment": " where"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#qfgn5crplnhh308pepplqtleojiqhlpveimv0htug2mqbvhnia7qjfcravqlfb8ooos56jo5qq6brr99gg5kj0g5bgllvgn1nesv608#a0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "abilityAliasMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "{"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#qfgn5crplnhh308pepplqtleojiqhlpveimv0htug2mqbvhnia7qjfcravqlfb8ooos56jo5qq6brr99gg5kj0g5bgllvgn1nesv608",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "AbilityAlias"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "}"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "AbilityAlias",
+                  "AbilityAliasMe"
+                ]
+              }
             },
             "tag": "Aliased"
           },
@@ -35,6 +167,93 @@
             "contents": {
               "fullName": "AbilityDeleteMe",
               "hash": "#val3i3ikhjc998qh1lfefhh08ad77f1eshera5d0hnbrp6qpgmfelbfa96pvsc18d5qd5qm7lij5el0raipb3mbjgalkh7g3aujej1o",
+              "rendered": {
+                "bestTypeName": "AbilityDeleteMe",
+                "defnTypeTag": "Ability",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "ability"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "AbilityDeleteMe",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "AbilityDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "ControlKeyword"
+                      },
+                      "segment": " where"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#val3i3ikhjc998qh1lfefhh08ad77f1eshera5d0hnbrp6qpgmfelbfa96pvsc18d5qd5qm7lij5el0raipb3mbjgalkh7g3aujej1o#a0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "abilityDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "{"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#val3i3ikhjc998qh1lfefhh08ad77f1eshera5d0hnbrp6qpgmfelbfa96pvsc18d5qd5qm7lij5el0raipb3mbjgalkh7g3aujej1o",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "AbilityDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "}"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "AbilityDeleteMe"
+                ]
+              },
               "shortName": "AbilityDeleteMe"
             },
             "tag": "Removed"
@@ -46,6 +265,93 @@
             "contents": {
               "fullName": "AbilityNew",
               "hash": "#t66tvdfo0l4pqj6hgav05tqifbuld8dc22g4rom3olfqj7b6cfpvf15j7307j8m2fpdsvcgv4ourrltpjutgpu3bh08efu2jl2nfqq0",
+              "rendered": {
+                "bestTypeName": "AbilityNew",
+                "defnTypeTag": "Ability",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "ability"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "AbilityNew",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "AbilityNew"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "ControlKeyword"
+                      },
+                      "segment": " where"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#t66tvdfo0l4pqj6hgav05tqifbuld8dc22g4rom3olfqj7b6cfpvf15j7307j8m2fpdsvcgv4ourrltpjutgpu3bh08efu2jl2nfqq0#a0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "abilityNew"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "{"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#t66tvdfo0l4pqj6hgav05tqifbuld8dc22g4rom3olfqj7b6cfpvf15j7307j8m2fpdsvcgv4ourrltpjutgpu3bh08efu2jl2nfqq0",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "AbilityNew"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "}"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Text",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Text"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "AbilityNew"
+                ]
+              },
               "shortName": "AbilityNew"
             },
             "tag": "Added"
@@ -60,7 +366,94 @@
               "newShortName": "AbilityRenamed",
               "oldNames": [
                 "AbilityRenameMe"
-              ]
+              ],
+              "rendered": {
+                "bestTypeName": "AbilityRenamed",
+                "defnTypeTag": "Ability",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "ability"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "AbilityRenamed",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "AbilityRenamed"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "ControlKeyword"
+                      },
+                      "segment": " where"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#iqmiiehu802p15ssntohl6l5kedd0j266rh7815s1t10rfe2bp207vh8ccngrlkii7i32h1n080dggr3r89osrq450kv6dj5uuc0o0o#a0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "abilityRenameMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "{"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#iqmiiehu802p15ssntohl6l5kedd0j266rh7815s1t10rfe2bp207vh8ccngrlkii7i32h1n080dggr3r89osrq450kv6dj5uuc0o0o",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "AbilityRenamed"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "}"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "AbilityRenamed"
+                ]
+              }
             },
             "tag": "RenamedFrom"
           },
@@ -69,6 +462,306 @@
         {
           "contents": {
             "contents": {
+              "diff": {
+                "diff": {
+                  "diff": {
+                    "contents": [
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "DataTypeKeyword"
+                            },
+                            "segment": "ability"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "contents": "AbilityUpdateMe",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "AbilityUpdateMe"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "ControlKeyword"
+                            },
+                            "segment": " where"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "annotationChange",
+                        "fromAnnotation": {
+                          "contents": "#0d5ej3mann48uffjea4epi8ss486689gsj46cscorhs3d4j7ohvj9t7ghg05tra792umcmgjr6lgqkskoo3odge7jm2ci91dlmpefcg#a0",
+                          "tag": "TermReference"
+                        },
+                        "segment": "abilityUpdateMe",
+                        "toAnnotation": {
+                          "contents": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18#a0",
+                          "tag": "TermReference"
+                        }
+                      },
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "TypeAscriptionColon"
+                            },
+                            "segment": " :"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "tag": "AbilityBraces"
+                            },
+                            "segment": "{"
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "annotationChange",
+                        "fromAnnotation": {
+                          "contents": "#0d5ej3mann48uffjea4epi8ss486689gsj46cscorhs3d4j7ohvj9t7ghg05tra792umcmgjr6lgqkskoo3odge7jm2ci91dlmpefcg",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "AbilityUpdateMe",
+                        "toAnnotation": {
+                          "contents": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18",
+                          "tag": "TypeReference"
+                        }
+                      },
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "AbilityBraces"
+                            },
+                            "segment": "}"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "old",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "##Nat",
+                              "tag": "TypeReference"
+                            },
+                            "segment": "Nat"
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "new",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "##Text",
+                              "tag": "TypeReference"
+                            },
+                            "segment": "Text"
+                          }
+                        ]
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "diffKind": "diff"
+                },
+                "left": {
+                  "bestTypeName": "AbilityUpdateMe",
+                  "defnTypeTag": "Ability",
+                  "typeDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "tag": "DataTypeKeyword"
+                        },
+                        "segment": "ability"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "AbilityUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "AbilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "ControlKeyword"
+                        },
+                        "segment": " where"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#0d5ej3mann48uffjea4epi8ss486689gsj46cscorhs3d4j7ohvj9t7ghg05tra792umcmgjr6lgqkskoo3odge7jm2ci91dlmpefcg#a0",
+                          "tag": "TermReference"
+                        },
+                        "segment": "abilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "AbilityBraces"
+                        },
+                        "segment": "{"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#0d5ej3mann48uffjea4epi8ss486689gsj46cscorhs3d4j7ohvj9t7ghg05tra792umcmgjr6lgqkskoo3odge7jm2ci91dlmpefcg",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "AbilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "AbilityBraces"
+                        },
+                        "segment": "}"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Nat",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "Nat"
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "typeDocs": [],
+                  "typeNames": [
+                    "AbilityUpdateMe"
+                  ]
+                },
+                "right": {
+                  "bestTypeName": "AbilityUpdateMe",
+                  "defnTypeTag": "Ability",
+                  "typeDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "tag": "DataTypeKeyword"
+                        },
+                        "segment": "ability"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "AbilityUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "AbilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "ControlKeyword"
+                        },
+                        "segment": " where"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18#a0",
+                          "tag": "TermReference"
+                        },
+                        "segment": "abilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "AbilityBraces"
+                        },
+                        "segment": "{"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "AbilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "AbilityBraces"
+                        },
+                        "segment": "}"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Text",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "Text"
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "typeDocs": [],
+                  "typeNames": [
+                    "AbilityUpdateMe"
+                  ]
+                }
+              },
               "fullName": "AbilityUpdateMe",
               "newHash": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18",
               "newTag": "Ability",
@@ -85,6 +778,49 @@
             "contents": {
               "fullName": "DataDeleteMe",
               "hash": "#keu02n8is0irijd65cvuos41kukj3f4ni18mmnudrbll2epo6ftd03nt9l0vqc4fvg98198tefgoupco4o0d0gvnigqgr1bmo2neo88",
+              "rendered": {
+                "bestTypeName": "DataDeleteMe",
+                "defnTypeTag": "Data",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "type"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "DataDeleteMe",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "DataDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": " = "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#keu02n8is0irijd65cvuos41kukj3f4ni18mmnudrbll2epo6ftd03nt9l0vqc4fvg98198tefgoupco4o0d0gvnigqgr1bmo2neo88#d0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "C"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "DataDeleteMe"
+                ]
+              },
               "shortName": "DataDeleteMe"
             },
             "tag": "Removed"
@@ -94,6 +830,176 @@
         {
           "contents": {
             "contents": {
+              "diff": {
+                "diff": {
+                  "diff": {
+                    "contents": [
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "DataTypeKeyword"
+                            },
+                            "segment": "type"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "contents": "DataUpdateMe",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "DataUpdateMe"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "DelimiterChar"
+                            },
+                            "segment": " = "
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "old",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "#fhc8jn2bhvfdnfr89dv2jf7tekuesna7gvje4ck6lfheh9rb184q4ddd29vm9mvfm6u1a98kpgditn8vb09durtel67rpof1c62535o#d0",
+                              "tag": "TermReference"
+                            },
+                            "segment": "D"
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "new",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "#qnblpurkqedrq0kae95ep7b8f6uh5b7igefp21r1nvl22agjoup5e7aunua4q8ku8mb532fh3lst4mj3m2bsb3kluchc3fuau5cllr0#d0",
+                              "tag": "TermReference"
+                            },
+                            "segment": "D2"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "contents": "##Nat",
+                              "tag": "TypeReference"
+                            },
+                            "segment": "Nat"
+                          }
+                        ]
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "diffKind": "diff"
+                },
+                "left": {
+                  "bestTypeName": "DataUpdateMe",
+                  "defnTypeTag": "Data",
+                  "typeDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "tag": "DataTypeKeyword"
+                        },
+                        "segment": "type"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "DataUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "DataUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "DelimiterChar"
+                        },
+                        "segment": " = "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#fhc8jn2bhvfdnfr89dv2jf7tekuesna7gvje4ck6lfheh9rb184q4ddd29vm9mvfm6u1a98kpgditn8vb09durtel67rpof1c62535o#d0",
+                          "tag": "TermReference"
+                        },
+                        "segment": "D"
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "typeDocs": [],
+                  "typeNames": [
+                    "DataUpdateMe"
+                  ]
+                },
+                "right": {
+                  "bestTypeName": "DataUpdateMe",
+                  "defnTypeTag": "Data",
+                  "typeDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "tag": "DataTypeKeyword"
+                        },
+                        "segment": "type"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "DataUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "DataUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "DelimiterChar"
+                        },
+                        "segment": " = "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#qnblpurkqedrq0kae95ep7b8f6uh5b7igefp21r1nvl22agjoup5e7aunua4q8ku8mb532fh3lst4mj3m2bsb3kluchc3fuau5cllr0#d0",
+                          "tag": "TermReference"
+                        },
+                        "segment": "D2"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Nat",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "Nat"
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "typeDocs": [],
+                  "typeNames": [
+                    "DataUpdateMe"
+                  ]
+                }
+              },
               "fullName": "DataUpdateMe",
               "newHash": "#qnblpurkqedrq0kae95ep7b8f6uh5b7igefp21r1nvl22agjoup5e7aunua4q8ku8mb532fh3lst4mj3m2bsb3kluchc3fuau5cllr0",
               "newTag": "Data",
@@ -110,6 +1016,49 @@
             "contents": {
               "fullName": "NewType",
               "hash": "#sa4ptibggqmbifhfj37gj2lq487q5ucfuojjcblfaas9bunlthhkvhstsrj20fvlpqakb8e9mqds4p32lnh8ohmf1s5omvdhc23jibg",
+              "rendered": {
+                "bestTypeName": "NewType",
+                "defnTypeTag": "Data",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "type"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "NewType",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "NewType"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": " = "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#sa4ptibggqmbifhfj37gj2lq487q5ucfuojjcblfaas9bunlthhkvhstsrj20fvlpqakb8e9mqds4p32lnh8ohmf1s5omvdhc23jibg#d0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "X"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "NewType"
+                ]
+              },
               "shortName": "NewType"
             },
             "tag": "Added"
@@ -124,7 +1073,50 @@
               "newShortName": "RenamedType",
               "oldNames": [
                 "DataRenameMe"
-              ]
+              ],
+              "rendered": {
+                "bestTypeName": "RenamedType",
+                "defnTypeTag": "Data",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "type"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "RenamedType",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "RenamedType"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": " = "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#8s3lsrv3p6ngq2bqotvli1f0gfcf9uvci4trmia6dosl3d8vu6i6kubdi3ic7m22r34m4mkru3hatdbgihj0fngmj7gktlq41ncs1e0#d0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "E"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "RenamedType"
+                ]
+              }
             },
             "tag": "RenamedFrom"
           },
@@ -135,6 +1127,123 @@
             "contents": {
               "fullName": "aDoc",
               "hash": "#areni4s9liksvfs3923a4ub81qpu37f964fqhbq832artpff8vm1em45ic0k2hlkv4nn08u712ibvjo9b4fl5u19o65g9medo7645i8",
+              "rendered": {
+                "bestTermName": "aDoc",
+                "defnTermTag": "Doc",
+                "signature": [
+                  {
+                    "annotation": {
+                      "contents": "#ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Doc2"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "aDoc",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aDoc"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Doc2"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "aDoc",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aDoc"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DocDelimiter"
+                      },
+                      "segment": "{{"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "Test"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "Doc"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DocDelimiter"
+                      },
+                      "segment": "}}"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [
+                  [
+                    "aDoc",
+                    "#areni4s9liksvfs3923a4ub81qpu37f964fqhbq832artpff8vm1em45ic0k2hlkv4nn08u712ibvjo9b4fl5u19o65g9medo7645i8",
+                    {
+                      "contents": [
+                        {
+                          "contents": "Test",
+                          "tag": "Word"
+                        },
+                        {
+                          "contents": "Doc",
+                          "tag": "Word"
+                        }
+                      ],
+                      "tag": "Paragraph"
+                    }
+                  ]
+                ],
+                "termNames": [
+                  "aDoc"
+                ]
+              },
               "shortName": "aDoc"
             },
             "tag": "Removed"
@@ -149,7 +1258,81 @@
               "hash": "#gjmq673r1vrurfotlnirv7vutdhm6sa3s02em5g22kk606mv6duvv8be402dv79312i4a0onepq5bo7citsodvq2g720nttj0ee9p0g",
               "otherNames": [
                 "termAliasMe"
-              ]
+              ],
+              "rendered": {
+                "bestTermName": "aTermAlias",
+                "defnTermTag": "Plain",
+                "signature": [
+                  {
+                    "annotation": {
+                      "contents": "##Nat",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "aTermAlias",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aTermAlias"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "aTermAlias",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aTermAlias"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "NumericLiteral"
+                      },
+                      "segment": "1"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [],
+                "termNames": [
+                  "aTermAlias",
+                  "termAliasMe"
+                ]
+              }
             },
             "tag": "Aliased"
           },
@@ -160,6 +1343,128 @@
             "contents": {
               "fullName": "aTest",
               "hash": "#qak36j7cshv12m9meuc97ovllqm8k2i305sh4oq5dbo4834t7atugsdpto6mou1tch2b3q9j2hbi23gdf4jpth7m97mannv9noucgl8",
+              "rendered": {
+                "bestTermName": "aTest",
+                "defnTermTag": "Test",
+                "signature": [
+                  {
+                    "annotation": {
+                      "tag": "DelimiterChar"
+                    },
+                    "segment": "["
+                  },
+                  {
+                    "annotation": {
+                      "contents": "#aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Result"
+                  },
+                  {
+                    "annotation": {
+                      "tag": "DelimiterChar"
+                    },
+                    "segment": "]"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "aTest",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aTest"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": "["
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Result"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": "]"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "aTest",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aTest"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "["
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#d1",
+                        "tag": "TermReference"
+                      },
+                      "segment": "Ok"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TextLiteral"
+                      },
+                      "segment": "\"Done\""
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "]"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [],
+                "termNames": [
+                  "aTest"
+                ]
+              },
               "shortName": "aTest"
             },
             "tag": "Removed"
@@ -171,6 +1476,79 @@
             "contents": {
               "fullName": "newTerm",
               "hash": "#u1qsl3nk5t2svl58ifqepem851775qca9p4hc10j3iordu1v7u8e16oodui9kvt2c0j1cbc50avado53bl2vt3pphrfj9mhbut1ipm8",
+              "rendered": {
+                "bestTermName": "newTerm",
+                "defnTermTag": "Plain",
+                "signature": [
+                  {
+                    "annotation": {
+                      "contents": "##Nat",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "newTerm",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "newTerm"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "newTerm",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "newTerm"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "NumericLiteral"
+                      },
+                      "segment": "100"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [],
+                "termNames": [
+                  "newTerm"
+                ]
+              },
               "shortName": "newTerm"
             },
             "tag": "Added"
@@ -185,7 +1563,80 @@
               "newShortName": "renamedTerm",
               "oldNames": [
                 "termRenameMe"
-              ]
+              ],
+              "rendered": {
+                "bestTermName": "renamedTerm",
+                "defnTermTag": "Plain",
+                "signature": [
+                  {
+                    "annotation": {
+                      "contents": "##Nat",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "renamedTerm",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "renamedTerm"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "renamedTerm",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "renamedTerm"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "NumericLiteral"
+                      },
+                      "segment": "3"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [],
+                "termNames": [
+                  "renamedTerm"
+                ]
+              }
             },
             "tag": "RenamedFrom"
           },
@@ -196,6 +1647,79 @@
             "contents": {
               "fullName": "termDeleteMe",
               "hash": "#dcgdua2lj6upd1ah5v0qp09gjsej0d77d87fu6qn8e2qrssnlnmuinoio46hiu53magr7qn8vnqke8ndt0v76700o5u8gcvo7st28jg",
+              "rendered": {
+                "bestTermName": "termDeleteMe",
+                "defnTermTag": "Plain",
+                "signature": [
+                  {
+                    "annotation": {
+                      "contents": "##Nat",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "termDeleteMe",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "termDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "termDeleteMe",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "termDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "NumericLiteral"
+                      },
+                      "segment": "2"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [],
+                "termNames": [
+                  "termDeleteMe"
+                ]
+              },
               "shortName": "termDeleteMe"
             },
             "tag": "Removed"
@@ -205,6 +1729,234 @@
         {
           "contents": {
             "contents": {
+              "diff": {
+                "diff": {
+                  "diff": {
+                    "contents": [
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "termUpdateMe",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "termUpdateMe"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "TypeAscriptionColon"
+                            },
+                            "segment": " :"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "contents": "##Text",
+                              "tag": "TypeReference"
+                            },
+                            "segment": "Text"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": "\n"
+                          },
+                          {
+                            "annotation": {
+                              "contents": "termUpdateMe",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "termUpdateMe"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "BindingEquals"
+                            },
+                            "segment": " ="
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "old",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "TextLiteral"
+                            },
+                            "segment": "\"original\""
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "new",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "TextLiteral"
+                            },
+                            "segment": "\"updated\""
+                          }
+                        ]
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "diffKind": "diff"
+                },
+                "left": {
+                  "bestTermName": "termUpdateMe",
+                  "defnTermTag": "Plain",
+                  "signature": [
+                    {
+                      "annotation": {
+                        "contents": "##Text",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Text"
+                    }
+                  ],
+                  "termDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "contents": "termUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "termUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Text",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "Text"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "termUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "termUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TextLiteral"
+                        },
+                        "segment": "\"original\""
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "termDocs": [],
+                  "termNames": [
+                    "termUpdateMe"
+                  ]
+                },
+                "right": {
+                  "bestTermName": "termUpdateMe",
+                  "defnTermTag": "Plain",
+                  "signature": [
+                    {
+                      "annotation": {
+                        "contents": "##Text",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Text"
+                    }
+                  ],
+                  "termDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "contents": "termUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "termUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Text",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "Text"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "termUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "termUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TextLiteral"
+                        },
+                        "segment": "\"updated\""
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "termDocs": [],
+                  "termNames": [
+                    "termUpdateMe"
+                  ]
+                }
+              },
               "fullName": "termUpdateMe",
               "newHash": "#711u1t9cjso4t3rhlq2rp491n2n5n4t9o7701053kpj5ouu3kfs2e2l63i879pnsb6ob9fp0gpj18u6fpcl1qosd704h4doklfo734g",
               "newTag": "Plain",
@@ -220,222 +1972,6 @@
       "children": [
         {
           "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "aliasFullName": "ATypeAlias.B",
-                    "aliasShortName": "B",
-                    "hash": "#bbsbe7lolqunqrftm9jeg299caa91r2mlviqic54toilse443ljup5eojm1et3lqv6ni5gsu9l9hpldptga3cp5e0qffhg36gv5u2jo#0",
-                    "otherNames": [
-                      "DataAliasMe.B"
-                    ]
-                  },
-                  "tag": "Aliased"
-                },
-                "tag": "DataConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "ATypeAlias"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "aliasFullName": "AbilityAlias.abilityAliasMe",
-                    "aliasShortName": "abilityAliasMe",
-                    "hash": "#qfgn5crplnhh308pepplqtleojiqhlpveimv0htug2mqbvhnia7qjfcravqlfb8ooos56jo5qq6brr99gg5kj0g5bgllvgn1nesv608#0",
-                    "otherNames": [
-                      "AbilityAliasMe.abilityAliasMe"
-                    ]
-                  },
-                  "tag": "Aliased"
-                },
-                "tag": "AbilityConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "AbilityAlias"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "AbilityDeleteMe.abilityDeleteMe",
-                    "hash": "#val3i3ikhjc998qh1lfefhh08ad77f1eshera5d0hnbrp6qpgmfelbfa96pvsc18d5qd5qm7lij5el0raipb3mbjgalkh7g3aujej1o#0",
-                    "shortName": "abilityDeleteMe"
-                  },
-                  "tag": "Removed"
-                },
-                "tag": "AbilityConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "AbilityDeleteMe"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "AbilityNew.abilityNew",
-                    "hash": "#t66tvdfo0l4pqj6hgav05tqifbuld8dc22g4rom3olfqj7b6cfpvf15j7307j8m2fpdsvcgv4ourrltpjutgpu3bh08efu2jl2nfqq0#0",
-                    "shortName": "abilityNew"
-                  },
-                  "tag": "Added"
-                },
-                "tag": "AbilityConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "AbilityNew"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "hash": "#iqmiiehu802p15ssntohl6l5kedd0j266rh7815s1t10rfe2bp207vh8ccngrlkii7i32h1n080dggr3r89osrq450kv6dj5uuc0o0o#0",
-                    "newFullName": "AbilityRenamed.abilityRenameMe",
-                    "newShortName": "abilityRenameMe",
-                    "oldNames": [
-                      "AbilityRenameMe.abilityRenameMe"
-                    ]
-                  },
-                  "tag": "RenamedFrom"
-                },
-                "tag": "AbilityConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "AbilityRenamed"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "AbilityUpdateMe.abilityUpdateMe",
-                    "newHash": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18#0",
-                    "newTag": "AbilityConstructor",
-                    "oldHash": "#0d5ej3mann48uffjea4epi8ss486689gsj46cscorhs3d4j7ohvj9t7ghg05tra792umcmgjr6lgqkskoo3odge7jm2ci91dlmpefcg#0",
-                    "oldTag": "AbilityConstructor",
-                    "shortName": "abilityUpdateMe"
-                  },
-                  "tag": "Updated"
-                },
-                "tag": "AbilityConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "AbilityUpdateMe"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "DataDeleteMe.C",
-                    "hash": "#keu02n8is0irijd65cvuos41kukj3f4ni18mmnudrbll2epo6ftd03nt9l0vqc4fvg98198tefgoupco4o0d0gvnigqgr1bmo2neo88#0",
-                    "shortName": "C"
-                  },
-                  "tag": "Removed"
-                },
-                "tag": "DataConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "DataDeleteMe"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "DataUpdateMe.D",
-                    "hash": "#fhc8jn2bhvfdnfr89dv2jf7tekuesna7gvje4ck6lfheh9rb184q4ddd29vm9mvfm6u1a98kpgditn8vb09durtel67rpof1c62535o#0",
-                    "shortName": "D"
-                  },
-                  "tag": "Removed"
-                },
-                "tag": "DataConstructor"
-              },
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "DataUpdateMe.D2",
-                    "hash": "#qnblpurkqedrq0kae95ep7b8f6uh5b7igefp21r1nvl22agjoup5e7aunua4q8ku8mb532fh3lst4mj3m2bsb3kluchc3fuau5cllr0#0",
-                    "shortName": "D2"
-                  },
-                  "tag": "Added"
-                },
-                "tag": "DataConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "DataUpdateMe"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "NewType.X",
-                    "hash": "#sa4ptibggqmbifhfj37gj2lq487q5ucfuojjcblfaas9bunlthhkvhstsrj20fvlpqakb8e9mqds4p32lnh8ohmf1s5omvdhc23jibg#0",
-                    "shortName": "X"
-                  },
-                  "tag": "Added"
-                },
-                "tag": "DataConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "NewType"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "hash": "#8s3lsrv3p6ngq2bqotvli1f0gfcf9uvci4trmia6dosl3d8vu6i6kubdi3ic7m22r34m4mkru3hatdbgihj0fngmj7gktlq41ncs1e0#0",
-                    "newFullName": "RenamedType.E",
-                    "newShortName": "E",
-                    "oldNames": [
-                      "DataRenameMe.E"
-                    ]
-                  },
-                  "tag": "RenamedFrom"
-                },
-                "tag": "DataConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "RenamedType"
-        },
-        {
-          "contents": {
             "changes": [],
             "children": [
               {
@@ -446,6 +1982,79 @@
                         "contents": {
                           "fullName": "a.definition.at.path1",
                           "hash": "#r303avnmdmja3ch96otiglq37214t43acpr1ikq4hrp5hmcibstipa69frbd6177jvbn28ioc5ii80fc54ecogm4n64dhjvkonrihso",
+                          "rendered": {
+                            "bestTermName": "path1",
+                            "defnTermTag": "Plain",
+                            "signature": [
+                              {
+                                "annotation": {
+                                  "contents": "##Text",
+                                  "tag": "TypeReference"
+                                },
+                                "segment": "Text"
+                              }
+                            ],
+                            "termDefinition": {
+                              "contents": [
+                                {
+                                  "annotation": {
+                                    "contents": "a.definition.at.path1",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.definition.at.path1"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "##Text",
+                                    "tag": "TypeReference"
+                                  },
+                                  "segment": "Text"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": "\n"
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "a.definition.at.path1",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.definition.at.path1"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TextLiteral"
+                                  },
+                                  "segment": "\"definition at path\""
+                                }
+                              ],
+                              "tag": "UserObject"
+                            },
+                            "termDocs": [],
+                            "termNames": [
+                              "a.definition.at.path1"
+                            ]
+                          },
                           "shortName": "path1"
                         },
                         "tag": "Removed"
@@ -457,6 +2066,79 @@
                         "contents": {
                           "fullName": "a.definition.at.path2",
                           "hash": "#k43vb9rkd3n4i8g8bbfb31erufbmu6v1f99i587oqsje51thrm1ugdqa7gkjbdvkactuql3cmc00b7oev0glqb2rko48atkuo798mno",
+                          "rendered": {
+                            "bestTermName": "path2",
+                            "defnTermTag": "Plain",
+                            "signature": [
+                              {
+                                "annotation": {
+                                  "contents": "##Text",
+                                  "tag": "TypeReference"
+                                },
+                                "segment": "Text"
+                              }
+                            ],
+                            "termDefinition": {
+                              "contents": [
+                                {
+                                  "annotation": {
+                                    "contents": "a.definition.at.path2",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.definition.at.path2"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "##Text",
+                                    "tag": "TypeReference"
+                                  },
+                                  "segment": "Text"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": "\n"
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "a.definition.at.path2",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.definition.at.path2"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TextLiteral"
+                                  },
+                                  "segment": "\"definition at path2\""
+                                }
+                              ],
+                              "tag": "UserObject"
+                            },
+                            "termDocs": [],
+                            "termNames": [
+                              "a.definition.at.path2"
+                            ]
+                          },
                           "shortName": "path2"
                         },
                         "tag": "Removed"
@@ -476,6 +2158,79 @@
                         "contents": {
                           "fullName": "a.different.path",
                           "hash": "#83be375arg68mqk26bu12elka6fb6mvq6cec92un1p1t5kulhh6672qlnego952pp7h4lfl7mq3crithvtvo3col9mfc8vurbnb8hvo",
+                          "rendered": {
+                            "bestTermName": "path",
+                            "defnTermTag": "Plain",
+                            "signature": [
+                              {
+                                "annotation": {
+                                  "contents": "##Text",
+                                  "tag": "TypeReference"
+                                },
+                                "segment": "Text"
+                              }
+                            ],
+                            "termDefinition": {
+                              "contents": [
+                                {
+                                  "annotation": {
+                                    "contents": "a.different.path",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.different.path"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "##Text",
+                                    "tag": "TypeReference"
+                                  },
+                                  "segment": "Text"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": "\n"
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "a.different.path",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.different.path"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TextLiteral"
+                                  },
+                                  "segment": "\"definition at different path\""
+                                }
+                              ],
+                              "tag": "UserObject"
+                            },
+                            "termDocs": [],
+                            "termNames": [
+                              "a.different.path"
+                            ]
+                          },
                           "shortName": "path"
                         },
                         "tag": "Removed"

--- a/transcripts/share-apis/contribution-diffs/namespace-diff.json
+++ b/transcripts/share-apis/contribution-diffs/namespace-diff.json
@@ -10,7 +10,51 @@
               "hash": "#bbsbe7lolqunqrftm9jeg299caa91r2mlviqic54toilse443ljup5eojm1et3lqv6ni5gsu9l9hpldptga3cp5e0qffhg36gv5u2jo",
               "otherNames": [
                 "DataAliasMe"
-              ]
+              ],
+              "rendered": {
+                "bestTypeName": "ATypeAlias",
+                "defnTypeTag": "Data",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "type"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "ATypeAlias",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "ATypeAlias"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": " = "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#bbsbe7lolqunqrftm9jeg299caa91r2mlviqic54toilse443ljup5eojm1et3lqv6ni5gsu9l9hpldptga3cp5e0qffhg36gv5u2jo#d0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "B"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "ATypeAlias",
+                  "DataAliasMe"
+                ]
+              }
             },
             "tag": "Aliased"
           },
@@ -24,7 +68,95 @@
               "hash": "#qfgn5crplnhh308pepplqtleojiqhlpveimv0htug2mqbvhnia7qjfcravqlfb8ooos56jo5qq6brr99gg5kj0g5bgllvgn1nesv608",
               "otherNames": [
                 "AbilityAliasMe"
-              ]
+              ],
+              "rendered": {
+                "bestTypeName": "AbilityAlias",
+                "defnTypeTag": "Ability",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "ability"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "AbilityAlias",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "AbilityAlias"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "ControlKeyword"
+                      },
+                      "segment": " where"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#qfgn5crplnhh308pepplqtleojiqhlpveimv0htug2mqbvhnia7qjfcravqlfb8ooos56jo5qq6brr99gg5kj0g5bgllvgn1nesv608#a0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "abilityAliasMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "{"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#qfgn5crplnhh308pepplqtleojiqhlpveimv0htug2mqbvhnia7qjfcravqlfb8ooos56jo5qq6brr99gg5kj0g5bgllvgn1nesv608",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "AbilityAlias"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "}"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "AbilityAlias",
+                  "AbilityAliasMe"
+                ]
+              }
             },
             "tag": "Aliased"
           },
@@ -35,6 +167,93 @@
             "contents": {
               "fullName": "AbilityDeleteMe",
               "hash": "#val3i3ikhjc998qh1lfefhh08ad77f1eshera5d0hnbrp6qpgmfelbfa96pvsc18d5qd5qm7lij5el0raipb3mbjgalkh7g3aujej1o",
+              "rendered": {
+                "bestTypeName": "AbilityDeleteMe",
+                "defnTypeTag": "Ability",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "ability"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "AbilityDeleteMe",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "AbilityDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "ControlKeyword"
+                      },
+                      "segment": " where"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#val3i3ikhjc998qh1lfefhh08ad77f1eshera5d0hnbrp6qpgmfelbfa96pvsc18d5qd5qm7lij5el0raipb3mbjgalkh7g3aujej1o#a0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "abilityDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "{"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#val3i3ikhjc998qh1lfefhh08ad77f1eshera5d0hnbrp6qpgmfelbfa96pvsc18d5qd5qm7lij5el0raipb3mbjgalkh7g3aujej1o",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "AbilityDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "}"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "AbilityDeleteMe"
+                ]
+              },
               "shortName": "AbilityDeleteMe"
             },
             "tag": "Removed"
@@ -46,6 +265,93 @@
             "contents": {
               "fullName": "AbilityNew",
               "hash": "#t66tvdfo0l4pqj6hgav05tqifbuld8dc22g4rom3olfqj7b6cfpvf15j7307j8m2fpdsvcgv4ourrltpjutgpu3bh08efu2jl2nfqq0",
+              "rendered": {
+                "bestTypeName": "AbilityNew",
+                "defnTypeTag": "Ability",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "ability"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "AbilityNew",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "AbilityNew"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "ControlKeyword"
+                      },
+                      "segment": " where"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#t66tvdfo0l4pqj6hgav05tqifbuld8dc22g4rom3olfqj7b6cfpvf15j7307j8m2fpdsvcgv4ourrltpjutgpu3bh08efu2jl2nfqq0#a0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "abilityNew"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "{"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#t66tvdfo0l4pqj6hgav05tqifbuld8dc22g4rom3olfqj7b6cfpvf15j7307j8m2fpdsvcgv4ourrltpjutgpu3bh08efu2jl2nfqq0",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "AbilityNew"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "}"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Text",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Text"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "AbilityNew"
+                ]
+              },
               "shortName": "AbilityNew"
             },
             "tag": "Added"
@@ -60,7 +366,94 @@
               "newShortName": "AbilityRenamed",
               "oldNames": [
                 "AbilityRenameMe"
-              ]
+              ],
+              "rendered": {
+                "bestTypeName": "AbilityRenamed",
+                "defnTypeTag": "Ability",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "ability"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "AbilityRenamed",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "AbilityRenamed"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "ControlKeyword"
+                      },
+                      "segment": " where"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#iqmiiehu802p15ssntohl6l5kedd0j266rh7815s1t10rfe2bp207vh8ccngrlkii7i32h1n080dggr3r89osrq450kv6dj5uuc0o0o#a0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "abilityRenameMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "{"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#iqmiiehu802p15ssntohl6l5kedd0j266rh7815s1t10rfe2bp207vh8ccngrlkii7i32h1n080dggr3r89osrq450kv6dj5uuc0o0o",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "AbilityRenamed"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "AbilityBraces"
+                      },
+                      "segment": "}"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "AbilityRenamed"
+                ]
+              }
             },
             "tag": "RenamedFrom"
           },
@@ -69,6 +462,306 @@
         {
           "contents": {
             "contents": {
+              "diff": {
+                "diff": {
+                  "diff": {
+                    "contents": [
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "DataTypeKeyword"
+                            },
+                            "segment": "ability"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "contents": "AbilityUpdateMe",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "AbilityUpdateMe"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "ControlKeyword"
+                            },
+                            "segment": " where"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "annotationChange",
+                        "fromAnnotation": {
+                          "contents": "#0d5ej3mann48uffjea4epi8ss486689gsj46cscorhs3d4j7ohvj9t7ghg05tra792umcmgjr6lgqkskoo3odge7jm2ci91dlmpefcg#a0",
+                          "tag": "TermReference"
+                        },
+                        "segment": "abilityUpdateMe",
+                        "toAnnotation": {
+                          "contents": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18#a0",
+                          "tag": "TermReference"
+                        }
+                      },
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "TypeAscriptionColon"
+                            },
+                            "segment": " :"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "tag": "AbilityBraces"
+                            },
+                            "segment": "{"
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "annotationChange",
+                        "fromAnnotation": {
+                          "contents": "#0d5ej3mann48uffjea4epi8ss486689gsj46cscorhs3d4j7ohvj9t7ghg05tra792umcmgjr6lgqkskoo3odge7jm2ci91dlmpefcg",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "AbilityUpdateMe",
+                        "toAnnotation": {
+                          "contents": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18",
+                          "tag": "TypeReference"
+                        }
+                      },
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "AbilityBraces"
+                            },
+                            "segment": "}"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "old",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "##Nat",
+                              "tag": "TypeReference"
+                            },
+                            "segment": "Nat"
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "new",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "##Text",
+                              "tag": "TypeReference"
+                            },
+                            "segment": "Text"
+                          }
+                        ]
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "diffKind": "diff"
+                },
+                "left": {
+                  "bestTypeName": "AbilityUpdateMe",
+                  "defnTypeTag": "Ability",
+                  "typeDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "tag": "DataTypeKeyword"
+                        },
+                        "segment": "ability"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "AbilityUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "AbilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "ControlKeyword"
+                        },
+                        "segment": " where"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#0d5ej3mann48uffjea4epi8ss486689gsj46cscorhs3d4j7ohvj9t7ghg05tra792umcmgjr6lgqkskoo3odge7jm2ci91dlmpefcg#a0",
+                          "tag": "TermReference"
+                        },
+                        "segment": "abilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "AbilityBraces"
+                        },
+                        "segment": "{"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#0d5ej3mann48uffjea4epi8ss486689gsj46cscorhs3d4j7ohvj9t7ghg05tra792umcmgjr6lgqkskoo3odge7jm2ci91dlmpefcg",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "AbilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "AbilityBraces"
+                        },
+                        "segment": "}"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Nat",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "Nat"
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "typeDocs": [],
+                  "typeNames": [
+                    "AbilityUpdateMe"
+                  ]
+                },
+                "right": {
+                  "bestTypeName": "AbilityUpdateMe",
+                  "defnTypeTag": "Ability",
+                  "typeDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "tag": "DataTypeKeyword"
+                        },
+                        "segment": "ability"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "AbilityUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "AbilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "ControlKeyword"
+                        },
+                        "segment": " where"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18#a0",
+                          "tag": "TermReference"
+                        },
+                        "segment": "abilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "AbilityBraces"
+                        },
+                        "segment": "{"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "AbilityUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "AbilityBraces"
+                        },
+                        "segment": "}"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Text",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "Text"
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "typeDocs": [],
+                  "typeNames": [
+                    "AbilityUpdateMe"
+                  ]
+                }
+              },
               "fullName": "AbilityUpdateMe",
               "newHash": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18",
               "newTag": "Ability",
@@ -85,6 +778,49 @@
             "contents": {
               "fullName": "DataDeleteMe",
               "hash": "#keu02n8is0irijd65cvuos41kukj3f4ni18mmnudrbll2epo6ftd03nt9l0vqc4fvg98198tefgoupco4o0d0gvnigqgr1bmo2neo88",
+              "rendered": {
+                "bestTypeName": "DataDeleteMe",
+                "defnTypeTag": "Data",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "type"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "DataDeleteMe",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "DataDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": " = "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#keu02n8is0irijd65cvuos41kukj3f4ni18mmnudrbll2epo6ftd03nt9l0vqc4fvg98198tefgoupco4o0d0gvnigqgr1bmo2neo88#d0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "C"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "DataDeleteMe"
+                ]
+              },
               "shortName": "DataDeleteMe"
             },
             "tag": "Removed"
@@ -94,6 +830,176 @@
         {
           "contents": {
             "contents": {
+              "diff": {
+                "diff": {
+                  "diff": {
+                    "contents": [
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "DataTypeKeyword"
+                            },
+                            "segment": "type"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "contents": "DataUpdateMe",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "DataUpdateMe"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "DelimiterChar"
+                            },
+                            "segment": " = "
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "old",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "#fhc8jn2bhvfdnfr89dv2jf7tekuesna7gvje4ck6lfheh9rb184q4ddd29vm9mvfm6u1a98kpgditn8vb09durtel67rpof1c62535o#d0",
+                              "tag": "TermReference"
+                            },
+                            "segment": "D"
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "new",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "#qnblpurkqedrq0kae95ep7b8f6uh5b7igefp21r1nvl22agjoup5e7aunua4q8ku8mb532fh3lst4mj3m2bsb3kluchc3fuau5cllr0#d0",
+                              "tag": "TermReference"
+                            },
+                            "segment": "D2"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "contents": "##Nat",
+                              "tag": "TypeReference"
+                            },
+                            "segment": "Nat"
+                          }
+                        ]
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "diffKind": "diff"
+                },
+                "left": {
+                  "bestTypeName": "DataUpdateMe",
+                  "defnTypeTag": "Data",
+                  "typeDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "tag": "DataTypeKeyword"
+                        },
+                        "segment": "type"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "DataUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "DataUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "DelimiterChar"
+                        },
+                        "segment": " = "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#fhc8jn2bhvfdnfr89dv2jf7tekuesna7gvje4ck6lfheh9rb184q4ddd29vm9mvfm6u1a98kpgditn8vb09durtel67rpof1c62535o#d0",
+                          "tag": "TermReference"
+                        },
+                        "segment": "D"
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "typeDocs": [],
+                  "typeNames": [
+                    "DataUpdateMe"
+                  ]
+                },
+                "right": {
+                  "bestTypeName": "DataUpdateMe",
+                  "defnTypeTag": "Data",
+                  "typeDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "tag": "DataTypeKeyword"
+                        },
+                        "segment": "type"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "DataUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "DataUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "DelimiterChar"
+                        },
+                        "segment": " = "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "#qnblpurkqedrq0kae95ep7b8f6uh5b7igefp21r1nvl22agjoup5e7aunua4q8ku8mb532fh3lst4mj3m2bsb3kluchc3fuau5cllr0#d0",
+                          "tag": "TermReference"
+                        },
+                        "segment": "D2"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Nat",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "Nat"
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "typeDocs": [],
+                  "typeNames": [
+                    "DataUpdateMe"
+                  ]
+                }
+              },
               "fullName": "DataUpdateMe",
               "newHash": "#qnblpurkqedrq0kae95ep7b8f6uh5b7igefp21r1nvl22agjoup5e7aunua4q8ku8mb532fh3lst4mj3m2bsb3kluchc3fuau5cllr0",
               "newTag": "Data",
@@ -110,6 +1016,49 @@
             "contents": {
               "fullName": "NewType",
               "hash": "#sa4ptibggqmbifhfj37gj2lq487q5ucfuojjcblfaas9bunlthhkvhstsrj20fvlpqakb8e9mqds4p32lnh8ohmf1s5omvdhc23jibg",
+              "rendered": {
+                "bestTypeName": "NewType",
+                "defnTypeTag": "Data",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "type"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "NewType",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "NewType"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": " = "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#sa4ptibggqmbifhfj37gj2lq487q5ucfuojjcblfaas9bunlthhkvhstsrj20fvlpqakb8e9mqds4p32lnh8ohmf1s5omvdhc23jibg#d0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "X"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "NewType"
+                ]
+              },
               "shortName": "NewType"
             },
             "tag": "Added"
@@ -124,7 +1073,50 @@
               "newShortName": "RenamedType",
               "oldNames": [
                 "DataRenameMe"
-              ]
+              ],
+              "rendered": {
+                "bestTypeName": "RenamedType",
+                "defnTypeTag": "Data",
+                "typeDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "tag": "DataTypeKeyword"
+                      },
+                      "segment": "type"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "RenamedType",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "RenamedType"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": " = "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#8s3lsrv3p6ngq2bqotvli1f0gfcf9uvci4trmia6dosl3d8vu6i6kubdi3ic7m22r34m4mkru3hatdbgihj0fngmj7gktlq41ncs1e0#d0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "E"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "typeDocs": [],
+                "typeNames": [
+                  "RenamedType"
+                ]
+              }
             },
             "tag": "RenamedFrom"
           },
@@ -135,6 +1127,123 @@
             "contents": {
               "fullName": "aDoc",
               "hash": "#areni4s9liksvfs3923a4ub81qpu37f964fqhbq832artpff8vm1em45ic0k2hlkv4nn08u712ibvjo9b4fl5u19o65g9medo7645i8",
+              "rendered": {
+                "bestTermName": "aDoc",
+                "defnTermTag": "Doc",
+                "signature": [
+                  {
+                    "annotation": {
+                      "contents": "#ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Doc2"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "aDoc",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aDoc"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Doc2"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "aDoc",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aDoc"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DocDelimiter"
+                      },
+                      "segment": "{{"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "Test"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "Doc"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DocDelimiter"
+                      },
+                      "segment": "}}"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [
+                  [
+                    "aDoc",
+                    "#areni4s9liksvfs3923a4ub81qpu37f964fqhbq832artpff8vm1em45ic0k2hlkv4nn08u712ibvjo9b4fl5u19o65g9medo7645i8",
+                    {
+                      "contents": [
+                        {
+                          "contents": "Test",
+                          "tag": "Word"
+                        },
+                        {
+                          "contents": "Doc",
+                          "tag": "Word"
+                        }
+                      ],
+                      "tag": "Paragraph"
+                    }
+                  ]
+                ],
+                "termNames": [
+                  "aDoc"
+                ]
+              },
               "shortName": "aDoc"
             },
             "tag": "Removed"
@@ -149,7 +1258,81 @@
               "hash": "#gjmq673r1vrurfotlnirv7vutdhm6sa3s02em5g22kk606mv6duvv8be402dv79312i4a0onepq5bo7citsodvq2g720nttj0ee9p0g",
               "otherNames": [
                 "termAliasMe"
-              ]
+              ],
+              "rendered": {
+                "bestTermName": "aTermAlias",
+                "defnTermTag": "Plain",
+                "signature": [
+                  {
+                    "annotation": {
+                      "contents": "##Nat",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "aTermAlias",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aTermAlias"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "aTermAlias",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aTermAlias"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "NumericLiteral"
+                      },
+                      "segment": "1"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [],
+                "termNames": [
+                  "aTermAlias",
+                  "termAliasMe"
+                ]
+              }
             },
             "tag": "Aliased"
           },
@@ -160,6 +1343,128 @@
             "contents": {
               "fullName": "aTest",
               "hash": "#qak36j7cshv12m9meuc97ovllqm8k2i305sh4oq5dbo4834t7atugsdpto6mou1tch2b3q9j2hbi23gdf4jpth7m97mannv9noucgl8",
+              "rendered": {
+                "bestTermName": "aTest",
+                "defnTermTag": "Test",
+                "signature": [
+                  {
+                    "annotation": {
+                      "tag": "DelimiterChar"
+                    },
+                    "segment": "["
+                  },
+                  {
+                    "annotation": {
+                      "contents": "#aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Result"
+                  },
+                  {
+                    "annotation": {
+                      "tag": "DelimiterChar"
+                    },
+                    "segment": "]"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "aTest",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aTest"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": "["
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Result"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "DelimiterChar"
+                      },
+                      "segment": "]"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "aTest",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "aTest"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "["
+                    },
+                    {
+                      "annotation": {
+                        "contents": "#aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#d1",
+                        "tag": "TermReference"
+                      },
+                      "segment": "Ok"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TextLiteral"
+                      },
+                      "segment": "\"Done\""
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "]"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [],
+                "termNames": [
+                  "aTest"
+                ]
+              },
               "shortName": "aTest"
             },
             "tag": "Removed"
@@ -171,6 +1476,79 @@
             "contents": {
               "fullName": "newTerm",
               "hash": "#u1qsl3nk5t2svl58ifqepem851775qca9p4hc10j3iordu1v7u8e16oodui9kvt2c0j1cbc50avado53bl2vt3pphrfj9mhbut1ipm8",
+              "rendered": {
+                "bestTermName": "newTerm",
+                "defnTermTag": "Plain",
+                "signature": [
+                  {
+                    "annotation": {
+                      "contents": "##Nat",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "newTerm",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "newTerm"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "newTerm",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "newTerm"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "NumericLiteral"
+                      },
+                      "segment": "100"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [],
+                "termNames": [
+                  "newTerm"
+                ]
+              },
               "shortName": "newTerm"
             },
             "tag": "Added"
@@ -185,7 +1563,80 @@
               "newShortName": "renamedTerm",
               "oldNames": [
                 "termRenameMe"
-              ]
+              ],
+              "rendered": {
+                "bestTermName": "renamedTerm",
+                "defnTermTag": "Plain",
+                "signature": [
+                  {
+                    "annotation": {
+                      "contents": "##Nat",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "renamedTerm",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "renamedTerm"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "renamedTerm",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "renamedTerm"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "NumericLiteral"
+                      },
+                      "segment": "3"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [],
+                "termNames": [
+                  "renamedTerm"
+                ]
+              }
             },
             "tag": "RenamedFrom"
           },
@@ -196,6 +1647,79 @@
             "contents": {
               "fullName": "termDeleteMe",
               "hash": "#dcgdua2lj6upd1ah5v0qp09gjsej0d77d87fu6qn8e2qrssnlnmuinoio46hiu53magr7qn8vnqke8ndt0v76700o5u8gcvo7st28jg",
+              "rendered": {
+                "bestTermName": "termDeleteMe",
+                "defnTermTag": "Plain",
+                "signature": [
+                  {
+                    "annotation": {
+                      "contents": "##Nat",
+                      "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                  }
+                ],
+                "termDefinition": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "termDeleteMe",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "termDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "TypeAscriptionColon"
+                      },
+                      "segment": " :"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Nat"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": {
+                        "contents": "termDeleteMe",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "termDeleteMe"
+                    },
+                    {
+                      "annotation": {
+                        "tag": "BindingEquals"
+                      },
+                      "segment": " ="
+                    },
+                    {
+                      "annotation": null,
+                      "segment": " "
+                    },
+                    {
+                      "annotation": {
+                        "tag": "NumericLiteral"
+                      },
+                      "segment": "2"
+                    }
+                  ],
+                  "tag": "UserObject"
+                },
+                "termDocs": [],
+                "termNames": [
+                  "termDeleteMe"
+                ]
+              },
               "shortName": "termDeleteMe"
             },
             "tag": "Removed"
@@ -205,6 +1729,234 @@
         {
           "contents": {
             "contents": {
+              "diff": {
+                "diff": {
+                  "diff": {
+                    "contents": [
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "termUpdateMe",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "termUpdateMe"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "TypeAscriptionColon"
+                            },
+                            "segment": " :"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "contents": "##Text",
+                              "tag": "TypeReference"
+                            },
+                            "segment": "Text"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": "\n"
+                          },
+                          {
+                            "annotation": {
+                              "contents": "termUpdateMe",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "termUpdateMe"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "BindingEquals"
+                            },
+                            "segment": " ="
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "old",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "TextLiteral"
+                            },
+                            "segment": "\"original\""
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "new",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "TextLiteral"
+                            },
+                            "segment": "\"updated\""
+                          }
+                        ]
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "diffKind": "diff"
+                },
+                "left": {
+                  "bestTermName": "termUpdateMe",
+                  "defnTermTag": "Plain",
+                  "signature": [
+                    {
+                      "annotation": {
+                        "contents": "##Text",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Text"
+                    }
+                  ],
+                  "termDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "contents": "termUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "termUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Text",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "Text"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "termUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "termUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TextLiteral"
+                        },
+                        "segment": "\"original\""
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "termDocs": [],
+                  "termNames": [
+                    "termUpdateMe"
+                  ]
+                },
+                "right": {
+                  "bestTermName": "termUpdateMe",
+                  "defnTermTag": "Plain",
+                  "signature": [
+                    {
+                      "annotation": {
+                        "contents": "##Text",
+                        "tag": "TypeReference"
+                      },
+                      "segment": "Text"
+                    }
+                  ],
+                  "termDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "contents": "termUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "termUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Text",
+                          "tag": "TypeReference"
+                        },
+                        "segment": "Text"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "termUpdateMe",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "termUpdateMe"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TextLiteral"
+                        },
+                        "segment": "\"updated\""
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "termDocs": [],
+                  "termNames": [
+                    "termUpdateMe"
+                  ]
+                }
+              },
               "fullName": "termUpdateMe",
               "newHash": "#711u1t9cjso4t3rhlq2rp491n2n5n4t9o7701053kpj5ouu3kfs2e2l63i879pnsb6ob9fp0gpj18u6fpcl1qosd704h4doklfo734g",
               "newTag": "Plain",
@@ -220,222 +1972,6 @@
       "children": [
         {
           "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "aliasFullName": "ATypeAlias.B",
-                    "aliasShortName": "B",
-                    "hash": "#bbsbe7lolqunqrftm9jeg299caa91r2mlviqic54toilse443ljup5eojm1et3lqv6ni5gsu9l9hpldptga3cp5e0qffhg36gv5u2jo#0",
-                    "otherNames": [
-                      "DataAliasMe.B"
-                    ]
-                  },
-                  "tag": "Aliased"
-                },
-                "tag": "DataConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "ATypeAlias"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "aliasFullName": "AbilityAlias.abilityAliasMe",
-                    "aliasShortName": "abilityAliasMe",
-                    "hash": "#qfgn5crplnhh308pepplqtleojiqhlpveimv0htug2mqbvhnia7qjfcravqlfb8ooos56jo5qq6brr99gg5kj0g5bgllvgn1nesv608#0",
-                    "otherNames": [
-                      "AbilityAliasMe.abilityAliasMe"
-                    ]
-                  },
-                  "tag": "Aliased"
-                },
-                "tag": "AbilityConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "AbilityAlias"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "AbilityDeleteMe.abilityDeleteMe",
-                    "hash": "#val3i3ikhjc998qh1lfefhh08ad77f1eshera5d0hnbrp6qpgmfelbfa96pvsc18d5qd5qm7lij5el0raipb3mbjgalkh7g3aujej1o#0",
-                    "shortName": "abilityDeleteMe"
-                  },
-                  "tag": "Removed"
-                },
-                "tag": "AbilityConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "AbilityDeleteMe"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "AbilityNew.abilityNew",
-                    "hash": "#t66tvdfo0l4pqj6hgav05tqifbuld8dc22g4rom3olfqj7b6cfpvf15j7307j8m2fpdsvcgv4ourrltpjutgpu3bh08efu2jl2nfqq0#0",
-                    "shortName": "abilityNew"
-                  },
-                  "tag": "Added"
-                },
-                "tag": "AbilityConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "AbilityNew"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "hash": "#iqmiiehu802p15ssntohl6l5kedd0j266rh7815s1t10rfe2bp207vh8ccngrlkii7i32h1n080dggr3r89osrq450kv6dj5uuc0o0o#0",
-                    "newFullName": "AbilityRenamed.abilityRenameMe",
-                    "newShortName": "abilityRenameMe",
-                    "oldNames": [
-                      "AbilityRenameMe.abilityRenameMe"
-                    ]
-                  },
-                  "tag": "RenamedFrom"
-                },
-                "tag": "AbilityConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "AbilityRenamed"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "AbilityUpdateMe.abilityUpdateMe",
-                    "newHash": "#qat72tp0lb43gp5pra5rgobup5r24qrc494crqd5pqjddbneiqdn3hq6puo2344nja1v6cp7aps1p0350ug0f1kvo9cp2gu9l31in18#0",
-                    "newTag": "AbilityConstructor",
-                    "oldHash": "#0d5ej3mann48uffjea4epi8ss486689gsj46cscorhs3d4j7ohvj9t7ghg05tra792umcmgjr6lgqkskoo3odge7jm2ci91dlmpefcg#0",
-                    "oldTag": "AbilityConstructor",
-                    "shortName": "abilityUpdateMe"
-                  },
-                  "tag": "Updated"
-                },
-                "tag": "AbilityConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "AbilityUpdateMe"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "DataDeleteMe.C",
-                    "hash": "#keu02n8is0irijd65cvuos41kukj3f4ni18mmnudrbll2epo6ftd03nt9l0vqc4fvg98198tefgoupco4o0d0gvnigqgr1bmo2neo88#0",
-                    "shortName": "C"
-                  },
-                  "tag": "Removed"
-                },
-                "tag": "DataConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "DataDeleteMe"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "DataUpdateMe.D",
-                    "hash": "#fhc8jn2bhvfdnfr89dv2jf7tekuesna7gvje4ck6lfheh9rb184q4ddd29vm9mvfm6u1a98kpgditn8vb09durtel67rpof1c62535o#0",
-                    "shortName": "D"
-                  },
-                  "tag": "Removed"
-                },
-                "tag": "DataConstructor"
-              },
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "DataUpdateMe.D2",
-                    "hash": "#qnblpurkqedrq0kae95ep7b8f6uh5b7igefp21r1nvl22agjoup5e7aunua4q8ku8mb532fh3lst4mj3m2bsb3kluchc3fuau5cllr0#0",
-                    "shortName": "D2"
-                  },
-                  "tag": "Added"
-                },
-                "tag": "DataConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "DataUpdateMe"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "fullName": "NewType.X",
-                    "hash": "#sa4ptibggqmbifhfj37gj2lq487q5ucfuojjcblfaas9bunlthhkvhstsrj20fvlpqakb8e9mqds4p32lnh8ohmf1s5omvdhc23jibg#0",
-                    "shortName": "X"
-                  },
-                  "tag": "Added"
-                },
-                "tag": "DataConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "NewType"
-        },
-        {
-          "contents": {
-            "changes": [
-              {
-                "contents": {
-                  "contents": {
-                    "hash": "#8s3lsrv3p6ngq2bqotvli1f0gfcf9uvci4trmia6dosl3d8vu6i6kubdi3ic7m22r34m4mkru3hatdbgihj0fngmj7gktlq41ncs1e0#0",
-                    "newFullName": "RenamedType.E",
-                    "newShortName": "E",
-                    "oldNames": [
-                      "DataRenameMe.E"
-                    ]
-                  },
-                  "tag": "RenamedFrom"
-                },
-                "tag": "DataConstructor"
-              }
-            ],
-            "children": []
-          },
-          "path": "RenamedType"
-        },
-        {
-          "contents": {
             "changes": [],
             "children": [
               {
@@ -446,6 +1982,79 @@
                         "contents": {
                           "fullName": "a.definition.at.path1",
                           "hash": "#r303avnmdmja3ch96otiglq37214t43acpr1ikq4hrp5hmcibstipa69frbd6177jvbn28ioc5ii80fc54ecogm4n64dhjvkonrihso",
+                          "rendered": {
+                            "bestTermName": "path1",
+                            "defnTermTag": "Plain",
+                            "signature": [
+                              {
+                                "annotation": {
+                                  "contents": "##Text",
+                                  "tag": "TypeReference"
+                                },
+                                "segment": "Text"
+                              }
+                            ],
+                            "termDefinition": {
+                              "contents": [
+                                {
+                                  "annotation": {
+                                    "contents": "a.definition.at.path1",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.definition.at.path1"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "##Text",
+                                    "tag": "TypeReference"
+                                  },
+                                  "segment": "Text"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": "\n"
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "a.definition.at.path1",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.definition.at.path1"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TextLiteral"
+                                  },
+                                  "segment": "\"definition at path\""
+                                }
+                              ],
+                              "tag": "UserObject"
+                            },
+                            "termDocs": [],
+                            "termNames": [
+                              "a.definition.at.path1"
+                            ]
+                          },
                           "shortName": "path1"
                         },
                         "tag": "Removed"
@@ -457,6 +2066,79 @@
                         "contents": {
                           "fullName": "a.definition.at.path2",
                           "hash": "#k43vb9rkd3n4i8g8bbfb31erufbmu6v1f99i587oqsje51thrm1ugdqa7gkjbdvkactuql3cmc00b7oev0glqb2rko48atkuo798mno",
+                          "rendered": {
+                            "bestTermName": "path2",
+                            "defnTermTag": "Plain",
+                            "signature": [
+                              {
+                                "annotation": {
+                                  "contents": "##Text",
+                                  "tag": "TypeReference"
+                                },
+                                "segment": "Text"
+                              }
+                            ],
+                            "termDefinition": {
+                              "contents": [
+                                {
+                                  "annotation": {
+                                    "contents": "a.definition.at.path2",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.definition.at.path2"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "##Text",
+                                    "tag": "TypeReference"
+                                  },
+                                  "segment": "Text"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": "\n"
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "a.definition.at.path2",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.definition.at.path2"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TextLiteral"
+                                  },
+                                  "segment": "\"definition at path2\""
+                                }
+                              ],
+                              "tag": "UserObject"
+                            },
+                            "termDocs": [],
+                            "termNames": [
+                              "a.definition.at.path2"
+                            ]
+                          },
                           "shortName": "path2"
                         },
                         "tag": "Removed"
@@ -476,6 +2158,79 @@
                         "contents": {
                           "fullName": "a.different.path",
                           "hash": "#83be375arg68mqk26bu12elka6fb6mvq6cec92un1p1t5kulhh6672qlnego952pp7h4lfl7mq3crithvtvo3col9mfc8vurbnb8hvo",
+                          "rendered": {
+                            "bestTermName": "path",
+                            "defnTermTag": "Plain",
+                            "signature": [
+                              {
+                                "annotation": {
+                                  "contents": "##Text",
+                                  "tag": "TypeReference"
+                                },
+                                "segment": "Text"
+                              }
+                            ],
+                            "termDefinition": {
+                              "contents": [
+                                {
+                                  "annotation": {
+                                    "contents": "a.different.path",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.different.path"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "##Text",
+                                    "tag": "TypeReference"
+                                  },
+                                  "segment": "Text"
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": "\n"
+                                },
+                                {
+                                  "annotation": {
+                                    "contents": "a.different.path",
+                                    "tag": "HashQualifier"
+                                  },
+                                  "segment": "a.different.path"
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                                },
+                                {
+                                  "annotation": null,
+                                  "segment": " "
+                                },
+                                {
+                                  "annotation": {
+                                    "tag": "TextLiteral"
+                                  },
+                                  "segment": "\"definition at different path\""
+                                }
+                              ],
+                              "tag": "UserObject"
+                            },
+                            "termDocs": [],
+                            "termNames": [
+                              "a.different.path"
+                            ]
+                          },
                           "shortName": "path"
                         },
                         "tag": "Removed"

--- a/transcripts/share-apis/contributions/merged-contribution-diff.json
+++ b/transcripts/share-apis/contributions/merged-contribution-diff.json
@@ -5,6 +5,234 @@
         {
           "contents": {
             "contents": {
+              "diff": {
+                "diff": {
+                  "diff": {
+                    "contents": [
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "term",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "term"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "TypeAscriptionColon"
+                            },
+                            "segment": " :"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "contents": "##Text",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "##Text"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": "\n"
+                          },
+                          {
+                            "annotation": {
+                              "contents": "term",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "term"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "BindingEquals"
+                            },
+                            "segment": " ="
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "old",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "TextLiteral"
+                            },
+                            "segment": "\"start\""
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "new",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "TextLiteral"
+                            },
+                            "segment": "\"feature-one\""
+                          }
+                        ]
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "diffKind": "diff"
+                },
+                "left": {
+                  "bestTermName": "term",
+                  "defnTermTag": "Plain",
+                  "signature": [
+                    {
+                      "annotation": {
+                        "contents": "##Text",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "##Text"
+                    }
+                  ],
+                  "termDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "contents": "term",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Text",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "##Text"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "term",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TextLiteral"
+                        },
+                        "segment": "\"start\""
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "termDocs": [],
+                  "termNames": [
+                    "term"
+                  ]
+                },
+                "right": {
+                  "bestTermName": "term",
+                  "defnTermTag": "Plain",
+                  "signature": [
+                    {
+                      "annotation": {
+                        "contents": "##Text",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "##Text"
+                    }
+                  ],
+                  "termDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "contents": "term",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Text",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "##Text"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "term",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TextLiteral"
+                        },
+                        "segment": "\"feature-one\""
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "termDocs": [],
+                  "termNames": [
+                    "term"
+                  ]
+                }
+              },
               "fullName": "term",
               "newHash": "#t8aquv2oldk8euc6uveu227hiv76tlic78h607s2nr47mruvocg1oq147b4jf8l850qj2jl37n37ohned32c4ag97mq22cvhl0sbbfo",
               "newTag": "Plain",

--- a/transcripts/share-apis/contributions/transitive-contribution-diff.json
+++ b/transcripts/share-apis/contributions/transitive-contribution-diff.json
@@ -5,6 +5,234 @@
         {
           "contents": {
             "contents": {
+              "diff": {
+                "diff": {
+                  "diff": {
+                    "contents": [
+                      {
+                        "diffTag": "both",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "contents": "term",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "term"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "TypeAscriptionColon"
+                            },
+                            "segment": " :"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          },
+                          {
+                            "annotation": {
+                              "contents": "##Text",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "##Text"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": "\n"
+                          },
+                          {
+                            "annotation": {
+                              "contents": "term",
+                              "tag": "HashQualifier"
+                            },
+                            "segment": "term"
+                          },
+                          {
+                            "annotation": {
+                              "tag": "BindingEquals"
+                            },
+                            "segment": " ="
+                          },
+                          {
+                            "annotation": null,
+                            "segment": " "
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "old",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "TextLiteral"
+                            },
+                            "segment": "\"feature-one\""
+                          }
+                        ]
+                      },
+                      {
+                        "diffTag": "new",
+                        "elements": [
+                          {
+                            "annotation": {
+                              "tag": "TextLiteral"
+                            },
+                            "segment": "\"feature-two\""
+                          }
+                        ]
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "diffKind": "diff"
+                },
+                "left": {
+                  "bestTermName": "term",
+                  "defnTermTag": "Plain",
+                  "signature": [
+                    {
+                      "annotation": {
+                        "contents": "##Text",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "##Text"
+                    }
+                  ],
+                  "termDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "contents": "term",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Text",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "##Text"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "term",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TextLiteral"
+                        },
+                        "segment": "\"feature-one\""
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "termDocs": [],
+                  "termNames": [
+                    "term"
+                  ]
+                },
+                "right": {
+                  "bestTermName": "term",
+                  "defnTermTag": "Plain",
+                  "signature": [
+                    {
+                      "annotation": {
+                        "contents": "##Text",
+                        "tag": "HashQualifier"
+                      },
+                      "segment": "##Text"
+                    }
+                  ],
+                  "termDefinition": {
+                    "contents": [
+                      {
+                        "annotation": {
+                          "contents": "term",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "contents": "##Text",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "##Text"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": {
+                          "contents": "term",
+                          "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                      },
+                      {
+                        "annotation": {
+                          "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                      },
+                      {
+                        "annotation": null,
+                        "segment": " "
+                      },
+                      {
+                        "annotation": {
+                          "tag": "TextLiteral"
+                        },
+                        "segment": "\"feature-two\""
+                      }
+                    ],
+                    "tag": "UserObject"
+                  },
+                  "termDocs": [],
+                  "termNames": [
+                    "term"
+                  ]
+                }
+              },
               "fullName": "term",
               "newHash": "#918iukm79ii0jll0m3qtsrcqjp1sqe5rdpf1kochqp52a52s9ciil7mu6m3t4l39pdk60imhj5be1d9rat2lgdmr6u0jn93v7v8o6rg",
               "newTag": "Plain",


### PR DESCRIPTION
## Overview

This change causes Share to compute diffs for Contributions in-advance using a background queue that gets populated on relevant branch updates or contribution creations.

It then returns the full diff as part of the contribution diff endpoint, see transcripts for more info 👀 

## Implementation notes

* Adds a new background job and associated PG queue table.
* Adds a table where we store the cached diffs. The diffs are based on namespace hashes, so won't ever go stale
* Adds the output to the contribution diff endpoint.

## Test coverage

See transcripts
