### PR TITLE
Ensure Serialized Entities

### DIFF
--- a/src/Share/BackgroundJobs/SerializedEntitiesMigration/Worker.hs
+++ b/src/Share/BackgroundJobs/SerializedEntitiesMigration/Worker.hs
@@ -92,4 +92,6 @@ saveUnsandboxedSerializedEntities hash entity = do
     Entity.C {} -> do
       cId <- CQ.expectCausalIdByHash (fromHash32 @CausalHash hash)
       CQ.saveSerializedCausal cId serialised
-    Entity.N {} -> SQ.saveSerializedNamespace hash serialised
+    Entity.N {} -> do
+      bhId <- HQ.expectBranchHashId (fromHash32 @BranchHash hash)
+      CQ.saveSerializedNamespace bhId serialised

--- a/src/Share/BackgroundJobs/SerializedEntitiesMigration/Worker.hs
+++ b/src/Share/BackgroundJobs/SerializedEntitiesMigration/Worker.hs
@@ -13,6 +13,7 @@ import Share.Postgres.Causal.Queries qualified as CQ
 import Share.Postgres.Definitions.Queries qualified as DefnQ
 import Share.Postgres.Hashes.Queries qualified as HQ
 import Share.Postgres.IDs
+import Share.Postgres.Patches.Queries qualified as PQ
 import Share.Postgres.Sync.Queries qualified as SQ
 import Share.Prelude
 import Share.Web.Authorization qualified as AuthZ
@@ -88,7 +89,9 @@ saveUnsandboxedSerializedEntities hash entity = do
   case entity of
     Entity.TC {} -> error "Unexpected term component"
     Entity.DC {} -> error "Unexpected decl component"
-    Entity.P {} -> SQ.saveSerializedPatch hash serialised
+    Entity.P {} -> do
+      patchId <- HQ.expectPatchIdsOf id (fromHash32 @PatchHash hash)
+      PQ.saveSerializedPatch patchId serialised
     Entity.C {} -> do
       cId <- CQ.expectCausalIdByHash (fromHash32 @CausalHash hash)
       CQ.saveSerializedCausal cId serialised

--- a/src/Share/Codebase.hs
+++ b/src/Share/Codebase.hs
@@ -468,7 +468,7 @@ squashCausal Causal.Causal {valueHash = unsquashedBranchHash, value} = do
       let squashedBranchHead = branch {V2.children = snd <$> squashedChildren}
       (squashedBranchHashId, squashedBranchHash) <- CausalQ.saveV2BranchShallow squashedBranchHead
       let ancestors = mempty
-      (squashedCausalId, squashedCausalHash) <- CausalQ.saveCausal Nothing squashedBranchHashId ancestors
+      (squashedCausalId, squashedCausalHash) <- CausalQ.saveCausal Nothing Nothing squashedBranchHashId ancestors
       let squashedCausalBranch =
             Causal.Causal
               { causalHash = squashedCausalHash,

--- a/src/Share/Postgres/IDs.hs
+++ b/src/Share/Postgres/IDs.hs
@@ -33,13 +33,17 @@ module Share.Postgres.IDs
     hash32FromBranchHash_,
     hash32AsCausalHash_,
     hash32FromCausalHash_,
+    toHash32,
+    fromHash32,
   )
 where
 
 import Control.Lens
+import Data.Coerce (Coercible)
 import Share.Postgres qualified as PG
 import Share.Prelude
 import U.Codebase.HashTags (BranchHash (..), CausalHash (..), ComponentHash (..), PatchHash (..))
+import Unison.Hash (Hash)
 import Unison.Hash32 (Hash32)
 import Unison.Hash32 qualified as Hash32
 
@@ -98,6 +102,12 @@ newtype NamespaceTypeMappingId = NamespaceTypeMappingId Int32
 newtype ComponentSummaryDigest = ComponentSummaryDigest {unComponentSummaryDigest :: ByteString}
   deriving stock (Show, Eq, Ord)
   deriving (PG.EncodeValue, PG.DecodeValue) via ByteString
+
+toHash32 :: (Coercible h Hash) => h -> Hash32
+toHash32 = Hash32.fromHash . coerce
+
+fromHash32 :: (Coercible h Hash) => Hash32 -> h
+fromHash32 = coerce . Hash32.toHash
 
 hash32AsComponentHash_ :: Iso Hash32 b ComponentHash b
 hash32AsComponentHash_ = iso (ComponentHash . Hash32.toHash) id

--- a/src/Share/Postgres/LooseCode/Queries.hs
+++ b/src/Share/Postgres/LooseCode/Queries.hs
@@ -120,5 +120,5 @@ setLooseCodeRoot !_nlReceipt callerUserId description newCausalId = do
 initialize :: CodebaseM e ()
 initialize = do
   (emptyBhId, _) <- CausalQ.savePgNamespace Nothing BranchFull.emptyBranch
-  (cid, _causalHash) <- CausalQ.saveCausal Nothing emptyBhId mempty
+  (cid, _causalHash) <- CausalQ.saveCausal Nothing Nothing emptyBhId mempty
   ensureLooseCodeRootHash cid

--- a/src/Share/Postgres/LooseCode/Queries.hs
+++ b/src/Share/Postgres/LooseCode/Queries.hs
@@ -119,6 +119,6 @@ setLooseCodeRoot !_nlReceipt callerUserId description newCausalId = do
 -- | Initializes a codebase for a new user
 initialize :: CodebaseM e ()
 initialize = do
-  (emptyBhId, _) <- CausalQ.savePgNamespace Nothing BranchFull.emptyBranch
+  (emptyBhId, _) <- CausalQ.savePgNamespace Nothing Nothing BranchFull.emptyBranch
   (cid, _causalHash) <- CausalQ.saveCausal Nothing Nothing emptyBhId mempty
   ensureLooseCodeRootHash cid


### PR DESCRIPTION
Some special cases were resulting in missing serialized entities, specifically squashing causals (for releases);

This change ensures that you can't save an entity without also adding its serialized form.