### PR TITLE
Naïve dependency negotiation API

### DIFF
--- a/share-api.cabal
+++ b/share-api.cabal
@@ -158,6 +158,7 @@ library
       Share.Web.UCM.SyncV2.API
       Share.Web.UCM.SyncV2.Impl
       Share.Web.UCM.SyncV2.Queries
+      Share.Web.UCM.SyncV2.Types
       Unison.PrettyPrintEnvDecl.Postgres
       Unison.Server.NameSearch.Postgres
       Unison.Server.Share.Definitions

--- a/sql/2025-01-31_dependencies-of-causal.sql
+++ b/sql/2025-01-31_dependencies-of-causal.sql
@@ -1,0 +1,131 @@
+-- Takes a causal_id and returns a table of ALL hashes which are dependencies of that causal.
+CREATE OR REPLACE FUNCTION dependencies_of_causals(the_causal_ids INTEGER[]) RETURNS TABLE (hash TEXT) AS $$
+  WITH RECURSIVE all_causals(causal_id, causal_hash, causal_namespace_hash_id) AS (
+      -- Base causal
+      SELECT causal.id, causal.hash, causal.namespace_hash_id
+      FROM UNNEST(the_causal_ids) AS causal_id
+          JOIN causals causal ON causal.id = causal_id
+      UNION
+      -- This nested CTE is required because RECURSIVE CTEs can't refer
+      -- to the recursive table more than once.
+      -- I don't fully understand why or how this works, but it does
+      ( WITH rec AS (
+          SELECT tc.causal_id, tc.causal_namespace_hash_id
+          FROM all_causals tc
+      )
+          SELECT ancestor_causal.id, ancestor_causal.hash, ancestor_causal.namespace_hash_id
+          FROM causal_ancestors ca
+              JOIN rec tc ON ca.causal_id = tc.causal_id
+              JOIN causals ancestor_causal ON ca.ancestor_id = ancestor_causal.id
+          UNION
+          SELECT child_causal.id, child_causal.hash, child_causal.namespace_hash_id
+          FROM rec tc
+              JOIN namespace_children nc ON tc.causal_namespace_hash_id = nc.parent_namespace_hash_id
+              JOIN causals child_causal ON nc.child_causal_id = child_causal.id
+      )
+  ), all_namespaces(namespace_hash_id, namespace_hash) AS (
+      SELECT DISTINCT tc.causal_namespace_hash_id AS namespace_hash_id, bh.base32 as namespace_hash
+      FROM all_causals tc
+      JOIN branch_hashes bh ON tc.causal_namespace_hash_id = bh.id
+  ), all_patches(patch_id, patch_hash) AS (
+      SELECT DISTINCT patch.id, patch.hash
+      FROM all_namespaces an
+          JOIN namespace_patches np ON an.namespace_hash_id = np.namespace_hash_id
+          JOIN patches patch ON np.patch_id = patch.id
+  ),
+  -- term components to start transitively joining dependencies to
+  base_term_components(component_hash_id) AS (
+      SELECT DISTINCT term.component_hash_id
+      FROM all_namespaces an
+          JOIN namespace_terms nt ON an.namespace_hash_id = nt.namespace_hash_id
+          JOIN terms term ON nt.term_id = term.id
+      UNION
+      SELECT DISTINCT term.component_hash_id
+      FROM all_patches ap
+          JOIN patch_term_mappings ptm ON ap.patch_id = ptm.patch_id
+          JOIN terms term ON ptm.to_term_id = term.id
+      UNION
+      -- term metadata
+      SELECT DISTINCT term.component_hash_id
+      FROM all_namespaces an
+          JOIN namespace_terms nt ON an.namespace_hash_id = nt.namespace_hash_id
+          JOIN namespace_term_metadata meta ON nt.id = meta.named_term
+          JOIN terms term ON meta.metadata_term_id = term.id
+      UNION
+      -- type metadata
+      SELECT DISTINCT term.component_hash_id
+      FROM all_namespaces an
+          JOIN namespace_types nt ON an.namespace_hash_id = nt.namespace_hash_id
+          JOIN namespace_type_metadata meta ON nt.id = meta.named_type
+          JOIN terms term ON meta.metadata_term_id = term.id
+  ),
+  -- type components to start transitively joining dependencies to
+  base_type_components(component_hash_id) AS (
+      SELECT DISTINCT typ.component_hash_id
+      FROM all_namespaces an
+          JOIN namespace_types nt ON an.namespace_hash_id = nt.namespace_hash_id
+          JOIN types typ ON nt.type_id = typ.id
+      UNION
+      SELECT DISTINCT typ.component_hash_id
+      FROM all_namespaces an
+          JOIN namespace_terms nt ON an.namespace_hash_id = nt.namespace_hash_id
+          JOIN constructors con ON nt.constructor_id = con.id
+          JOIN types typ ON con.type_id = typ.id
+      UNION
+      SELECT DISTINCT typ.component_hash_id
+      FROM all_patches ap
+          JOIN patch_type_mappings ptm ON ap.patch_id = ptm.patch_id
+          JOIN types typ ON ptm.to_type_id = typ.id
+      UNION
+      SELECT DISTINCT typ.component_hash_id
+      FROM all_patches ap
+          JOIN patch_constructor_mappings pcm ON ap.patch_id = pcm.patch_id
+          JOIN constructors con ON pcm.to_constructor_id = con.id
+          JOIN types typ ON con.type_id = typ.id
+  ),
+  -- All the dependencies we join in transitively from the known term & type components we depend on.
+  all_components(component_hash_id) AS (
+      SELECT DISTINCT btc.component_hash_id
+      FROM base_term_components btc
+      UNION
+      SELECT DISTINCT btc.component_hash_id
+      FROM base_type_components btc
+      UNION
+      ( WITH rec AS (
+          SELECT DISTINCT ac.component_hash_id
+          FROM all_components ac
+      )
+          -- recursively union in term dependencies
+          SELECT DISTINCT ref.component_hash_id
+          FROM rec atc
+              -- This joins in ALL the terms from the component, not just the one that caused the dependency on the
+              -- component
+              JOIN terms term ON atc.component_hash_id = term.component_hash_id
+              JOIN term_local_component_references ref ON term.id = ref.term_id
+          UNION
+          -- recursively union in type dependencies
+          SELECT DISTINCT ref.component_hash_id
+          FROM rec atc
+              -- This joins in ALL the types from the component, not just the one that caused the dependency on the
+              -- component
+              JOIN types typ ON atc.component_hash_id = typ.component_hash_id
+              JOIN type_local_component_references ref ON typ.id = ref.type_id
+      )
+  )
+      (SELECT ch.base32 AS hash
+        FROM all_components ac
+          JOIN component_hashes ch ON ac.component_hash_id = ch.id
+      )
+      UNION ALL
+      (SELECT ap.patch_hash AS hash
+        FROM all_patches ap
+      )
+      UNION ALL
+      (SELECT an.namespace_hash AS hash
+        FROM all_namespaces an
+      )
+      UNION ALL
+      (SELECT ac.causal_hash AS hash
+        FROM all_causals ac
+      )
+$$ LANGUAGE SQL;

--- a/sql/2025-01-31_dependencies-of-causal.sql
+++ b/sql/2025-01-31_dependencies-of-causal.sql
@@ -2,7 +2,7 @@
 CREATE OR REPLACE FUNCTION dependencies_of_causals(the_causal_ids INTEGER[]) RETURNS TABLE (hash TEXT) AS $$
   WITH RECURSIVE all_causals(causal_id, causal_hash, causal_namespace_hash_id) AS (
       -- Base causal
-      SELECT causal.id, causal.hash, causal.namespace_hash_id
+      SELECT DISTINCT causal.id, causal.hash, causal.namespace_hash_id
       FROM UNNEST(the_causal_ids) AS causal_id
           JOIN causals causal ON causal.id = causal_id
       UNION

--- a/src/Share/Web/UCM/SyncV2/Queries.hs
+++ b/src/Share/Web/UCM/SyncV2/Queries.hs
@@ -214,7 +214,7 @@ spineAndLibDependenciesOfCausalCursor cid = do
       SELECT ch.causal_id, ROW_NUMBER() OVER () FROM causal_history(#{cid}) AS ch
         WHERE EXISTS (SELECT FROM causal_ownership co WHERE co.user_id = #{ownerUserId} AND co.causal_id = #{cid})
     ), lib_deps(causal_id, ord) AS (
-      SELECT DISTINCT ON (lib_dep.child_causal_id), cs.ord
+      SELECT DISTINCT ON (lib_dep.child_causal_id) lib_dep.child_causal_id, cs.ord
       FROM causal_spine cs
       -- Spinal causal
       -- Root where all library roots are attached

--- a/src/Share/Web/UCM/SyncV2/Queries.hs
+++ b/src/Share/Web/UCM/SyncV2/Queries.hs
@@ -16,173 +16,6 @@ import U.Codebase.Sqlite.TempEntity (TempEntity)
 import Unison.Hash32 (Hash32)
 import Unison.SyncV2.Types (CBORBytes)
 
--- Useful, but needs to be double-checked before use.
--- allHashDependenciesOfCausalCursor :: CausalId -> CodebaseM e (PGCursor Text)
--- allHashDependenciesOfCausalCursor cid = do
---   ownerUserId <- asks codebaseOwner
---   PGCursor.newColCursor
---     "causal_dependencies"
---     [sql|
---         WITH RECURSIVE transitive_causals(causal_id, causal_namespace_hash_id) AS (
---             SELECT causal.id, causal.namespace_hash_id
---             FROM causals causal
---                 WHERE causal.id = #{cid}
---                   AND EXISTS (SELECT FROM causal_ownership co WHERE co.user_id = #{ownerUserId} AND co.causal_id = causal.id)
---             UNION
---             -- This nested CTE is required because RECURSIVE CTEs can't refer
---             -- to the recursive table more than once.
---             ( WITH rec AS (
---                 SELECT causal_id, causal_namespace_hash_id
---                 FROM transitive_causals tc
---             )
---                 SELECT ancestor_causal.id, ancestor_causal.namespace_hash_id
---                 FROM causal_ancestors ca
---                     JOIN rec tc ON ca.causal_id = tc.causal_id
---                     JOIN causals ancestor_causal ON ca.ancestor_id = ancestor_causal.id
---                     -- WHERE NOT EXISTS (SELECT FROM causal_ownership co WHERE co.user_id = to_codebase_user_id AND co.causal_id = ancestor_causal.id)
---                 UNION
---                 SELECT child_causal.id, child_causal.namespace_hash_id
---                 FROM rec tc
---                     JOIN namespace_children nc ON tc.causal_namespace_hash_id = nc.parent_namespace_hash_id
---                     JOIN causals child_causal ON nc.child_causal_id = child_causal.id
---                     -- WHERE NOT EXISTS (SELECT FROM causal_ownership co WHERE co.user_id = to_codebase_user_id AND co.causal_id = child_causal.id)
---             )
---         ), all_namespaces(namespace_hash_id) AS (
---             SELECT DISTINCT causal_namespace_hash_id AS namespace_hash_id
---             FROM transitive_causals
---             -- WHERE NOT EXISTS (SELECT FROM namespace_ownership no WHERE no.user_id = to_codebase_user_id AND no.namespace_hash_id = causal_namespace_hash_id)
---         ), all_patches(patch_id) AS (
---             SELECT DISTINCT patch.id
---             FROM all_namespaces an
---                 JOIN namespace_patches np ON an.namespace_hash_id = np.namespace_hash_id
---                 JOIN patches patch ON np.patch_id = patch.id
---                 -- WHERE NOT EXISTS (SELECT FROM patch_ownership po WHERE po.user_id = to_codebase_user_id AND po.patch_id = patch.id)
---         ),
---         -- term components to start transitively joining dependencies to
---         base_term_components(component_hash_id) AS (
---             SELECT DISTINCT term.component_hash_id
---             FROM all_namespaces an
---                 JOIN namespace_terms nt ON an.namespace_hash_id = nt.namespace_hash_id
---                 JOIN terms term ON nt.term_id = term.id
---                 -- WHERE NOT EXISTS (SELECT FROM sandboxed_terms st WHERE st.user_id = to_codebase_user_id AND st.term_id = term.id)
---             UNION
---             SELECT DISTINCT term.component_hash_id
---             FROM all_patches ap
---                 JOIN patch_term_mappings ptm ON ap.patch_id = ptm.patch_id
---                 JOIN terms term ON ptm.to_term_id = term.id
---                 -- WHERE NOT EXISTS (SELECT FROM sandboxed_terms st WHERE st.user_id = to_codebase_user_id AND st.term_id = term.id)
---             UNION
---             -- term metadata
---             SELECT DISTINCT term.component_hash_id
---             FROM all_namespaces an
---                 JOIN namespace_terms nt ON an.namespace_hash_id = nt.namespace_hash_id
---                 JOIN namespace_term_metadata meta ON nt.id = meta.named_term
---                 JOIN terms term ON meta.metadata_term_id = term.id
---                 -- WHERE NOT EXISTS (SELECT FROM sandboxed_terms st WHERE st.user_id = to_codebase_user_id AND st.term_id = term.id)
---             UNION
---             -- type metadata
---             SELECT DISTINCT term.component_hash_id
---             FROM all_namespaces an
---                 JOIN namespace_types nt ON an.namespace_hash_id = nt.namespace_hash_id
---                 JOIN namespace_type_metadata meta ON nt.id = meta.named_type
---                 JOIN terms term ON meta.metadata_term_id = term.id
---                 -- WHERE NOT EXISTS (SELECT FROM sandboxed_terms st WHERE st.user_id = to_codebase_user_id AND st.term_id = term.id)
---         ),
---         -- type components to start transitively joining dependencies to
---         base_type_components(component_hash_id) AS (
---             SELECT DISTINCT typ.component_hash_id
---             FROM all_namespaces an
---                 JOIN namespace_types nt ON an.namespace_hash_id = nt.namespace_hash_id
---                 JOIN types typ ON nt.type_id = typ.id
---                 -- WHERE NOT EXISTS (SELECT FROM sandboxed_types st WHERE st.user_id = to_codebase_user_id AND st.type_id = typ.id)
---             UNION
---             SELECT DISTINCT typ.component_hash_id
---             FROM all_namespaces an
---                 JOIN namespace_terms nt ON an.namespace_hash_id = nt.namespace_hash_id
---                 JOIN constructors con ON nt.constructor_id = con.id
---                 JOIN types typ ON con.type_id = typ.id
---                 -- WHERE NOT EXISTS (SELECT FROM sandboxed_types st WHERE st.user_id = to_codebase_user_id AND st.type_id = typ.id)
---             UNION
---             SELECT DISTINCT typ.component_hash_id
---             FROM all_patches ap
---                 JOIN patch_type_mappings ptm ON ap.patch_id = ptm.patch_id
---                 JOIN types typ ON ptm.to_type_id = typ.id
---                 -- WHERE NOT EXISTS (SELECT FROM sandboxed_types st WHERE st.user_id = to_codebase_user_id AND st.type_id = typ.id)
---             UNION
---             SELECT DISTINCT typ.component_hash_id
---             FROM all_patches ap
---                 JOIN patch_constructor_mappings pcm ON ap.patch_id = pcm.patch_id
---                 JOIN constructors con ON pcm.to_constructor_id = con.id
---                 JOIN types typ ON con.type_id = typ.id
---                 -- WHERE NOT EXISTS (SELECT FROM sandboxed_types st WHERE st.user_id = to_codebase_user_id AND st.type_id = typ.id)
---         ),
---         -- All the dependencies we join in transitively from the known term & type components we depend on.
---         -- Unfortunately it's not possible to know which hashes are terms vs types :'(
---         transitive_components(component_hash_id) AS (
---             SELECT DISTINCT btc.component_hash_id
---             FROM base_term_components btc
---             UNION
---             SELECT DISTINCT btc.component_hash_id
---             FROM base_type_components btc
---             UNION
---             ( WITH rec AS (
---                 SELECT component_hash_id
---                 FROM transitive_components tc
---             )
---                 -- recursively union in term dependencies
---                 SELECT DISTINCT ref.component_hash_id
---                 FROM rec atc
---                     -- This joins in ALL the terms from the component, not just the one that caused the dependency on the
---                     -- component
---                     JOIN terms term ON atc.component_hash_id = term.component_hash_id
---                     JOIN term_local_component_references ref ON term.id = ref.term_id
---                 UNION
---                 -- recursively union in type dependencies
---                 SELECT DISTINCT ref.component_hash_id
---                 FROM rec atc
---                     -- This joins in ALL the types from the component, not just the one that caused the dependency on the
---                     -- component
---                     JOIN types typ ON atc.component_hash_id = typ.component_hash_id
---                     JOIN type_local_component_references ref ON typ.id = ref.type_id
---             )
---         ), copied_causals(causal_id) AS (
---             SELECT DISTINCT tc.causal_id
---             FROM transitive_causals tc
---         ), copied_namespaces(namespace_hash_id) AS (
---             SELECT DISTINCT an.namespace_hash_id
---             FROM all_namespaces an
---         ), copied_patches(patch_id) AS (
---             SELECT DISTINCT ap.patch_id
---             FROM all_patches ap
---         ), copied_term_components AS (
---                 SELECT DISTINCT term.id, copy.bytes_id
---                 FROM transitive_components tc
---                     JOIN terms term ON tc.component_hash_id = term.component_hash_id
---                     JOIN sandboxed_terms copy ON term.id = copy.term_id
---                     WHERE copy.user_id = #{ownerUserId}
---         ), copied_type_components AS (
---                 SELECT DISTINCT typ.id, copy.bytes_id
---                 FROM transitive_components tc
---                     JOIN types typ ON tc.component_hash_id = typ.component_hash_id
---                     JOIN sandboxed_types copy ON typ.id = copy.type_id
---                     WHERE copy.user_id = #{ownerUserId}
---         ) SELECT causal.hash
---              FROM copied_causals cc
---                JOIN causals causal ON cc.causal_id = causal.id
---            UNION ALL
---            SELECT branch_hashes.base32
---              FROM copied_namespaces cn
---                JOIN branch_hashes ON cn.namespace_hash_id = branch_hashes.id
---            UNION ALL
---            SELECT patch.hash
---              FROM copied_patches cp
---                JOIN patches patch ON cp.patch_id = patch.id
---            UNION ALL
---            SELECT component_hashes.base32
---              FROM transitive_components tc
---                JOIN component_hashes ON tc.component_hash_id = component_hashes.id
---   |]
-
 allSerializedDependenciesOfCausalCursor :: CausalId -> Set CausalHash -> CodebaseM e (PGCursor (CBORBytes TempEntity, Hash32))
 allSerializedDependenciesOfCausalCursor cid exceptCausalHashes = do
   ownerUserId <- asks codebaseOwner
@@ -374,38 +207,31 @@ spineAndLibDependenciesOfCausalCursor cid = do
   PGCursor.newRowCursor
     "causal_dependencies"
     [sql|
-    -- is_lib_causal indicates the causal itself is the library, whereas is_lib_root indicates
-    -- the causal is the root of a library INSIDE 'lib'
-        WITH RECURSIVE transitive_causals(causal_id, causal_hash, causal_namespace_hash_id, is_spine, is_lib_causal, is_lib_root) AS (
-            SELECT causal.id, causal.hash, causal.namespace_hash_id, true AS is_spine, false AS is_lib_causal, false AS is_lib_root
-            FROM causals causal
-                WHERE causal.id = #{cid}
-                  AND EXISTS (SELECT FROM causal_ownership co WHERE co.user_id = #{ownerUserId} AND co.causal_id = causal.id)
-            UNION
-            -- This nested CTE is required because RECURSIVE CTEs can't refer
-            -- to the recursive table more than once.
-            ( WITH rec AS (
-                SELECT tc.causal_id, tc.causal_namespace_hash_id, tc.is_spine, tc.is_lib_causal, tc.is_lib_root
-                FROM transitive_causals tc
-            )
-                SELECT ancestor_causal.id, ancestor_causal.hash, ancestor_causal.namespace_hash_id, rec.is_spine, rec.is_lib_causal, rec.is_lib_root
-                FROM causal_ancestors ca
-                    JOIN rec ON ca.causal_id = rec.causal_id
-                    JOIN causals ancestor_causal ON ca.ancestor_id = ancestor_causal.id
-                    -- Only get the history of the top level spine
-                    WHERE rec.is_spine
-                UNION
-                SELECT child_causal.id, child_causal.hash, child_causal.namespace_hash_id, false AS is_spine, nc.name_segment_id = #{libSegmentTextId} AS is_lib_causal, rec.is_lib_causal AS is_lib_root
-                FROM rec
-                    JOIN namespace_children nc ON rec.causal_namespace_hash_id = nc.parent_namespace_hash_id
-                    JOIN causals child_causal ON nc.child_causal_id = child_causal.id
-                    -- Don't sync children of lib roots.
-                    WHERE NOT rec.is_lib_root
-                          AND (nc.name_segment_id = #{libSegmentTextId} OR rec.is_lib_causal))
-            )
-           (SELECT tc.causal_hash, tc.is_spine, tc.is_lib_root
-             FROM transitive_causals tc
-             WHERE tc.is_spine OR tc.is_lib_causal
-           )
+    WITH causal_spine(causal_id, ord) AS (
+      -- Empty OVER clause is valid and just numbers the rows in the order they come back,
+      -- which is what we want in this case.
+      -- Perhaps we can use a proper order-by on causal depth once that's available.
+      SELECT ch.causal_id, ROW_NUMBER() OVER () FROM causal_history(#{cid}) AS ch
+        WHERE EXISTS (SELECT FROM causal_ownership co WHERE co.user_id = #{ownerUserId} AND co.causal_id = #{cid})
+    ), lib_deps(causal_id, ord) AS (
+      SELECT DISTINCT ON (lib_dep.child_causal_id), cs.ord
+      FROM causal_spine cs
+      -- Spinal causal
+      -- Root where all library roots are attached
+        JOIN causals spine_causal ON spine_causal.id = cs.causal_id
+      -- The actual library dependency children
+        JOIN namespace_children lib_root_ns ON spine_causal.namespace_hash_id = lib_root_ns.parent_namespace_hash_id
+        JOIN causals lib_root_causal ON lib_root_ns.child_causal_id = lib_root_causal.id
+        JOIN namespace_children lib_dep ON lib_root_causal.namespace_hash_id = lib_dep.parent_namespace_hash_id
+        WHERE lib_root_ns.name_segment_id = #{libSegmentTextId}
+        ORDER BY lib_dep.child_causal_id, cs.ord ASC
+    )   SELECT c.hash AS hash, true AS is_spine, false AS is_lib, cs.ord AS ord
+          FROM causal_spine cs
+          JOIN causals c ON cs.causal_id = c.id
+        UNION
+        SELECT c.hash AS hash, false AS is_spine, true AS is_lib, ld.ord AS ord
+          FROM lib_deps ld
+          JOIN causals c ON ld.causal_id = c.id
+      ORDER BY ord ASC, is_lib ASC, is_spine ASC
   |]
     <&> fmap (\(hash, isSpine, isLibRoot) -> (hash, if isSpine then IsCausalSpine else NotCausalSpine, if isLibRoot then IsLibRoot else NotLibRoot))

--- a/src/Share/Web/UCM/SyncV2/Types.hs
+++ b/src/Share/Web/UCM/SyncV2/Types.hs
@@ -1,0 +1,13 @@
+module Share.Web.UCM.SyncV2.Types
+  ( IsLibRoot (..),
+    IsCausalSpine (..),
+  )
+where
+
+data IsLibRoot
+  = IsLibRoot
+  | NotLibRoot
+
+data IsCausalSpine
+  = IsCausalSpine
+  | NotCausalSpine


### PR DESCRIPTION
## Overview

Deployment
* [x]  Run SQL migrations/add new functions.

Adds a simple causal-dependencies API for UCM to determine before a pull which hashes it actually needs.

The causal-dependencies endpoint returns a stream of causals to UCM , each tagged with whether it's part of the top-level history of the root, or whether it's a lib root.

UCM can then pick out which of these dependencies it _does_ have, then send those to the server with the pull.v2 request; where Share will cull entire subtrees based on the dependencies it knows UCM has already.

This allows us to use pull.v2 in cases where it's likely to be a small update.

## Test coverage

I've tested this locally, I'll throw it up on staging and run it through its paces.

Luckily its' back-compatible with the previous syncv2 version, which simply doesn't do the pre-negotiation.

## Loose ends

We may wish to recurse causal-negotiation on lib deps which have missing deps as well. Should be easy enough to include hash-jwts for those;

Or we can do this on the server and include those deps in the initial stream.