### PR TITLE
Definition rendering fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,7 +240,7 @@ jobs:
 
           # Install ucm
           mkdir ucm
-          curl -L https://github.com/unisonweb/unison/releases/download/release%2F0.5.33/ucm-linux.tar.gz | tar -xz -C ucm
+          curl -L https://github.com/unisonweb/unison/releases/download/release%2F0.5.33/ucm-linux-x64.tar.gz | tar -xz -C ucm
           export PATH=$PWD/ucm:$PATH
 
           # Clean up old postgres data if it exists.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,7 +240,7 @@ jobs:
 
           # Install ucm
           mkdir ucm
-          curl -L https://github.com/unisonweb/unison/releases/download/release%2F0.5.25/ucm-linux.tar.gz | tar -xz -C ucm
+          curl -L https://github.com/unisonweb/unison/releases/download/release%2F0.5.33/ucm-linux.tar.gz | tar -xz -C ucm
           export PATH=$PWD/ucm:$PATH
 
           # Clean up old postgres data if it exists.

--- a/src/Share/Postgres/NameLookups/Types.hs
+++ b/src/Share/Postgres/NameLookups/Types.hs
@@ -10,6 +10,7 @@ module Share.Postgres.NameLookups.Types
     NameLookupReceipt (..),
     pathSegmentsToText,
     textToPathSegments,
+    nameToPathSegments,
     reversedNameToNamespaceText,
     reversedNameToPathSegments,
     prefixNamedRef,
@@ -23,6 +24,7 @@ module Share.Postgres.NameLookups.Types
 where
 
 import Control.Lens hiding (from)
+import Data.Foldable qualified as Foldable
 import Data.List.Extra qualified as List
 import Data.List.NonEmpty.Extra qualified as NonEmpty
 import Data.Text qualified as Text
@@ -34,6 +36,7 @@ import Share.Prelude
 import U.Codebase.Referent (ConstructorType)
 import Unison.Name (Name)
 import Unison.Name qualified as Name
+import Unison.NameSegment qualified as NameSegment
 import Unison.NameSegment.Internal (NameSegment (..))
 
 -- | Proof that we've checked that a given name lookup exists before we try to use it.
@@ -123,6 +126,11 @@ type NamespaceText = Text
 -- "base.data.List"
 pathSegmentsToText :: PathSegments -> Text
 pathSegmentsToText (PathSegments txt) = Text.intercalate "." txt
+
+-- >>> nameToPathSegments (Name.fromSegments (NameSegment "base" :| [NameSegment "data", NameSegment "List"]))
+-- PathSegments ["base","data","List"]
+nameToPathSegments :: Name -> PathSegments
+nameToPathSegments name = (PathSegments . Foldable.toList . fmap NameSegment.toUnescapedText $ Name.segments name)
 
 -- |
 -- >>> textToPathSegments "base.data.List"

--- a/transcripts/share-apis/contribution-diffs/contribution-diff.json
+++ b/transcripts/share-apis/contribution-diffs/contribution-diff.json
@@ -99,7 +99,11 @@
                     },
                     {
                       "annotation": null,
-                      "segment": " "
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "  "
                     },
                     {
                       "annotation": {
@@ -197,7 +201,11 @@
                     },
                     {
                       "annotation": null,
-                      "segment": " "
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "  "
                     },
                     {
                       "annotation": {
@@ -295,7 +303,11 @@
                     },
                     {
                       "annotation": null,
-                      "segment": " "
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "  "
                     },
                     {
                       "annotation": {
@@ -397,7 +409,11 @@
                     },
                     {
                       "annotation": null,
-                      "segment": " "
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "  "
                     },
                     {
                       "annotation": {
@@ -494,7 +510,11 @@
                           },
                           {
                             "annotation": null,
-                            "segment": " "
+                            "segment": "\n"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": "  "
                           }
                         ]
                       },
@@ -617,7 +637,11 @@
                       },
                       {
                         "annotation": null,
-                        "segment": " "
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "  "
                       },
                       {
                         "annotation": {
@@ -704,7 +728,11 @@
                       },
                       {
                         "annotation": null,
-                        "segment": " "
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "  "
                       },
                       {
                         "annotation": {

--- a/transcripts/share-apis/contribution-diffs/namespace-diff.json
+++ b/transcripts/share-apis/contribution-diffs/namespace-diff.json
@@ -99,7 +99,11 @@
                     },
                     {
                       "annotation": null,
-                      "segment": " "
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "  "
                     },
                     {
                       "annotation": {
@@ -197,7 +201,11 @@
                     },
                     {
                       "annotation": null,
-                      "segment": " "
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "  "
                     },
                     {
                       "annotation": {
@@ -295,7 +303,11 @@
                     },
                     {
                       "annotation": null,
-                      "segment": " "
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "  "
                     },
                     {
                       "annotation": {
@@ -397,7 +409,11 @@
                     },
                     {
                       "annotation": null,
-                      "segment": " "
+                      "segment": "\n"
+                    },
+                    {
+                      "annotation": null,
+                      "segment": "  "
                     },
                     {
                       "annotation": {
@@ -494,7 +510,11 @@
                           },
                           {
                             "annotation": null,
-                            "segment": " "
+                            "segment": "\n"
+                          },
+                          {
+                            "annotation": null,
+                            "segment": "  "
                           }
                         ]
                       },
@@ -617,7 +637,11 @@
                       },
                       {
                         "annotation": null,
-                        "segment": " "
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "  "
                       },
                       {
                         "annotation": {
@@ -704,7 +728,11 @@
                       },
                       {
                         "annotation": null,
-                        "segment": " "
+                        "segment": "\n"
+                      },
+                      {
+                        "annotation": null,
+                        "segment": "  "
                       },
                       {
                         "annotation": {

--- a/transcripts/share-apis/contribution-merge/contribution-setup.output.md
+++ b/transcripts/share-apis/contribution-merge/contribution-setup.output.md
@@ -1,6 +1,12 @@
 Add a change to a contributor branch, based on the main branch.
 
-``` unison
+``` ucm :hide
+scratch/main> clone @transcripts/merge/main
+
+@transcripts/merge/main> branch @test/fast-forward-feature
+```
+
+``` unison :hide
 term = "feature"
 ```
 
@@ -8,9 +14,6 @@ Push the feature branch.
 
 ``` ucm
 @transcripts/merge/@test/fast-forward-feature> update
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
 
   Done.
 
@@ -22,5 +25,4 @@ Push the feature branch.
   on http://localhost:5424
 
   View it here: @transcripts/merge/@test/fast-forward-feature on http://localhost:5424
-
 ```

--- a/transcripts/share-apis/contribution-merge/project-setup.output.md
+++ b/transcripts/share-apis/contribution-merge/project-setup.output.md
@@ -1,6 +1,10 @@
+``` ucm :hide
+scratch/main> project.create-empty merge
+```
+
 Create a main branch.
 
-``` unison
+``` unison :hide
 term = "start"
 ```
 
@@ -8,9 +12,6 @@ Push it.
 
 ``` ucm
 merge/main> update
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
 
   Done.
 
@@ -21,5 +22,4 @@ merge/main> push @transcripts/merge/main
   I just created @transcripts/merge on http://localhost:5424
 
   View it here: @transcripts/merge/main on http://localhost:5424
-
 ```

--- a/transcripts/share-apis/contribution-merge/pull-after-merge.output.md
+++ b/transcripts/share-apis/contribution-merge/pull-after-merge.output.md
@@ -9,5 +9,4 @@ scratch/main> clone @transcripts/merge/main
 
   term : ##Text
   term = "feature"
-
 ```

--- a/transcripts/share-apis/contributions/contribution-setup.output.md
+++ b/transcripts/share-apis/contributions/contribution-setup.output.md
@@ -7,7 +7,11 @@ Let's set up a main branch with two feature branches:
 
 `main <- feature-one <- feature-two`
 
-``` unison
+``` ucm :hide
+scratch/main> project.create-empty bca-updates
+```
+
+``` unison :hide
 term = "start"
 ```
 
@@ -15,7 +19,7 @@ term = "start"
 bca-updates/main> add
 
   ⍟ I've added these definitions:
-  
+
     term : ##Text
 
 bca-updates/main> push @transcripts/bca-updates/main
@@ -30,20 +34,17 @@ bca-updates/main> push @transcripts/bca-updates/main
 bca-updates/main> branch /feature-one
 
   Done. I've created the feature-one branch based off of main.
-  
+
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /feature-one`.
-
 ```
-``` unison
+
+``` unison :hide
 term = "feature-one"
 ```
 
 ``` ucm
 bca-updates/feature-one> update
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
 
   Done.
 
@@ -60,20 +61,17 @@ bca-updates/feature-one> branch /feature-two
 
   Done. I've created the feature-two branch based off of
   feature-one.
-  
+
   Tip: To merge your work back into the feature-one branch,
        first `switch /feature-one` then `merge /feature-two`.
-
 ```
-``` unison
+
+``` unison :hide
 term = "feature-two"
 ```
 
 ``` ucm
 bca-updates/feature-two> update
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
 
   Done.
 
@@ -85,7 +83,6 @@ bca-updates/feature-two> push @transcripts/bca-updates/feature-two
   http://localhost:5424
 
   View it here: @transcripts/bca-updates/feature-two on http://localhost:5424
-
 ```
-See the script, we will create a contribution, then will merge and push branches to see how things change.
 
+See the script, we will create a contribution, then will merge and push branches to see how things change.

--- a/transcripts/share-apis/contributions/merge-contribution-branches.output.md
+++ b/transcripts/share-apis/contributions/merge-contribution-branches.output.md
@@ -12,6 +12,7 @@ scratch/main> clone @transcripts/bca-updates/feature-one
   Cloned @transcripts/bca-updates/feature-one.
 
 -- Merge the feature branch, then push the merged branch to main
+
 @transcripts/bca-updates/main> merge /feature-one
 
   I fast-forward merged @transcripts/bca-updates/feature-one
@@ -22,5 +23,4 @@ scratch/main> clone @transcripts/bca-updates/feature-one
   Uploaded 1 entities.
 
   View it here: @transcripts/bca-updates/main on http://localhost:5424
-
 ```

--- a/transcripts/share-apis/definition-diffs/standard-ability-diff.json
+++ b/transcripts/share-apis/definition-diffs/standard-ability-diff.json
@@ -52,7 +52,11 @@
             },
             {
               "annotation": null,
-              "segment": " "
+              "segment": "\n"
+            },
+            {
+              "annotation": null,
+              "segment": "  "
             }
           ]
         },
@@ -221,7 +225,11 @@
           },
           {
             "annotation": null,
-            "segment": " "
+            "segment": "\n"
+          },
+          {
+            "annotation": null,
+            "segment": "  "
           },
           {
             "annotation": {
@@ -326,7 +334,11 @@
           },
           {
             "annotation": null,
-            "segment": " "
+            "segment": "\n"
+          },
+          {
+            "annotation": null,
+            "segment": "  "
           },
           {
             "annotation": {

--- a/transcripts/sync-apis/pull-without-history.output.md
+++ b/transcripts/sync-apis/pull-without-history.output.md
@@ -2,19 +2,18 @@
 x = 1
 ```
 
-``` ucm
-
+``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
-  
+
     ⍟ These new definitions are ok to `add`:
     
       x : ##Nat
-
 ```
+
 Create a project, add some history, then push it.
 
 ``` ucm
@@ -25,19 +24,19 @@ scratch/main> project.create-empty myproject
   🎨 Type `ui` to explore this project's code in your browser.
   🔭 Discover libraries at https://share.unison-lang.org
   📖 Use `help-topic projects` to learn more about projects.
-  
+
   Write your first Unison code with UCM:
-  
+
     1. Open scratch.u.
     2. Write some Unison code and save the file.
     3. In UCM, type `add` to save it to your new project.
-  
+
   🎉 🥳 Happy coding!
 
 myproject/main> add
 
   ⍟ I've added these definitions:
-  
+
     x : ##Nat
 
 myproject/main> move.term x y
@@ -52,21 +51,21 @@ myproject/main> history
 
   Note: The most recent namespace hash is immediately below this
         message.
-  
+
   ⊙ 1. #leqcfs7jl2
-  
+
     > Moves:
     
       Original name New name
       y             z
-  
+
   ⊙ 2. #8p3ptealk8
-  
+
     > Moves:
     
       Original name New name
       x             y
-  
+
   □ 3. #i52j9fd57b (start of history)
 
 myproject/main> push
@@ -80,7 +79,7 @@ myproject/main> push
 myproject/main> branch.create-empty dest
 
   Done. I've created an empty branch myproject/dest.
-  
+
   Tip: Use `merge /somebranch` to initialize this branch.
 
 myproject/dest> pull.without-history @transcripts/myproject/main
@@ -88,7 +87,7 @@ myproject/dest> pull.without-history @transcripts/myproject/main
   Downloaded 1 entities.
 
   ✅
-  
+
   Successfully updated myproject/dest from
   @transcripts/myproject/main.
 
@@ -96,9 +95,8 @@ myproject/dest> history
 
   Note: The most recent namespace hash is immediately below this
         message.
-  
-  
-  
-  □ 1. #gd3audeh9u (start of history)
 
+
+
+  □ 1. #gd3audeh9u (start of history)
 ```

--- a/transcripts/sync-apis/sync.output.md
+++ b/transcripts/sync-apis/sync.output.md
@@ -1,3 +1,9 @@
+``` ucm :hide
+scratch/main> project.create-empty proj
+
+proj/main> builtins.merge
+```
+
 Create some types and values with deep-dependencies and cycles to ensure we have non-trivial components.
 
 ``` unison
@@ -16,14 +22,13 @@ xs = [a, b]
 ys = [!a, !b] :+ 3
 ```
 
-``` ucm
-
+``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
-  
+
     ⍟ These new definitions are ok to `add`:
     
       type A
@@ -32,8 +37,12 @@ ys = [!a, !b] :+ 3
       b  : 'Nat
       xs : ['{g} Nat]
       ys : [Nat]
-
 ```
+
+``` ucm :hide
+proj/main> add
+```
+
 Push and pull it back.
 
 ``` ucm
@@ -48,13 +57,13 @@ proj/main> push @transcripts/proj/main
 proj/main> branch.create-empty pulled
 
   Done. I've created an empty branch proj/pulled.
-  
+
   Tip: Use `merge /somebranch` to initialize this branch.
 
 proj/pulled> pull @transcripts/proj/main
 
   ✅
-  
+
   Successfully pulled into proj/pulled, which was empty.
 
 proj/pulled> ls
@@ -68,9 +77,9 @@ proj/pulled> ls
   7. builtin/ (469 terms, 74 types)
   8. xs       (['{g} Nat])
   9. ys       ([Nat])
-
 ```
-``` unison
+
+``` unison :hide
 newValue = 99
 ```
 
@@ -80,7 +89,7 @@ Do a fast-forward push.
 proj/main> add
 
   ⍟ I've added these definitions:
-  
+
     newValue : Nat
 
 proj/main> push
@@ -88,20 +97,20 @@ proj/main> push
   Uploaded 3 entities.
 
   View it here: @transcripts/proj/main on http://localhost:5424
-
 ```
+
 Do a non-fast-forward push.
 
 ``` ucm
 proj/main> branch /diverge 
 
   Done. I've created the diverge branch based off of main.
-  
+
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /diverge`.
-
 ```
-``` unison
+
+``` unison :hide
 diverge = 100
 ```
 
@@ -109,7 +118,7 @@ diverge = 100
 proj/main> add
 
   ⍟ I've added these definitions:
-  
+
     diverge : Nat
 
 proj/main> push @transcripts/proj/main
@@ -117,28 +126,28 @@ proj/main> push @transcripts/proj/main
   Uploaded 3 entities.
 
   View it here: @transcripts/proj/main on http://localhost:5424
-
 ```
-``` unison
+
+``` unison :hide
 diverge = 200
 ```
 
-``` ucm
+``` ucm :error
 proj/diverge> add
 
   ⍟ I've added these definitions:
-  
+
     diverge : Nat
 
 proj/diverge> push @transcripts/proj/main
 
   @transcripts/proj/main on http://localhost:5424 has some
   history that I don't know about.
-
 ```
+
 Pull to trigger local merge
 
-``` ucm
+``` ucm :error
 proj/diverge> pull @transcripts/proj/main
 
   Merging...
@@ -146,21 +155,21 @@ proj/diverge> pull @transcripts/proj/main
   I couldn't automatically merge remote @transcripts/proj/main
   into proj/diverge. However, I've added the definitions that
   need attention to the top of scratch.u.
-  
+
   When you're done, you can run
-  
+
     merge.commit
-  
+
   to merge your changes back into diverge and delete the
   temporary branch. Or, if you decide to cancel the merge
   instead, you can run
-  
-    delete.branch /merge-remote-main-into-diverge
-  
-  to delete the temporary branch and switch back to diverge.
 
+    delete.branch /merge-remote-main-into-diverge
+
+  to delete the temporary branch and switch back to diverge.
 ```
-``` unison:added-by-ucm scratch.u
+
+``` unison :added-by-ucm scratch.u
 -- proj/diverge
 diverge : Nat
 diverge = 200
@@ -170,4 +179,3 @@ diverge : Nat
 diverge = 100
 
 ```
-

--- a/transcripts/sync-apis/write-other-user-without-permission.output.md
+++ b/transcripts/sync-apis/write-other-user-without-permission.output.md
@@ -1,8 +1,8 @@
-``` unison
+``` unison :hide
 stuff = 300
 ```
 
-``` ucm
+``` ucm :error
 scratch/main> project.create-empty proj
 
   🎉 I've created the project proj.
@@ -10,23 +10,22 @@ scratch/main> project.create-empty proj
   🎨 Type `ui` to explore this project's code in your browser.
   🔭 Discover libraries at https://share.unison-lang.org
   📖 Use `help-topic projects` to learn more about projects.
-  
+
   Write your first Unison code with UCM:
-  
+
     1. Open scratch.u.
     2. Write some Unison code and save the file.
     3. In UCM, type `add` to save it to your new project.
-  
+
   🎉 🥳 Happy coding!
 
 proj/main> add
 
   ⍟ I've added these definitions:
-  
+
     stuff : ##Nat
 
 proj/main> push @test/proj
 
   Unauthorized: Not permitted to create this project
-
 ```


### PR DESCRIPTION
## Overview

Share wouldn't find docs for definitions in Lib if they were linked via a hash, this fixes that.

Also, use suffixified names for self-references in types and abilities

Also, render abilities on two lines, always.

## Implementation notes

We first search for the name via the hash, then we re-scope the doc search to wherever the name was found, even if that's in a lib.

Also updates the ucm version used in CI and updates transcripts to match.

## Test coverage

* tested locally
