### PR TITLE
Add UserID to search results

### DIFF
--- a/src/Share/Web/Share/Impl.hs
+++ b/src/Share/Web/Share/Impl.hs
@@ -35,6 +35,7 @@ import Share.Utils.API
 import Share.Utils.Caching
 import Share.Utils.Logging qualified as Logging
 import Share.Utils.Servant.Cookies qualified as Cookies
+import Share.Utils.URI (URIParam (..))
 import Share.Web.App
 import Share.Web.Authentication qualified as AuthN
 import Share.Web.Authorization qualified as AuthZ
@@ -363,8 +364,8 @@ searchEndpoint (MaybeAuthedUserID callerUserId) (Query query) (fromMaybe (Limit 
     pure (users, projects)
   let userResults =
         users
-          <&> \User {user_name, avatar_url, handle} ->
-            SearchResultUser handle user_name avatar_url
+          <&> \User {user_name = name, avatar_url = avatarUrl, handle, user_id = userId} ->
+            SearchResultUser (UserDisplayInfo {handle, name, avatarUrl = unpackURI <$> avatarUrl, userId})
   let projectResults =
         projects
           <&> \(Project {slug, summary, visibility}, ownerHandle) ->

--- a/src/Share/Web/Share/Types.hs
+++ b/src/Share/Web/Share/Types.hs
@@ -89,19 +89,19 @@ instance ToJSON DocResponse where
       ]
 
 data SearchResult
-  = -- | handle displayName avatarUrl
-    SearchResultUser UserHandle (Maybe Text) (Maybe URIParam)
+  = SearchResultUser UserDisplayInfo
   | -- | shorthand summary visibility
     SearchResultProject ProjectShortHand (Maybe Text) ProjectVisibility
   deriving (Show)
 
 instance ToJSON SearchResult where
   toJSON = \case
-    SearchResultUser handle name avatarUrl ->
+    SearchResultUser (UserDisplayInfo {handle, name, avatarUrl, userId}) ->
       Aeson.object
         [ "handle" .= fromId @UserHandle @Text handle,
           "name" .= name,
           "avatarUrl" .= avatarUrl,
+          "userId" .= userId,
           "tag" .= ("User" :: Text)
         ]
     SearchResultProject shorthand summary visibility ->

--- a/src/Share/Web/Share/Types.hs
+++ b/src/Share/Web/Share/Types.hs
@@ -156,8 +156,7 @@ instance ToJSON UserDisplayInfo where
         "userId" Aeson..= userId
       ]
 
-data DefinitionNameSearchResult
-  = DefinitionNameSearchResult
+data DefinitionNameSearchResult = DefinitionNameSearchResult
   { token :: Name,
     tag :: TermOrTypeTag
   }
@@ -179,8 +178,7 @@ instance ToJSON DefinitionSearchResults where
       [ "results" .= results
       ]
 
-data DefinitionSearchResult
-  = DefinitionSearchResult
+data DefinitionSearchResult = DefinitionSearchResult
   { fqn :: Name,
     summary :: DefSync.TermOrTypeSummary,
     project :: ProjectShortHand,

--- a/transcripts/run-transcripts.zsh
+++ b/transcripts/run-transcripts.zsh
@@ -2,6 +2,8 @@
 
 set -e
 
+unset UNISON_SYNC_VERSION
+
 while ! (  curl http://localhost:5424/health > /dev/null 2> /dev/null )  do \
     echo "Waiting for share server to come up, did you run 'make serve'?"; \
     sleep 1; \

--- a/transcripts/share-apis/code-browse/account.json
+++ b/transcripts/share-apis/code-browse/account.json
@@ -8,7 +8,11 @@
       "unison"
     ],
     "primaryEmail": "transcripts@example.com",
-    "userId": "U-43efd5e7-139a-40b2-8a35-3f99b054dc84"
+    "userId": "U-<UUID>"
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-browse.json
+++ b/transcripts/share-apis/code-browse/codebase-browse.json
@@ -128,5 +128,9 @@
     "namespaceListingFQN": "names",
     "namespaceListingHash": "#77bp25t820hpn7t6andan3evac2o5gon8ulggl3kq2galktlbo10jkpub3rli3teop6h5ikgjhuirk87hf58g7cir4pk0ra6a9r5rro"
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-definition-by-hash-constructor.json
+++ b/transcripts/share-apis/code-browse/codebase-definition-by-hash-constructor.json
@@ -71,5 +71,9 @@
       }
     }
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-definition-by-hash-term.json
+++ b/transcripts/share-apis/code-browse/codebase-definition-by-hash-term.json
@@ -80,5 +80,9 @@
     },
     "typeDefinitions": {}
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-definition-by-name-encoded.json
+++ b/transcripts/share-apis/code-browse/codebase-definition-by-name-encoded.json
@@ -190,5 +190,9 @@
     },
     "typeDefinitions": {}
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-definition-by-name-should-minimally-suffix-again.json
+++ b/transcripts/share-apis/code-browse/codebase-definition-by-name-should-minimally-suffix-again.json
@@ -80,5 +80,9 @@
     },
     "typeDefinitions": {}
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-definition-by-name-should-minimally-suffix.json
+++ b/transcripts/share-apis/code-browse/codebase-definition-by-name-should-minimally-suffix.json
@@ -80,5 +80,9 @@
     },
     "typeDefinitions": {}
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-definition-by-name-should-not-find-names-in-other-namespaces.json
+++ b/transcripts/share-apis/code-browse/codebase-definition-by-name-should-not-find-names-in-other-namespaces.json
@@ -6,5 +6,9 @@
     "termDefinitions": {},
     "typeDefinitions": {}
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-definition-by-name-should-pretty-print-external-names-if-no-local-name.json
+++ b/transcripts/share-apis/code-browse/codebase-definition-by-name-should-pretty-print-external-names-if-no-local-name.json
@@ -156,5 +156,9 @@
     },
     "typeDefinitions": {}
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-definition-by-name-should-work-with-empty-perspective.json
+++ b/transcripts/share-apis/code-browse/codebase-definition-by-name-should-work-with-empty-perspective.json
@@ -80,5 +80,9 @@
     },
     "typeDefinitions": {}
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-definition-by-name.json
+++ b/transcripts/share-apis/code-browse/codebase-definition-by-name.json
@@ -134,5 +134,9 @@
     },
     "typeDefinitions": {}
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-find.json
+++ b/transcripts/share-apis/code-browse/codebase-find.json
@@ -50,5 +50,9 @@
       }
     ]
   ],
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-namespace-by-name-root.json
+++ b/transcripts/share-apis/code-browse/codebase-namespace-by-name-root.json
@@ -4,5 +4,9 @@
     "hash": "#r5v225oed8drb36fume3h5uo3bgbg9sbc739u591q8uod3oksi5s0n0si838dkt5smqe3vv1dc9jcibi5jvrbg5c3g9iojd2se5g2h8",
     "readme": null
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/codebase-namespace-by-name.json
+++ b/transcripts/share-apis/code-browse/codebase-namespace-by-name.json
@@ -12,5 +12,9 @@
       "tag": "Paragraph"
     }
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/run.zsh
+++ b/transcripts/share-apis/code-browse/run.zsh
@@ -6,45 +6,19 @@ source "../../transcript_helpers.sh"
 
 transcript_ucm transcript prelude.md
 
-typeset -A tests
-# Add tests here:
-tests=(
-    codebase-browse "/users/transcripts/projects/code-browse/branches/main/browse?namespace=names"
-    codebase-definition-by-name "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/compoundTerm?relativeTo=names.apples"
-    codebase-definition-by-name-encoded "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/%2F%2B%25?relativeTo=names"
-    codebase-definition-by-name-should-not-find-names-in-other-namespaces "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/externalName?relativeTo=names"
-    codebase-definition-by-name-should-work-with-empty-perspective "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/names.oranges.two"
-    codebase-definition-by-name-should-pretty-print-external-names-if-no-local-name "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/referencesExternal?relativeTo=names"
-    codebase-definition-by-name-should-minimally-suffix "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/oranges.two?relativeTo=names"
-    codebase-definition-by-name-should-minimally-suffix-again "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/two?relativeTo=names.apples"
-    codebase-definition-by-hash-term "/users/transcripts/projects/code-browse/branches/main/definitions/by-hash/@dcgdua2lj6upd1ah5v0qp09gjsej0d77d87fu6qn8e2qrssnlnmuinoio46hiu53magr7qn8vnqke8ndt0v76700o5u8gcvo7st28jg"
-    codebase-definition-by-hash-constructor "/users/transcripts/projects/code-browse/branches/main/definitions/by-hash/@6kbe32g06nqg93cqub6ohqc4ql4o49ntgnunifds0t75qre6lacnbsr3evn8bkivj68ecbvmhkbak4dbg4fqertcpgb396rmo34tnh0@d0"
-    codebase-find "/users/transcripts/projects/code-browse/branches/main/find?query=oranges.tw"
-    codebase-namespace-by-name "/users/transcripts/projects/code-browse/branches/main/namespaces/by-name/names"
-    codebase-namespace-by-name-root "/users/transcripts/projects/code-browse/branches/main/namespaces/by-name/"
-    search "/search?query=te"
-    account "/account"
-    user-info "/user-info"
-)
-
-cookie_jar="$(mktemp)"
-
-# Log in to the test user and save the credentials to use in tests.
-echo "/local/user/transcripts/login"
-curl -s --cookie-jar "$cookie_jar" http://localhost:5424/local/user/transcripts/login > /dev/null
-
-exit_code=0
-
-for testname api_path in "${(@kv)tests}"; do
-    echo "${api_path}"
-    url="http://localhost:5424${api_path}"
-    result_file="$(mktemp)"
-    curl -L -s --cookie "$cookie_jar" -H "Accept: application/json" -w '{"status_code":%{http_code}}' "http://localhost:5424${api_path}" > "${result_file}" 
-    jq --sort-keys -s '{"status": .[1].status_code, "body": .[0]}' > "./$testname.json" <"${result_file}" || {
-        echo "Failed to parse json response for ${url}:" 
-        cat "${result_file}" >&2
-        exit_code=1
-    }
-done
-
-exit "$exit_code"
+fetch "$transcript_user" GET codebase-browse "/users/transcripts/projects/code-browse/branches/main/browse?namespace=names"
+fetch "$transcript_user" GET codebase-definition-by-name "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/compoundTerm?relativeTo=names.apples"
+fetch "$transcript_user" GET codebase-definition-by-name-encoded "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/%2F%2B%25?relativeTo=names"
+fetch "$transcript_user" GET codebase-definition-by-name-should-not-find-names-in-other-namespaces "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/externalName?relativeTo=names"
+fetch "$transcript_user" GET codebase-definition-by-name-should-work-with-empty-perspective "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/names.oranges.two"
+fetch "$transcript_user" GET codebase-definition-by-name-should-pretty-print-external-names-if-no-local-name "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/referencesExternal?relativeTo=names"
+fetch "$transcript_user" GET codebase-definition-by-name-should-minimally-suffix "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/oranges.two?relativeTo=names"
+fetch "$transcript_user" GET codebase-definition-by-name-should-minimally-suffix-again "/users/transcripts/projects/code-browse/branches/main/definitions/by-name/two?relativeTo=names.apples"
+fetch "$transcript_user" GET codebase-definition-by-hash-term "/users/transcripts/projects/code-browse/branches/main/definitions/by-hash/@dcgdua2lj6upd1ah5v0qp09gjsej0d77d87fu6qn8e2qrssnlnmuinoio46hiu53magr7qn8vnqke8ndt0v76700o5u8gcvo7st28jg"
+fetch "$transcript_user" GET codebase-definition-by-hash-constructor "/users/transcripts/projects/code-browse/branches/main/definitions/by-hash/@6kbe32g06nqg93cqub6ohqc4ql4o49ntgnunifds0t75qre6lacnbsr3evn8bkivj68ecbvmhkbak4dbg4fqertcpgb396rmo34tnh0@d0"
+fetch "$transcript_user" GET codebase-find "/users/transcripts/projects/code-browse/branches/main/find?query=oranges.tw"
+fetch "$transcript_user" GET codebase-namespace-by-name "/users/transcripts/projects/code-browse/branches/main/namespaces/by-name/names"
+fetch "$transcript_user" GET codebase-namespace-by-name-root "/users/transcripts/projects/code-browse/branches/main/namespaces/by-name/"
+fetch "$transcript_user" GET search "/search?query=te"
+fetch "$transcript_user" GET account "/account"
+fetch "$transcript_user" GET user-info "/user-info"

--- a/transcripts/share-apis/code-browse/search.json
+++ b/transcripts/share-apis/code-browse/search.json
@@ -4,7 +4,8 @@
       "avatarUrl": null,
       "handle": "test",
       "name": null,
-      "tag": "User"
+      "tag": "User",
+      "userId": "U-<UUID>"
     },
     {
       "projectRef": "@test/publictestproject",
@@ -13,5 +14,9 @@
       "visibility": "public"
     }
   ],
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/code-browse/user-info.json
+++ b/transcripts/share-apis/code-browse/user-info.json
@@ -5,7 +5,11 @@
     "name": "Transcript User",
     "picture": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
     "profile": "http://localhost:1234/@transcripts",
-    "sub": "U-43efd5e7-139a-40b2-8a35-3f99b054dc84"
+    "sub": "U-<UUID>"
   },
-  "status": 200
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
 }

--- a/transcripts/share-apis/projects-flow/project-search.json
+++ b/transcripts/share-apis/projects-flow/project-search.json
@@ -4,7 +4,8 @@
       "avatarUrl": null,
       "handle": "test",
       "name": null,
-      "tag": "User"
+      "tag": "User",
+      "userId": "U-<UUID>"
     },
     {
       "projectRef": "@test/publictestproject",


### PR DESCRIPTION
## Overview

In some cases, like granting a user permission to a new repo, it's safest to use a user's UserId rather than their handle, since the user Id is immutable.

To enable this, we provide the UserID in search results alongside the handle, name, and avatar.

## Implementation notes

* Adds the `userId` field to the User search result JSON
* Updates transcripts, and ports the code-browse transcripts to the new format.

## Test coverage

See transcripts
