### PR TITLE
Unify JWT interfaces into a single class

### DIFF
--- a/share-auth/share-auth.cabal
+++ b/share-auth/share-auth.cabal
@@ -25,6 +25,7 @@ source-repository head
 library
   exposed-modules:
       Share.JWT
+      Share.JWT.Types
       Share.OAuth.API
       Share.OAuth.Errors
       Share.OAuth.IdentityProvider.Share

--- a/share-auth/src/Share/JWT.hs
+++ b/share-auth/src/Share/JWT.hs
@@ -2,30 +2,36 @@
 
 -- | This module provides helpers for working with JSON Web Tokens (JWTs).
 module Share.JWT
-  ( JWTSettings,
+  ( -- * App setup
+    JWTSettings,
     defaultJWTSettings,
+
+    -- * Signing keys
     SupportedAlg (..),
     KeyDescription (..),
-    JWTParam (..),
-    StandardClaims (..),
-    ExtendedClaims (..),
-    KeyMap (..),
     KeyThumbprint (..),
+    KeyMap (..),
+    keyDescToJWK,
+    publicJWKSet,
+
+    -- * Claims and converting between types
+    StandardClaims (..),
     JWTClaimsMap,
     AsJWTClaims (..),
     JSONJWTClaims (..),
     addClaim,
     getClaim,
+
+    -- * JWT operations
     signJWT,
     signJWTWithJWK,
     verifyJWT,
-    keyDescToJWK,
 
-    -- * Additional Helpers
+    -- * Utilities
+    JWTParam (..),
     textToSignedJWT,
     signedJWTToText,
     createSignedCookie,
-    publicJWKSet,
 
     -- * Re-exports
     CryptoError (..),

--- a/share-auth/src/Share/JWT.hs
+++ b/share-auth/src/Share/JWT.hs
@@ -7,8 +7,15 @@ module Share.JWT
     SupportedAlg (..),
     KeyDescription (..),
     JWTParam (..),
-    ServantAuth.ToJWT (..),
-    ServantAuth.FromJWT (..),
+    StandardClaims (..),
+    ExtendedClaims (..),
+    KeyMap (..),
+    KeyThumbprint (..),
+    JWTClaimsMap,
+    AsJWTClaims (..),
+    JSONJWTClaims (..),
+    addClaim,
+    getClaim,
     signJWT,
     signJWTWithJWK,
     verifyJWT,
@@ -25,56 +32,29 @@ module Share.JWT
   )
 where
 
-import Control.Applicative (empty)
 import Control.Lens
-import Control.Monad (guard)
 import Control.Monad.Except
 import Crypto.Error (CryptoError (..), CryptoFailable (..))
-import Crypto.JOSE qualified as Jose
 import Crypto.JOSE.JWA.JWS qualified as JWS
 import Crypto.JOSE.JWK qualified as JWK
 import Crypto.JWT qualified as CryptoJWT
 import Crypto.JWT qualified as JWT
 import Crypto.PubKey.Ed25519 qualified as Ed25519
-import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Aeson qualified as Aeson
-import Data.Binary
 import Data.ByteArray qualified as ByteArray
 import Data.ByteString qualified as BS
 import Data.ByteString.Base64.URL qualified as Base64URL
-import Data.List qualified as List
-import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (maybeToList)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
-import Data.Text.Lazy qualified as TL
-import Data.Text.Lazy.Encoding qualified as TL
-import Data.Typeable (Typeable, typeRep)
 import Servant
-import Servant.Auth.Server qualified as ServantAuth
+import Share.JWT.Types
 import Share.OAuth.Orphans ()
 import Share.Utils.Servant.Cookies qualified as Cookies
-import Share.Utils.Show (Censored (..))
 import UnliftIO (MonadIO (..))
-
--- | @JWTSettings@ are used to generate and verify JWTs.
-data JWTSettings = JWTSettings
-  { -- | Key used to sign JWT.
-    signingJWK :: Jose.JWK,
-    -- | Keys used to validate JWT.
-    validationKeys :: KeyMap,
-    -- | An @aud@ predicate. The @aud@ is a string or URI that identifies the
-    -- intended recipient of the JWT.
-    audienceMatches :: JWT.StringOrURI -> Bool,
-    -- | The set of audiences the app accepts tokens for.
-    acceptedAudiences :: Set URI,
-    issuer :: URI
-  }
-  deriving (Show) via Censored JWTSettings
 
 -- | Get the JWK Set value which is safe to expose to the public, e.g. in a JWKS endpoint.
 -- This will only include public keys.
@@ -87,37 +67,6 @@ publicJWKSet JWTSettings {validationKeys = KeyMap {byKeyId}} =
     ( byKeyId
         & foldMap (\jwk -> jwk ^.. JWK.asPublicKey . _Just)
     )
-
-data SupportedAlg = HS256 | Ed25519
-  deriving (Eq, Ord)
-
-data KeyDescription = KeyDescription {alg :: SupportedAlg, key :: BS.ByteString}
-  deriving (Eq, Ord)
-
-newtype KeyThumbprint = KeyThumbprint Text
-  deriving newtype (Eq, Ord)
-
-data KeyMap = KeyMap
-  { byKeyId :: (Map KeyThumbprint JWT.JWK),
-    -- | The key from before the introduction of key ids.
-    -- This will be used to verify legacy tokens, but is also used to sign HashJWTs on share.
-    legacyKey :: Maybe JWT.JWK
-  }
-  deriving (Show) via (Censored KeyMap)
-
--- | This instance is used to look up the verification keys for a given JWT, assuring that the
--- expected algorithm and key id matches.
-instance (Applicative m) => JWT.VerificationKeyStore m (JWT.JWSHeader ()) JWT.ClaimsSet KeyMap where
-  getVerificationKeys header _claims (KeyMap km legacyKey) =
-    case (header ^? JWT.kid . _Just . JWT.param) of
-      Nothing -> pure $ maybeToList legacyKey
-      Just jwtKid -> pure . maybe [] List.singleton $ do
-        let jwtAlg = header ^. JWT.alg . JWT.param
-        case Map.lookup (KeyThumbprint jwtKid) km of
-          Just key | Just (JWT.JWSAlg keyAlg) <- key ^. JWT.jwkAlg -> do
-            guard (keyAlg == jwtAlg)
-            pure key
-          _ -> empty
 
 -- | Create a 'JWTSettings' using the required information.
 defaultJWTSettings ::
@@ -187,49 +136,17 @@ keyDescToJWK (KeyDescription {key, alg}) = cryptoFailableToEither $ do
         & Base64URL.encodeUnpadded
         & Text.decodeUtf8
 
-newtype JWTParam = JWTParam JWT.SignedJWT
-  deriving (Show) via (Censored JWTParam)
-
-instance ToHttpApiData JWTParam where
-  toQueryParam (JWTParam signed) = signedJWTToText signed
-
-instance ToJSON JWTParam where
-  toJSON = Aeson.String . toQueryParam
-
-instance FromHttpApiData JWTParam where
-  parseQueryParam txt = bimap (Text.pack . show) JWTParam $ textToSignedJWT txt
-
-instance FromJSON JWTParam where
-  parseJSON = Aeson.withText "jwt" $ either (fail . Text.unpack) pure . parseQueryParam
-
-instance Binary JWTParam where
-  put = put . toQueryParam
-  get =
-    (parseQueryParam <$> get)
-      >>= ( \case
-              Left err -> fail (Text.unpack err)
-              Right a -> pure a
-          )
-
--- | Encode a signed JWT as text.
-signedJWTToText :: JWT.SignedJWT -> Text
-signedJWTToText =
-  TL.toStrict . TL.decodeUtf8 . JWT.encodeCompact
-
-textToSignedJWT :: Text -> Either JWT.JWTError JWT.SignedJWT
-textToSignedJWT jwtText = JWT.decodeCompact (TL.encodeUtf8 . TL.fromStrict $ jwtText)
-
 -- | Signs and encodes a JWT using the given 'JWTSettings'.
-signJWT :: forall m v. (MonadIO m, ServantAuth.ToJWT v) => JWTSettings -> v -> m (Either JWT.JWTError JWT.SignedJWT)
+signJWT :: forall v m. (MonadIO m, AsJWTClaims v) => JWTSettings -> v -> m (Either JWT.JWTError JWT.SignedJWT)
 signJWT JWTSettings {signingJWK} v = signJWTWithJWK signingJWK v
 
 -- | Signs and encodes a JWT using the given JWK, you should typically use 'signJWT' instead
 -- unless you have a specific reason to use a different JWK.
-signJWTWithJWK :: forall m v. (MonadIO m, ServantAuth.ToJWT v) => JWK.JWK -> v -> m (Either JWT.JWTError JWT.SignedJWT)
+signJWTWithJWK :: forall m v. (MonadIO m, AsJWTClaims v) => JWK.JWK -> v -> m (Either JWT.JWTError JWT.SignedJWT)
 signJWTWithJWK jwk v = runExceptT $ do
-  let claimsSet = ServantAuth.encodeJWT v
   jwtHeader <- mapExceptT liftIO (JWT.makeJWSHeader jwk)
-  mapExceptT liftIO (JWT.signClaims jwk jwtHeader claimsSet)
+  let claimsJSON = Aeson.toJSON (toClaims v)
+  mapExceptT liftIO (JWT.signJWT jwk jwtHeader claimsJSON)
 
 -- | Decodes a JWT and verifies the following:
 -- * algorithm (except for legacy tokens)
@@ -240,14 +157,12 @@ signJWTWithJWK jwk v = runExceptT $ do
 -- * signature
 --
 -- Any other checks should be performed on the returned claims.
-verifyJWT :: forall claims m. (Typeable claims, MonadIO m, ServantAuth.FromJWT claims) => JWTSettings -> JWT.SignedJWT -> m (Either JWT.JWTError claims)
-verifyJWT JWTSettings {validationKeys, issuer, acceptedAudiences} signedJWT = do
-  result :: Either JWT.JWTError JWT.ClaimsSet <- liftIO . runExceptT $ JWT.verifyClaims validators validationKeys signedJWT
-  pure $ do
-    claimsSet <- result
-    case ServantAuth.decodeJWT claimsSet of
-      Left err -> Left . JWT.JWTClaimsSetDecodeError $ "Failed to decode " <> show (typeRep (Proxy @claims)) <> ": " <> Text.unpack err
-      Right claims -> Right claims
+verifyJWT :: forall claims m. (AsJWTClaims claims, MonadIO m) => JWTSettings -> JWT.SignedJWT -> m (Either JWT.JWTError claims)
+verifyJWT JWTSettings {validationKeys, issuer, acceptedAudiences} signedJWT = runExceptT do
+  jwtClaimsMap <- ExceptT . liftIO . runExceptT $ JWT.verifyJWT validators validationKeys signedJWT
+  case fromClaims jwtClaimsMap of
+    Left err -> throwError $ JWT.JWTClaimsSetDecodeError (Text.unpack err)
+    Right claims -> pure claims
   where
     auds :: [CryptoJWT.StringOrURI]
     auds =
@@ -263,8 +178,8 @@ verifyJWT JWTSettings {validationKeys, issuer, acceptedAudiences} signedJWT = do
                  & CryptoJWT.validationSettingsAlgorithms .~ Set.fromList [JWS.HS256, JWS.EdDSA]
              )
 
--- | Create a signed session cookie using a ToJWT instance.
-createSignedCookie :: (MonadIO m, ServantAuth.ToJWT session) => JWTSettings -> Cookies.CookieSettings -> Text -> session -> m (Either JWT.JWTError Cookies.SetCookie)
+-- | Create a signed session cookie using a ToJSON instance.
+createSignedCookie :: (MonadIO m, AsJWTClaims session) => JWTSettings -> Cookies.CookieSettings -> Text -> session -> m (Either JWT.JWTError Cookies.SetCookie)
 createSignedCookie jwtSettings cookieSettings sessionName value = runExceptT do
   signedJWT <- ExceptT (signJWT jwtSettings value)
   pure $ Cookies.newSetCookie cookieSettings sessionName (signedJWTToText signedJWT)

--- a/share-auth/src/Share/JWT/Types.hs
+++ b/share-auth/src/Share/JWT/Types.hs
@@ -1,0 +1,276 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Share.JWT.Types
+  ( JWTParam (..),
+    JWTSettings (..),
+    StandardClaims (..),
+    ExtendedClaims (..),
+    SupportedAlg (..),
+    KeyDescription (..),
+    KeyMap (..),
+    KeyThumbprint (..),
+    JWTClaimsMap,
+    AsJWTClaims (..),
+    JSONJWTClaims (..),
+    addClaim,
+    getClaim,
+    signedJWTToText,
+    textToSignedJWT,
+  )
+where
+
+import Control.Applicative
+import Control.Lens
+import Control.Monad
+import Crypto.JOSE qualified as Jose
+import Crypto.JWT (HasClaimsSet)
+import Crypto.JWT qualified as JWT
+import Data.Aeson (FromJSON, ToJSON (..))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Aeson.Lens
+import Data.Aeson.Types (FromJSON (..))
+import Data.Binary
+import Data.ByteString qualified as BS
+import Data.List qualified as List
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Set.Lens (setOf)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Lazy qualified as TL
+import Data.Text.Lazy.Encoding qualified as TL
+import Data.Time (UTCTime)
+import Network.URI qualified as URI
+import Servant
+import Share.Utils.Show (Censored (..))
+import Prelude hiding (exp)
+
+newtype JWTClaimsMap = JWTClaimsMap (Map Text Aeson.Value)
+  deriving newtype (Show, Eq, Ord, ToJSON, FromJSON)
+
+addClaim :: (ToJSON a) => Text -> a -> JWTClaimsMap -> JWTClaimsMap
+addClaim k v (JWTClaimsMap m) = JWTClaimsMap (Map.insert k (Aeson.toJSON v) m)
+
+getClaim :: (FromJSON a) => Text -> JWTClaimsMap -> Either Text a
+getClaim k (JWTClaimsMap m) =
+  case Map.lookup k m of
+    Nothing -> Left $ "Claim not found: " <> k
+    Just v -> case Aeson.fromJSON v of
+      Aeson.Error err -> Left $ "Error decoding claim: " <> Text.pack err
+      Aeson.Success a -> Right a
+
+instance HasClaimsSet JWTClaimsMap where
+  claimsSet = lens getClaims setClaims
+    where
+      setClaims (JWTClaimsMap cm) cs =
+        case Aeson.fromJSON . Aeson.toJSON $ cs of
+          Aeson.Success newMap -> JWTClaimsMap (Map.union newMap cm)
+          Aeson.Error err -> error $ err
+      getClaims cm = do
+        case Aeson.fromJSON $ Aeson.toJSON cm of
+          Aeson.Success a -> a
+          Aeson.Error err -> error $ err
+
+newtype JWTParam = JWTParam JWT.SignedJWT
+  deriving (Show) via (Censored JWTParam)
+
+-- | Encode a signed JWT as text.
+signedJWTToText :: JWT.SignedJWT -> Text
+signedJWTToText =
+  TL.toStrict . TL.decodeUtf8 . JWT.encodeCompact
+
+textToSignedJWT :: Text -> Either JWT.JWTError JWT.SignedJWT
+textToSignedJWT jwtText = JWT.decodeCompact (TL.encodeUtf8 . TL.fromStrict $ jwtText)
+
+-- | @JWTSettings@ are used to generate and verify JWTs.
+data JWTSettings = JWTSettings
+  { -- | Key used to sign JWT.
+    signingJWK :: Jose.JWK,
+    -- | Keys used to validate JWT.
+    validationKeys :: KeyMap,
+    -- | An @aud@ predicate. The @aud@ is a string or URI that identifies the
+    -- intended recipient of the JWT.
+    audienceMatches :: JWT.StringOrURI -> Bool,
+    -- | The set of audiences the app accepts tokens for.
+    acceptedAudiences :: Set URI,
+    issuer :: URI
+  }
+  deriving (Show) via Censored JWTSettings
+
+-- | Helper for working with standard claim sets more easily/without a bunch of Maybes.
+data StandardClaims = StandardClaims
+  { sub :: Text,
+    iat :: UTCTime,
+    exp :: UTCTime,
+    iss :: URI,
+    aud :: Set URI,
+    jti :: Text
+  }
+  deriving stock (Show, Eq, Ord)
+
+instance HasClaimsSet StandardClaims where
+  claimsSet = lens standardClaimsToClaimsSet (\_ claims -> either (\err -> error $ "Invalid claims set: " <> Text.unpack err) id $ standardClaimsFromClaimsSet claims)
+
+instance AsJWTClaims StandardClaims where
+  toClaims = toClaims . standardClaimsToClaimsSet
+  fromClaims c = do
+    cs <- fromClaims @JWT.ClaimsSet c
+    standardClaimsFromClaimsSet cs
+
+standardClaimsToClaimsSet :: StandardClaims -> JWT.ClaimsSet
+standardClaimsToClaimsSet StandardClaims {..} =
+  JWT.emptyClaimsSet
+    & JWT.claimSub ?~ (JWT.string # sub)
+    & JWT.claimIat ?~ JWT.NumericDate iat
+    & JWT.claimExp ?~ JWT.NumericDate exp
+    & JWT.claimIss ?~ (JWT.uri # iss)
+    & JWT.claimAud ?~ JWT.Audience (review JWT.uri <$> Set.toList aud)
+    & JWT.claimJti ?~ jti
+
+standardClaimsFromClaimsSet :: JWT.ClaimsSet -> Either Text StandardClaims
+standardClaimsFromClaimsSet claims = do
+  sub <- maybe (Left "Invalid 'sub' claim.") Right $ (claims ^? JWT.claimSub . _Just . JWT.string)
+  JWT.NumericDate iat <- maybe (Left "Invalid 'iat' claim.") Right $ (claims ^? JWT.claimIat . _Just)
+  JWT.NumericDate exp <- maybe (Left "Invalid 'exp' claim.") Right $ (claims ^? JWT.claimExp . _Just)
+  iss <- maybe (Left "Invalid 'iss' claim.") Right $ (claims ^? JWT.claimIss . _Just . re JWT.stringOrUri . folding URI.parseURI)
+  let aud = (claims & setOf (JWT.claimAud . _Just . folding (\(JWT.Audience auds) -> auds) . JWT.uri))
+  when (null aud) $ Left "Invalid 'aud' claim."
+  jti <- maybe (Left "Invalid 'jti' claim.") Right $ (claims ^? JWT.claimJti . _Just)
+  pure StandardClaims {..}
+
+instance ToJSON StandardClaims where
+  toJSON sc = toJSON (standardClaimsToClaimsSet sc)
+
+instance FromJSON StandardClaims where
+  parseJSON v = do
+    cs <- parseJSON @JWT.ClaimsSet v
+    either (fail . Text.unpack) pure $ standardClaimsFromClaimsSet cs
+
+-- | All of the ToJWT/FromJWT and HasClaimsSet instances are confusing, complex, and error
+-- prone, so instead of worrying about those we just use this type which is tougher to screw
+-- up.
+--
+-- Specify the standard JWT claims using the 'StandardClaims' field, and any additional claims
+-- using the 'additionalClaims' field via the JSON instances on this type.
+data ExtendedClaims a = ExtendedClaims
+  { standardClaims :: JWT.ClaimsSet,
+    additionalClaims :: Maybe a
+  }
+  deriving stock (Show, Eq)
+
+instance HasClaimsSet (ExtendedClaims a) where
+  claimsSet = lens (\ExtendedClaims {standardClaims} -> standardClaims) (\ec claims -> ec {standardClaims = claims})
+
+instance (ToJSON a) => ToJSON (ExtendedClaims a) where
+  toJSON (ExtendedClaims {standardClaims, additionalClaims}) =
+    case additionalClaims of
+      Nothing -> toJSON (standardClaims ^. JWT.claimsSet)
+      Just additionalClaims' ->
+        case toJSON additionalClaims' ^? _Object of
+          Nothing -> error "Additional claims must be an object."
+          Just additionalClaimsMap ->
+            (toJSON (standardClaims ^. JWT.claimsSet))
+              & _Object
+                %~ ( KeyMap.unionWithKey (\k _ _ -> error $ "Duplicate key when encoding ExtendedClaims: " <> show k) additionalClaimsMap
+                   )
+
+instance (FromJSON a) => FromJSON (ExtendedClaims a) where
+  parseJSON v = do
+    standardClaims <- Aeson.parseJSON v
+    additionalClaims <- Aeson.parseJSON v
+    pure ExtendedClaims {..}
+
+data SupportedAlg = HS256 | Ed25519
+  deriving (Eq, Ord)
+
+data KeyDescription = KeyDescription {alg :: SupportedAlg, key :: BS.ByteString}
+  deriving (Eq, Ord)
+
+newtype KeyThumbprint = KeyThumbprint Text
+  deriving newtype (Eq, Ord)
+
+data KeyMap = KeyMap
+  { byKeyId :: (Map KeyThumbprint JWT.JWK),
+    -- | The key from before the introduction of key ids.
+    -- This will be used to verify legacy tokens, but is also used to sign HashJWTs on share.
+    legacyKey :: Maybe JWT.JWK
+  }
+  deriving (Show) via (Censored KeyMap)
+
+-- | This instance is used to look up the verification keys for a given JWT, assuring that the
+-- expected algorithm and key id matches.
+instance (Applicative m) => JWT.VerificationKeyStore m (JWT.JWSHeader ()) payload KeyMap where
+  getVerificationKeys header _claims (KeyMap km legacyKey) =
+    case (header ^? JWT.kid . _Just . JWT.param) of
+      Nothing -> pure $ maybeToList legacyKey
+      Just jwtKid -> pure . maybe [] List.singleton $ do
+        let jwtAlg = header ^. JWT.alg . JWT.param
+        case Map.lookup (KeyThumbprint jwtKid) km of
+          Just key | Just (JWT.JWSAlg keyAlg) <- key ^. JWT.jwkAlg -> do
+            guard (keyAlg == jwtAlg)
+            pure key
+          _ -> empty
+
+instance ToHttpApiData JWTParam where
+  toQueryParam (JWTParam signed) = signedJWTToText signed
+
+instance ToJSON JWTParam where
+  toJSON = Aeson.String . toQueryParam
+
+instance FromHttpApiData JWTParam where
+  parseQueryParam txt = bimap (Text.pack . show) JWTParam $ textToSignedJWT txt
+
+instance FromJSON JWTParam where
+  parseJSON = Aeson.withText "jwt" $ either (fail . Text.unpack) pure . parseQueryParam
+
+instance Binary JWTParam where
+  put = put . toQueryParam
+  get =
+    (parseQueryParam <$> get)
+      >>= ( \case
+              Left err -> fail (Text.unpack err)
+              Right a -> pure a
+          )
+
+-- | Class for converting a data type to/from a JWT claims map.
+class AsJWTClaims a where
+  toClaims :: a -> JWTClaimsMap
+  fromClaims :: JWTClaimsMap -> Either Text a
+
+-- | Newtype for deriving AsJWTClaims instances for types that have ToJSON/FromJSON instances
+-- using 'deriving via JSONJWTClaims Foo'
+newtype JSONJWTClaims a = JSONJWTClaims a
+
+instance (ToJSON a, FromJSON a) => AsJWTClaims (JSONJWTClaims a) where
+  toClaims (JSONJWTClaims a) = toClaims . toJSON $ a
+  fromClaims c = do
+    v <- fromClaims c
+    case Aeson.fromJSON v of
+      Aeson.Error err -> Left (Text.pack err)
+      Aeson.Success a -> Right (JSONJWTClaims a)
+
+instance AsJWTClaims Aeson.Value where
+  toClaims = \case
+    Aeson.Object o ->
+      KeyMap.toMap o
+        & Map.mapKeys Key.toText
+        & JWTClaimsMap
+    _ -> error "Expected object."
+  fromClaims (JWTClaimsMap m) =
+    m
+      & Map.mapKeys Key.fromText
+      & KeyMap.fromMap
+      & Aeson.Object
+      & Right
+
+deriving via JSONJWTClaims JWT.ClaimsSet instance AsJWTClaims JWT.ClaimsSet
+
+instance AsJWTClaims JWTClaimsMap where
+  toClaims = id
+  fromClaims = Right

--- a/share-auth/src/Share/OAuth/Session.hs
+++ b/share-auth/src/Share/OAuth/Session.hs
@@ -26,18 +26,14 @@ module Share.OAuth.Session
 where
 
 import Control.Applicative
-import Control.Lens hiding ((:>))
 import Control.Monad.Random
 import Control.Monad.Trans.Maybe (MaybeT (..))
-import Crypto.JWT qualified as JWT
 import Data.Aeson
 import Data.Binary
 import Data.Binary.Instances.Time ()
 import Data.ByteString qualified as BS
 import Data.Kind (Type)
 import Data.Set (Set)
-import Data.Set qualified as Set
-import Data.Set.Lens (setOf)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
@@ -48,7 +44,7 @@ import Network.URI
 import Network.Wai qualified as Wai
 import Servant
 import Servant.Server.Experimental.Auth qualified as ServantAuth
-import Share.JWT qualified
+import Share.JWT
 import Share.OAuth.Types
 import Share.Utils.Binary
 import Share.Utils.IDs qualified as IDs
@@ -219,40 +215,26 @@ data Session = Session
   }
   deriving stock (Show)
   deriving (Binary) via JSONBinary Session
-
-instance Share.JWT.ToJWT Session where
-  encodeJWT (Session (SessionId sessionId) userID created expiry issuer aud) =
-    JWT.emptyClaimsSet
-      & JWT.claimSub ?~ (JWT.string # IDs.toText userID)
-      & JWT.claimJti ?~ IDs.toText (JTI sessionId)
-      & JWT.claimIat ?~ JWT.NumericDate created
-      & JWT.claimExp ?~ JWT.NumericDate expiry
-      & JWT.claimIss ?~ (JWT.uri # issuer)
-      & JWT.claimAud ?~ JWT.Audience (review JWT.uri <$> Set.toList aud)
-
-instance Share.JWT.FromJWT Session where
-  decodeJWT claims = do
-    sessionUserId <- maybeToEither "Missing sub claim" (claims ^? JWT.claimSub . _Just . JWT.string) >>= IDs.fromText
-    sessionId <-
-      maybeToEither "Missing jti claim" (claims ^? JWT.claimJti . _Just) >>= \txt -> do
-        JTI uuid <- IDs.fromText txt
-        pure $ SessionId uuid
-    sessionCreated <- maybeToEither "Missing iat claim" (claims ^? JWT.claimIat . _Just . to (\(JWT.NumericDate utcTime) -> utcTime))
-    sessionExpiry <- maybeToEither "Missing exp claim" (claims ^? JWT.claimExp . _Just . to (\(JWT.NumericDate utcTime) -> utcTime))
-    sessionIssuer <- maybeToEither "Missing iss claim" (claims ^? JWT.claimIss . _Just . JWT.uri)
-    let sessionAudience = claims & setOf (JWT.claimAud . _Just . folding (\(JWT.Audience auds) -> auds) . JWT.uri)
-    pure $ Session {..}
-    where
-      maybeToEither :: e -> Maybe a -> Either e a
-      maybeToEither e = maybe (Left e) Right
+  deriving (AsJWTClaims) via JSONJWTClaims Session
 
 instance ToJSON Session where
-  toJSON s = toJSON $ Share.JWT.encodeJWT s
+  toJSON Session {..} =
+    toJSON $
+      StandardClaims
+        { sub = IDs.toText sessionUserId,
+          iat = sessionCreated,
+          exp = sessionExpiry,
+          iss = sessionIssuer,
+          aud = sessionAudience,
+          jti = IDs.toText sessionId
+        }
 
 instance FromJSON Session where
   parseJSON v = do
-    claims <- parseJSON v
-    either (fail . Text.unpack) pure $ Share.JWT.decodeJWT claims
+    StandardClaims {..} <- parseJSON v
+    sessionId <- either (fail . Text.unpack) pure $ IDs.fromText jti
+    sessionUserId <- either (fail . Text.unpack) pure $ IDs.fromText sub
+    pure Session {sessionId, sessionUserId, sessionCreated = iat, sessionExpiry = exp, sessionIssuer = iss, sessionAudience = aud}
 
 data PendingSession = PendingSession
   { pendingId :: PendingSessionId,

--- a/share-auth/src/Share/OAuth/Types.hs
+++ b/share-auth/src/Share/OAuth/Types.hs
@@ -42,7 +42,7 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Time (NominalDiffTime)
 import Data.UUID (UUID)
-import Share.JWT
+import Share.JWT.Types
 import Share.OAuth.Scopes
 import Share.Utils.Binary (JSONBinary (..))
 import Share.Utils.IDs

--- a/src/Share/NamespaceDiffs.hs
+++ b/src/Share/NamespaceDiffs.hs
@@ -374,7 +374,7 @@ compressNameTree (diffs Cofree.:< children) =
                   (childDiffs Cofree.:< nestedChildren)
                     | null childDiffs,
                       [(k, v)] <- Map.toList nestedChildren ->
-                        (ns Path.:< k, v)
+                        (Path.singleton ns <> k, v)
                     | otherwise ->
                         (Path.singleton ns, child)
             )

--- a/src/Share/Postgres/NameLookups/Ops.hs
+++ b/src/Share/Postgres/NameLookups/Ops.hs
@@ -102,7 +102,7 @@ relocateToNameRoot perspective query rootBh = do
             & Name.segments
             & NonEmpty.init
             & Path.fromList
-        Nothing -> Path.empty
+        Nothing -> mempty
   let fullPath = perspective <> nameLocation
   Debug.debugM Debug.Server "relocateToNameRoot fullPath" fullPath
   namesPerspective@NamesPerspective {relativePerspective} <- namesPerspectiveForRootAndPath rootBh (PathSegments . fmap NameSegment.toUnescapedText . Path.toList $ fullPath)

--- a/src/Share/Web/Authentication/HashJWT.hs
+++ b/src/Share/Web/Authentication/HashJWT.hs
@@ -1,6 +1,7 @@
 module Share.Web.Authentication.HashJWT where
 
 import Crypto.JWT
+import Data.Aeson qualified as Aeson
 import Share.Env qualified as Env
 import Share.JWT qualified as JWT
 import Share.Prelude
@@ -11,6 +12,6 @@ import Unison.Share.API.Hash (HashJWTClaims)
 signHashJWT :: HashJWTClaims -> WebApp SignedJWT
 signHashJWT claims = do
   hashJWTJWK <- asks Env.hashJWTJWK
-  JWT.signJWTWithJWK hashJWTJWK claims >>= \case
+  JWT.signJWTWithJWK hashJWTJWK (Aeson.toJSON claims) >>= \case
     Left err -> respondError (InternalServerError "jwt:signing-error" err)
     Right a -> pure a

--- a/src/Share/Web/Authentication/JWT.hs
+++ b/src/Share/Web/Authentication/JWT.hs
@@ -5,14 +5,9 @@ module Share.Web.Authentication.JWT where
 
 import Control.Lens hiding ((.=))
 import Crypto.JWT
-import Crypto.JWT qualified as JWT
-import Data.Aeson qualified as Aeson
 import Data.Either.Combinators qualified as Either
-import Data.Set qualified as Set
-import Data.Set.Lens (setOf)
-import Data.Time (NominalDiffTime, UTCTime, addUTCTime, getCurrentTime)
+import Data.Time (NominalDiffTime, addUTCTime, getCurrentTime)
 import Network.URI (URI)
-import Network.URI qualified as URI
 import Share.App
 import Share.Env qualified as Env
 import Share.IDs (JTI (..), SessionId (..), UserId (..))
@@ -24,59 +19,15 @@ import Share.Web.App
 import Share.Web.Authentication.Types
 import Share.Web.Errors
 
--- | Helper for working with standard claim sets more easily/without a bunch of Maybes.
-data StandardClaims = StandardClaims
-  { sub :: UserId,
-    iat :: UTCTime,
-    exp :: UTCTime,
-    iss :: URI,
-    aud :: Set URI,
-    jti :: Text
-  }
-  deriving stock (Show, Eq, Ord)
-
-instance JWT.ToJWT StandardClaims where
-  encodeJWT (StandardClaims {sub, iat, exp, iss, aud, jti}) =
-    JWT.emptyClaimsSet
-      & JWT.claimSub ?~ (JWT.string # IDs.toText sub)
-      & JWT.claimIat ?~ JWT.NumericDate iat
-      & JWT.claimExp ?~ JWT.NumericDate exp
-      & JWT.claimIss ?~ (JWT.uri # iss)
-      & JWT.claimAud ?~ JWT.Audience (review JWT.uri <$> Set.toList aud)
-      & JWT.claimJti ?~ jti
-
-instance JWT.FromJWT StandardClaims where
-  decodeJWT claims = do
-    sub <- maybe (Left "Invalid 'sub' claim.") Right $ (claims ^? JWT.claimSub . _Just . JWT.string . folding (IDs.fromText @UserId))
-    JWT.NumericDate iat <- maybe (Left "Invalid 'iat' claim.") Right $ (claims ^? JWT.claimIat . _Just)
-    JWT.NumericDate exp <- maybe (Left "Invalid 'exp' claim.") Right $ (claims ^? JWT.claimExp . _Just)
-    iss <- maybe (Left "Invalid 'iss' claim.") Right $ (claims ^? JWT.claimIss . _Just . re JWT.stringOrUri . folding URI.parseURI)
-    let aud = (claims & setOf (JWT.claimAud . _Just . folding (\(Audience auds) -> auds) . JWT.uri))
-    when (null aud) $ Left "Invalid 'aud' claim."
-    jti <- maybe (Left "Invalid 'jti' claim.") Right $ (claims ^? JWT.claimJti . _Just)
-    pure StandardClaims {..}
-
--- | Encode a JWT from standard claims and additional claims
-encodeStandardClaims :: StandardClaims -> Map Text Aeson.Value -> ClaimsSet
-encodeStandardClaims standardClaims additionalClaims =
-  JWT.encodeJWT standardClaims
-    & JWT.unregisteredClaims .~ additionalClaims
-
-decodeStandardClaims :: ClaimsSet -> Either Text (StandardClaims, Map Text Aeson.Value)
-decodeStandardClaims claims = do
-  standardClaims <- JWT.decodeJWT claims
-  let additionalClaims = claims ^. JWT.unregisteredClaims
-  pure (standardClaims, additionalClaims)
-
-shareStandardClaims :: Set URI -> UserId -> NominalDiffTime -> SessionId -> AppM reqCtx StandardClaims
+shareStandardClaims :: Set URI -> UserId -> NominalDiffTime -> SessionId -> AppM reqCtx JWT.StandardClaims
 shareStandardClaims aud sub ttl (SessionId sessionIdUUID) = do
   let jti = IDs.toText $ JTI sessionIdUUID
   iss <- shareIssuer
   iat <- liftIO getCurrentTime
   let exp = addUTCTime ttl iat
-  pure (StandardClaims {..})
+  pure (JWT.StandardClaims {sub = IDs.toText sub, ..})
 
-signJWT :: (JWT.ToJWT a) => a -> WebApp SignedJWT
+signJWT :: (JWT.AsJWTClaims a) => a -> WebApp SignedJWT
 signJWT claims = do
   jSettings <- asks Env.jwtSettings
   Share.JWT.signJWT jSettings claims >>= \case
@@ -90,7 +41,7 @@ signJWT claims = do
 -- * signature
 --
 -- Any other checks should be performed on the returned claims.
-verifyJWT :: forall claims reqCtx. (JWT.FromJWT claims, Typeable claims) => SignedJWT -> (claims -> Maybe AuthenticationErr) -> AppM reqCtx (Either AuthenticationErr claims)
+verifyJWT :: forall claims reqCtx. (JWT.AsJWTClaims claims) => SignedJWT -> (claims -> Maybe AuthenticationErr) -> AppM reqCtx (Either AuthenticationErr claims)
 verifyJWT signedJWT checks = do
   jwtS <- asks Env.jwtSettings
   Either.mapLeft JWTErr <$> Share.JWT.verifyJWT @claims jwtS signedJWT <&> \case

--- a/src/Share/Web/Share/Branches/Impl.hs
+++ b/src/Share/Web/Share/Branches/Impl.hs
@@ -128,7 +128,7 @@ projectBranchBrowseEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle pr
   where
     projectBranchShortHand = ProjectBranchShortHand {userHandle, projectSlug, contributorHandle = mayContributorHandle, branchName}
 
-    cacheParams = [IDs.toText projectBranchShortHand, tShow $ fromMaybe Path.empty relativeTo, tShow $ fromMaybe Path.empty namespace]
+    cacheParams = [IDs.toText projectBranchShortHand, tShow $ fromMaybe mempty relativeTo, tShow $ fromMaybe mempty namespace]
 
 projectBranchDefinitionsByNameEndpoint ::
   Maybe Session ->
@@ -149,10 +149,10 @@ projectBranchDefinitionsByNameEndpoint (AuthN.MaybeAuthedUserID callerUserId) us
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-branch-definitions-by-name" cacheParams causalId $ do
     Codebase.runCodebaseTransaction codebase $ do
-      ShareBackend.definitionForHQName (fromMaybe Path.empty relativeTo) causalId renderWidth (Suffixify False) rt name
+      ShareBackend.definitionForHQName (fromMaybe mempty relativeTo) causalId renderWidth (Suffixify False) rt name
   where
     projectBranchShortHand = ProjectBranchShortHand {userHandle, projectSlug, contributorHandle, branchName}
-    cacheParams = [IDs.toText projectBranchShortHand, HQ.toTextWith Name.toText name, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectBranchShortHand, HQ.toTextWith Name.toText name, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
 
 projectBranchDefinitionsByHashEndpoint ::
   Maybe Session ->
@@ -175,10 +175,10 @@ projectBranchDefinitionsByHashEndpoint (AuthN.MaybeAuthedUserID callerUserId) us
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-branch-definitions-by-hash" cacheParams causalId $ do
     Codebase.runCodebaseTransaction codebase $ do
-      ShareBackend.definitionForHQName (fromMaybe Path.empty relativeTo) causalId renderWidth (Suffixify False) rt query
+      ShareBackend.definitionForHQName (fromMaybe mempty relativeTo) causalId renderWidth (Suffixify False) rt query
   where
     projectBranchShortHand = ProjectBranchShortHand {userHandle, projectSlug, contributorHandle, branchName}
-    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece referent, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece referent, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
 
 projectBranchTermSummaryEndpoint ::
   Maybe Session ->
@@ -202,7 +202,7 @@ projectBranchTermSummaryEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHand
       serveTermSummary ref mayName causalId relativeTo renderWidth
   where
     projectBranchShortHand = ProjectBranchShortHand {userHandle, projectSlug, contributorHandle, branchName}
-    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
 
 projectBranchTypeSummaryEndpoint ::
   Maybe Session ->
@@ -226,7 +226,7 @@ projectBranchTypeSummaryEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHand
       serveTypeSummary ref mayName renderWidth
   where
     projectBranchShortHand = ProjectBranchShortHand {userHandle, projectSlug, contributorHandle, branchName}
-    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
 
 projectBranchFindEndpoint ::
   Maybe Session ->
@@ -241,7 +241,7 @@ projectBranchFindEndpoint ::
   Maybe CausalHash ->
   WebApp [(Fuzzy.Alignment, Fuzzy.FoundResult)]
 projectBranchFindEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug (BranchShortHand {contributorHandle, branchName}) mayRelativeTo limit renderWidth query searchDependencies rootHash = do
-  let relativeTo = fromMaybe Path.empty mayRelativeTo
+  let relativeTo = fromMaybe mempty mayRelativeTo
   (project@Project {ownerUserId = projectOwnerUserId}, Branch {causal = branchHead, contributorId}) <- getProjectBranch projectBranchShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectBranchRead callerUserId project
   let codebaseLoc = Codebase.codebaseLocationForProjectBranchCodebase projectOwnerUserId contributorId
@@ -271,7 +271,7 @@ projectBranchNamespacesByNameEndpoint (AuthN.MaybeAuthedUserID callerUserId) use
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-branch-namespaces-by-name" cacheParams causalId $ do
     Codebase.runCodebaseTransactionOrRespondError codebase $ do
-      ND.namespaceDetails rt (fromMaybe Path.Empty path) causalId renderWidth
+      ND.namespaceDetails rt (fromMaybe mempty path) causalId renderWidth
         `whenNothingM` throwError (EntityMissing (ErrorID "namespace-not-found") "Namespace not found")
   where
     cacheParams = [IDs.toText projectBranchShortHand, tShow path, foldMap (toUrlPiece . Pretty.widthToInt) renderWidth]
@@ -288,7 +288,7 @@ getProjectBranchReadmeEndpoint ::
 getProjectBranchReadmeEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug (BranchShortHand {contributorHandle, branchName}) rootHash = do
   (project@Project {ownerUserId = projectOwnerUserId}, Branch {causal = branchHead, contributorId}) <- getProjectBranch projectBranchShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectBranchRead callerUserId project
-  let rootPath = Path.empty
+  let rootPath = mempty
   let codebaseLoc = Codebase.codebaseLocationForProjectBranchCodebase projectOwnerUserId contributorId
   let codebase = Codebase.codebaseEnv authZReceipt codebaseLoc
   causalId <- resolveRootHash codebase branchHead rootHash
@@ -367,7 +367,7 @@ getProjectBranchDocEndpoint ::
 getProjectBranchDocEndpoint cacheKey docNames (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug BranchShortHand {contributorHandle, branchName} rootHash = do
   (project@Project {ownerUserId = projectOwnerUserId}, Branch {causal = branchHead, contributorId}) <- getProjectBranch projectBranchShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectBranchRead callerUserId project
-  let rootPath = Path.empty
+  let rootPath = mempty
   let codebaseLoc = Codebase.codebaseLocationForProjectBranchCodebase projectOwnerUserId contributorId
   let codebase = Codebase.codebaseEnv authZReceipt codebaseLoc
   causalId <- resolveRootHash codebase branchHead rootHash

--- a/src/Share/Web/Share/Diffs/Impl.hs
+++ b/src/Share/Web/Share/Diffs/Impl.hs
@@ -34,7 +34,6 @@ import Share.Web.Authorization (AuthZReceipt)
 import Share.Web.Errors
 import U.Codebase.Reference qualified as V2Reference
 import U.Codebase.Referent qualified as V2Referent
-import Unison.Codebase.Path qualified as Path
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
 import Unison.PrettyPrintEnvDecl qualified as PPED
@@ -160,7 +159,7 @@ diffTerms !_authZReceipt old@(_, _, oldName) new@(_, _, newName) = do
 
 getTermDefinition :: (Codebase.CodebaseEnv, BranchHashId, Name) -> AppM r (Maybe TermDefinition)
 getTermDefinition (codebase, bhId, name) = do
-  let perspective = Path.empty
+  let perspective = mempty
   (namesPerspective, Identity relocatedName) <- PG.runTransaction $ NameLookupOps.relocateToNameRoot perspective (Identity name) bhId
   let ppedBuilder deps = (PPED.biasTo [name]) <$> lift (PPEPostgres.ppedForReferences namesPerspective deps)
   let nameSearch = PGNameSearch.nameSearchForPerspective namesPerspective
@@ -189,7 +188,7 @@ diffTypes !_authZReceipt old@(_, _, oldTypeName) new@(_, _, newTypeName) = do
 
 getTypeDefinition :: (Codebase.CodebaseEnv, BranchHashId, Name) -> AppM r (Maybe TypeDefinition)
 getTypeDefinition (codebase, bhId, name) = do
-  let perspective = Path.empty
+  let perspective = mempty
   (namesPerspective, Identity relocatedName) <- PG.runTransaction $ NameLookupOps.relocateToNameRoot perspective (Identity name) bhId
   let ppedBuilder deps = (PPED.biasTo [name]) <$> lift (PPEPostgres.ppedForReferences namesPerspective deps)
   let nameSearch = PGNameSearch.nameSearchForPerspective namesPerspective

--- a/src/Share/Web/Share/Impl.hs
+++ b/src/Share/Web/Share/Impl.hs
@@ -122,10 +122,10 @@ browseEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle relativeTo name
     Codebase.runCodebaseTransactionOrRespondError codebase $ do
       NL.serve rootCausalId relativeTo namespace `whenNothingM` throwError (EntityMissing (ErrorID "no-namespace") $ "No namespace found at " <> Path.toText namespacePrefix)
   where
-    cacheParams = [tShow $ fromMaybe Path.empty relativeTo, tShow $ fromMaybe Path.empty namespace]
+    cacheParams = [tShow $ fromMaybe mempty relativeTo, tShow $ fromMaybe mempty namespace]
     namespacePrefix :: Path.Path
     namespacePrefix =
-      fromMaybe Path.empty relativeTo <> fromMaybe Path.empty namespace
+      fromMaybe mempty relativeTo <> fromMaybe mempty namespace
 
 definitionsByNameEndpoint ::
   Maybe Session ->
@@ -146,13 +146,13 @@ definitionsByNameEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle name
   (rootCausalId, _rootCausalHash) <- Codebase.runCodebaseTransaction codebase Codebase.expectLooseCodeRoot
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "definitions-by-name" cacheParams rootCausalId $ do
     Codebase.runCodebaseTransaction codebase $ do
-      ShareBackend.definitionForHQName (fromMaybe Path.empty relativeTo) rootCausalId renderWidth (Suffixify False) rt query
+      ShareBackend.definitionForHQName (fromMaybe mempty relativeTo) rootCausalId renderWidth (Suffixify False) rt query
   where
-    cacheParams = [HQ.toTextWith Name.toText name, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [HQ.toTextWith Name.toText name, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
     authPath :: Path.Path
     authPath =
-      let prefix = fromMaybe Path.empty relativeTo
-          suffix = maybe Path.empty Path.fromName $ HQ.toName name
+      let prefix = fromMaybe mempty relativeTo
+          suffix = maybe mempty Path.fromName $ HQ.toName name
        in prefix <> suffix
 
 definitionsByHashEndpoint ::
@@ -167,7 +167,7 @@ definitionsByHashEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle refe
   whenJust rootHash $ \ch -> respondError (InvalidParam "rootHash" (into @Text ch) "Specifying a rootHash is not supported within loose-code")
   codebaseOwner@(User {user_id = codebaseOwnerUserId}) <- PGO.expectUserByHandle userHandle
   let codebaseLoc = Codebase.codebaseLocationForUserCodebase codebaseOwnerUserId
-  let authPath = fromMaybe Path.empty relativeTo
+  let authPath = fromMaybe mempty relativeTo
   let shortHash = Referent.toShortHash referent
   let query = HQ.HashOnly shortHash
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkReadUserCodebase callerUserId codebaseOwner authPath
@@ -176,9 +176,9 @@ definitionsByHashEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle refe
   (rootCausalId, _rootCausalHash) <- Codebase.runCodebaseTransaction codebase Codebase.expectLooseCodeRoot
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "definitions-by-hash" cacheParams rootCausalId $ do
     Codebase.runCodebaseTransaction codebase $ do
-      ShareBackend.definitionForHQName (fromMaybe Path.empty relativeTo) rootCausalId renderWidth (Suffixify False) rt query
+      ShareBackend.definitionForHQName (fromMaybe mempty relativeTo) rootCausalId renderWidth (Suffixify False) rt query
   where
-    cacheParams = [toUrlPiece referent, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [toUrlPiece referent, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
 
 termSummaryEndpoint ::
   Maybe Session ->
@@ -200,11 +200,11 @@ termSummaryEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle ref mayNam
     Codebase.runCodebaseTransaction codebase $ do
       serveTermSummary ref mayName rootCausalId relativeTo renderWidth
   where
-    cacheParams = [toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
     authPath :: Path.Path
     authPath =
-      let prefix = fromMaybe Path.empty relativeTo
-          suffix = maybe Path.empty Path.fromName mayName
+      let prefix = fromMaybe mempty relativeTo
+          suffix = maybe mempty Path.fromName mayName
        in prefix <> suffix
 
 typeSummaryEndpoint ::
@@ -227,11 +227,11 @@ typeSummaryEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle ref mayNam
     Codebase.runCodebaseTransaction codebase $ do
       serveTypeSummary ref mayName renderWidth
   where
-    cacheParams = [toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
     authPath :: Path.Path
     authPath =
-      let prefix = fromMaybe Path.empty relativeTo
-          suffix = maybe Path.empty Path.fromName mayName
+      let prefix = fromMaybe mempty relativeTo
+          suffix = maybe mempty Path.fromName mayName
        in prefix <> suffix
 
 findEndpoint ::
@@ -246,7 +246,7 @@ findEndpoint ::
   WebApp [(Fuzzy.Alignment, Fuzzy.FoundResult)]
 findEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle mayRelativeTo limit renderWidth query searchDependencies rootHash = do
   whenJust rootHash $ \ch -> respondError (InvalidParam "rootHash" (into @Text ch) "Specifying a rootHash is not supported within loose-code")
-  let relativeTo = fromMaybe Path.empty mayRelativeTo
+  let relativeTo = fromMaybe mempty mayRelativeTo
   let authPath = relativeTo
   codebaseOwner@(User {user_id = codebaseOwnerUserId}) <- PGO.expectUserByHandle userHandle
   let codebaseLoc = Codebase.codebaseLocationForUserCodebase codebaseOwnerUserId
@@ -265,7 +265,7 @@ namespacesByNameEndpoint ::
   Maybe Pretty.Width ->
   Maybe CausalHash ->
   WebApp (Cached JSON NamespaceDetails)
-namespacesByNameEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle (fromMaybe Path.Empty -> path) renderWidth rootHash = do
+namespacesByNameEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle (fromMaybe mempty -> path) renderWidth rootHash = do
   whenJust rootHash $ \ch -> respondError (InvalidParam "rootHash" (into @Text ch) "Specifying a rootHash is not supported within loose-code")
   codebaseOwner@(User {user_id = codebaseOwnerUserId}) <- PGO.expectUserByHandle userHandle
   let codebaseLoc = Codebase.codebaseLocationForUserCodebase codebaseOwnerUserId

--- a/src/Share/Web/Share/Releases/Impl.hs
+++ b/src/Share/Web/Share/Releases/Impl.hs
@@ -124,7 +124,7 @@ projectReleaseBrowseEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle p
   where
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
 
-    cacheParams = [IDs.toText projectReleaseShortHand, tShow $ fromMaybe Path.empty relativeTo, tShow $ fromMaybe Path.empty namespace]
+    cacheParams = [IDs.toText projectReleaseShortHand, tShow $ fromMaybe mempty relativeTo, tShow $ fromMaybe mempty namespace]
 
 projectReleaseDefinitionsByNameEndpoint ::
   Maybe Session ->
@@ -145,10 +145,10 @@ projectReleaseDefinitionsByNameEndpoint (AuthN.MaybeAuthedUserID callerUserId) u
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-release-definitions-by-name" cacheParams releaseHead $ do
     Codebase.runCodebaseTransaction codebase $ do
-      ShareBackend.definitionForHQName (fromMaybe Path.empty relativeTo) releaseHead renderWidth (Suffixify False) rt name
+      ShareBackend.definitionForHQName (fromMaybe mempty relativeTo) releaseHead renderWidth (Suffixify False) rt name
   where
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
-    cacheParams = [IDs.toText projectReleaseShortHand, HQ.toTextWith Name.toText name, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectReleaseShortHand, HQ.toTextWith Name.toText name, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
 
 projectReleaseDefinitionsByHashEndpoint ::
   Maybe Session ->
@@ -171,10 +171,10 @@ projectReleaseDefinitionsByHashEndpoint (AuthN.MaybeAuthedUserID callerUserId) u
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-release-definitions-by-hash" cacheParams releaseHead $ do
     Codebase.runCodebaseTransaction codebase $ do
-      ShareBackend.definitionForHQName (fromMaybe Path.empty relativeTo) releaseHead renderWidth (Suffixify False) rt query
+      ShareBackend.definitionForHQName (fromMaybe mempty relativeTo) releaseHead renderWidth (Suffixify False) rt query
   where
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
-    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece referent, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece referent, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
 
 projectReleaseTermSummaryEndpoint ::
   Maybe Session ->
@@ -198,7 +198,7 @@ projectReleaseTermSummaryEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHan
       serveTermSummary ref mayName releaseHead relativeTo renderWidth
   where
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
-    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
 
 projectReleaseTypeSummaryEndpoint ::
   Maybe Session ->
@@ -222,7 +222,7 @@ projectReleaseTypeSummaryEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHan
       serveTypeSummary ref mayName renderWidth
   where
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
-    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe mempty relativeTo, foldMap toUrlPiece renderWidth]
 
 projectReleaseFindEndpoint ::
   Maybe Session ->
@@ -238,7 +238,7 @@ projectReleaseFindEndpoint ::
   WebApp [(Fuzzy.Alignment, Fuzzy.FoundResult)]
 projectReleaseFindEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug releaseVersion mayRelativeTo limit renderWidth query searchDependencies rootHash = do
   whenJust rootHash $ \ch -> respondError (InvalidParam "rootHash" (into @Text ch) "Specifying a rootHash is not supported for releases")
-  let relativeTo = fromMaybe Path.empty mayRelativeTo
+  let relativeTo = fromMaybe mempty mayRelativeTo
   (project@Project {ownerUserId = projectOwnerUserId}, Release {squashedCausal = releaseHead}) <- getProjectRelease projectReleaseShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectReleaseRead callerUserId project
   let codebaseLoc = Codebase.codebaseLocationForProjectRelease projectOwnerUserId
@@ -267,7 +267,7 @@ projectReleaseNamespacesByNameEndpoint (AuthN.MaybeAuthedUserID callerUserId) us
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-release-namespaces-by-name" cacheParams releaseHead $ do
     Codebase.runCodebaseTransactionOrRespondError codebase $ do
-      ND.namespaceDetails rt (fromMaybe Path.Empty path) releaseHead renderWidth `whenNothingM` throwSomeServerError (EntityMissing (ErrorID "missing-namespace") "Namespace could not be found")
+      ND.namespaceDetails rt (fromMaybe mempty path) releaseHead renderWidth `whenNothingM` throwSomeServerError (EntityMissing (ErrorID "missing-namespace") "Namespace could not be found")
   where
     cacheParams = [IDs.toText projectReleaseShortHand, tShow path, foldMap (toUrlPiece . Pretty.widthToInt) renderWidth]
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
@@ -304,7 +304,7 @@ getProjectReleaseReadmeEndpoint ::
 getProjectReleaseReadmeEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug releaseVersion = do
   (project@Project {ownerUserId = projectOwnerUserId}, Release {squashedCausal = releaseHead}) <- getProjectRelease projectReleaseShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectReleaseRead callerUserId project
-  let rootPath = Path.empty
+  let rootPath = mempty
   let codebaseLoc = Codebase.codebaseLocationForProjectRelease projectOwnerUserId
   let codebase = Codebase.codebaseEnv authZReceipt codebaseLoc
   rt <- Codebase.codebaseRuntime codebase
@@ -341,7 +341,7 @@ getProjectReleaseDocEndpoint ::
 getProjectReleaseDocEndpoint cacheKey docNames (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug releaseVersion = do
   (project@Project {ownerUserId = projectOwnerUserId}, Release {squashedCausal = releaseHead}) <- getProjectRelease projectReleaseShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectReleaseRead callerUserId project
-  let rootPath = Path.empty
+  let rootPath = mempty
   let codebaseLoc = Codebase.codebaseLocationForProjectRelease projectOwnerUserId
   let codebase = Codebase.codebaseEnv authZReceipt codebaseLoc
   rt <- Codebase.codebaseRuntime codebase

--- a/src/Unison/Server/Share/DefinitionSummary.hs
+++ b/src/Unison/Server/Share/DefinitionSummary.hs
@@ -72,7 +72,7 @@ termSummaryForReferent ::
 termSummaryForReferent referent typeSig mayName rootBranchHashId relativeTo mayWidth = do
   let shortHash = V2Referent.toShortHash referent
   let displayName = maybe (HQ.HashOnly shortHash) HQ.NameOnly mayName
-  let relativeToPath = fromMaybe Path.empty relativeTo
+  let relativeToPath = fromMaybe mempty relativeTo
   let termReference = V2Referent.toReference referent
   let deps = Type.labeledDependencies typeSig
   namesPerspective <- NLOps.namesPerspectiveForRootAndPath rootBranchHashId (NameLookups.PathSegments . fmap NameSegment.toUnescapedText . Path.toList $ relativeToPath)

--- a/src/Unison/Server/Share/Definitions.hs
+++ b/src/Unison/Server/Share/Definitions.hs
@@ -258,7 +258,7 @@ hqNameQuery ::
   PG.Transaction e QueryResult
 hqNameQuery NameSearch {typeSearch, termSearch} hqs = do
   -- Split the query into hash-only and hash-qualified-name queries.
-  let (hashes, hqnames) = partitionEithers (map HQ'.fromHQ2 hqs)
+  let (hashes, hqnames) = partitionEithers (map HQ'.fromHQ hqs)
   -- Find the terms with those hashes.
   termRefs <-
     filter (not . Set.null . snd) . zip hashes

--- a/src/Unison/Server/Share/NamespaceListing.hs
+++ b/src/Unison/Server/Share/NamespaceListing.hs
@@ -173,8 +173,8 @@ serve rootCausalId mayRelativeTo mayNamespaceName = runMaybeT $ do
   -- to look up the namespace listing and present shallow name, so that the
   -- definition "base.List.Nonempty.map", simple has the name "map"
   --
-  let relativeToPath = fromMaybe Path.empty mayRelativeTo
-  let namespacePath = fromMaybe Path.empty mayNamespaceName
+  let relativeToPath = fromMaybe mempty mayRelativeTo
+  let namespacePath = fromMaybe mempty mayNamespaceName
   let path = relativeToPath <> namespacePath
   listingCausal <- MaybeT $ Codebase.loadCausalNamespaceAtPath rootCausalId path
   listingBranch <- lift $ V2Causal.value listingCausal


### PR DESCRIPTION
## Overview

* [x] TODO: Merge in https://github.com/unisonweb/unison/pull/5624 before merging this, it fixes a missing `t` claim on the HashJWTClaims

The Jose library's interface for adding additional arbitrary jwt claims is pretty hard to work with IMO; and sometimes you want your JWT format to differ from your JSON format, this provides a separate class for doing it and simplifies the act of managing additional arbitrary claims.