### PR TITLE
Add notification channels so we can process jobs immediately after submission

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -86,6 +86,7 @@ dependencies:
 - hasql
 - hasql-pool
 - hasql-interpolate
+- hasql-listen-notify
 - prometheus-client
 - prometheus-metrics-ghc
 - random

--- a/share-api.cabal
+++ b/share-api.cabal
@@ -67,6 +67,7 @@ library
       Share.Postgres.NameLookups.Queries
       Share.Postgres.NameLookups.Types
       Share.Postgres.NamespaceDiffs
+      Share.Postgres.Notifications
       Share.Postgres.Ops
       Share.Postgres.Orphans
       Share.Postgres.Patches.Queries
@@ -232,6 +233,7 @@ library
     , generic-lens
     , hasql
     , hasql-interpolate
+    , hasql-listen-notify
     , hasql-pool
     , hedis
     , here
@@ -380,6 +382,7 @@ executable share-api
     , generic-lens
     , hasql
     , hasql-interpolate
+    , hasql-listen-notify
     , hasql-pool
     , hedis
     , here

--- a/src/Share.hs
+++ b/src/Share.hs
@@ -42,6 +42,7 @@ import Share.IDs qualified as IDs
 import Share.JWT qualified as JWT
 import Share.Metrics (requestMetricsMiddleware, serveMetricsMiddleware)
 import Share.OAuth.Session (AuthCheckCtx, MaybeAuthenticatedUserId, addAuthCheckCtx)
+import Share.Postgres.Notifications qualified as PGNotif
 import Share.Prelude
 import Share.Utils.Deployment qualified as Deployment
 import Share.Utils.Logging (LogMsg (..), logErrorText)
@@ -65,7 +66,8 @@ startApp :: Env.Env () -> IO ()
 startApp env = do
   app <- mkShareServer env
   Ki.scoped \scope -> do
-    runBackground env "background-jobs" $ BackgroundJobs.startWorkers scope
+    runBackground env "notifications-init" $ do PGNotif.initialize scope
+    runBackground env "background-jobs" $ do BackgroundJobs.startWorkers scope
     run (Env.serverPort env) app
 
 newtype UncaughtException err = UncaughtException err

--- a/src/Share/BackgroundJobs/Diffs/Queries.hs
+++ b/src/Share/BackgroundJobs/Diffs/Queries.hs
@@ -8,6 +8,7 @@ import Data.Foldable (toList)
 import Data.Set (Set)
 import Share.IDs
 import Share.Postgres
+import Share.Postgres.Notifications qualified as Notif
 
 submitContributionsToBeDiffed :: (QueryM m) => Set ContributionId -> m ()
 submitContributionsToBeDiffed contributions = do
@@ -20,6 +21,7 @@ submitContributionsToBeDiffed contributions = do
       SELECT nc.contribution_id FROM new_contributions nc
       ON CONFLICT DO NOTHING
     |]
+  Notif.notifyChannel Notif.ContributionDiffChannel
 
 -- | Claim the oldest contribution in the queue to be diffed.
 claimContributionToDiff :: Transaction e (Maybe ContributionId)

--- a/src/Share/Postgres/Notifications.hs
+++ b/src/Share/Postgres/Notifications.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE DataKinds #-}
+
+-- | Note: this is for detecting notifications from the postgres instance, not anything
+-- related to Share notifications.
+module Share.Postgres.Notifications
+  ( initialize,
+    waitOnChannel,
+  )
+where
+
+import Control.Concurrent.STM (TVar)
+import Control.Concurrent.STM qualified as STM
+import Data.Set qualified as Set
+import Hasql.ListenNotify qualified as Hasql
+import Ki.Unlifted qualified as Ki
+import Share.BackgroundJobs.Errors qualified as Background
+import Share.BackgroundJobs.Monad (Background)
+import Share.Postgres qualified as PG
+import Share.Prelude
+import Share.Utils.Logging qualified as Logging
+import System.IO.Unsafe (unsafePerformIO)
+import UnliftIO qualified
+
+data NotificationError
+  = UnknownChannel Text
+  | NotificationWorkerException UnliftIO.SomeException
+  deriving stock (Show)
+  deriving (Logging.Loggable) via (Logging.ShowLoggable Logging.Error NotificationError)
+
+notifs :: TVar (Set ChannelKind)
+notifs = unsafePerformIO $ STM.newTVarIO mempty
+{-# NOINLINE notifs #-}
+
+-- | Initializes the notification worker, which listens for notifications from the database.
+-- Must be called once at the beginning of the program.
+initialize ::
+  Ki.Scope -> -- The scope of the server
+  Background ()
+initialize scope = void $ Ki.fork scope $ forever do
+  result <- UnliftIO.try $ do
+    PG.runSession $ do
+      for_ [minBound .. maxBound] \kind -> do
+        PG.statement () $ Hasql.listen (toChannelId kind)
+      -- Wait for notifications
+      let loop = do
+            Hasql.Notification {channel} <- lift $ Hasql.await
+            fromChannelId channel & \case
+              Just kind -> do
+                liftIO . STM.atomically $ STM.modifyTVar' notifs $ Set.insert kind
+                loop
+              Nothing -> pure $ UnknownChannel channel
+      loop
+
+  case result of
+    Left (e :: UnliftIO.SomeException) -> do
+      Background.reportError $ NotificationWorkerException e
+    Right err ->
+      Background.reportError err
+
+data ChannelKind
+  = DefinitionSyncChannel
+  | ContributionDiffChannel
+  deriving stock (Eq, Ord, Show, Bounded, Enum)
+
+toChannelId :: ChannelKind -> Hasql.Identifier
+toChannelId = \case
+  DefinitionSyncChannel -> Hasql.Identifier "definition_sync"
+  ContributionDiffChannel -> Hasql.Identifier "contribution_diff"
+
+fromChannelId :: Text -> Maybe ChannelKind
+fromChannelId = \case
+  "definition_sync" -> Just DefinitionSyncChannel
+  "contribution_diff" -> Just ContributionDiffChannel
+  _ -> Nothing
+
+-- | Wait on a channel for notifications, OR until the max polling time has been reached
+-- The channel notifications can help ensure we process items as they come in, but they're not
+-- robust in spite of restarts or within a cluster setting, so we also have a max polling time
+-- to ensure any missed notifications are eventually processed.
+--
+-- For this reason, when the wait resolves, you can only assume that something _might_ have
+-- happened.
+waitOnChannel :: (MonadIO m) => ChannelKind -> Int -> m ()
+waitOnChannel kind maxPollInterval =
+  liftIO . void $ UnliftIO.timeout maxPollInterval $ STM.atomically do
+    channels <- STM.readTVar notifs
+    guard (Set.member kind channels)
+    STM.modifyTVar' notifs $ Set.delete kind

--- a/src/Share/Postgres/Search/DefinitionSearch/Queries.hs
+++ b/src/Share/Postgres/Search/DefinitionSearch/Queries.hs
@@ -27,6 +27,7 @@ import Servant.Server (err500)
 import Share.BackgroundJobs.Search.DefinitionSync.Types
 import Share.IDs (ProjectId, ReleaseId, UserId)
 import Share.Postgres
+import Share.Postgres.Notifications qualified as Notif
 import Share.Prelude
 import Share.Utils.API (Limit, Query (Query))
 import Share.Utils.Logging qualified as Logging
@@ -60,6 +61,7 @@ submitReleaseToBeSynced releaseId = do
     INSERT INTO global_definition_search_release_queue (release_id)
     VALUES (#{releaseId})
     |]
+  Notif.notifyChannel Notif.DefinitionSyncChannel
 
 -- | Claim the oldest unsynced release to be indexed.
 claimUnsyncedRelease :: Transaction e (Maybe ReleaseId)

--- a/stack.yaml
+++ b/stack.yaml
@@ -61,3 +61,9 @@ ghc-options:
  # All packages
  "$locals": -Wall -Wno-name-shadowing -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
  statistics: -fsimpl-tick-factor=10000 # statistics fails on GHC 9 without this, https://github.com/haskell/statistics/issues/173
+
+allow-newer: true
+allow-newer-deps:
+  - hasql-listen-notify
+  # hasql-listen-notify wants an older version of hasql than we're using.
+  - hasql


### PR DESCRIPTION
## Overview

Uses Postgres LISTEN/NOTIFY to have background-job workers detect when there's work to do immediately.

This allows us to reduce our polling intervals, and process work immediately (which is nice esp. when running local transcripts)

We still need to poll since workers can crash after receiving the notifications, or things can be forgotten, but this'll help us seem more responsive without hammering Postgres with polling.

## Implementation notes

* Adds a new module with Postgres Notification Channels
* Listen on these channels in the background job workers
* Notify on these channels when inserting new work into the job queues.

## Testing

If it's NOT working then transcripts will take >10 minutes to complete, so I guess we'll see :)