### PR TITLE
Bump `unison` dep to trunk

### DIFF
--- a/src/Share/NamespaceDiffs.hs
+++ b/src/Share/NamespaceDiffs.hs
@@ -374,7 +374,7 @@ compressNameTree (diffs Cofree.:< children) =
                   (childDiffs Cofree.:< nestedChildren)
                     | null childDiffs,
                       [(k, v)] <- Map.toList nestedChildren ->
-                        (ns Path.:< k, v)
+                        (Path.prefix (Path.singleton ns) (Path.Relative k), v)
                     | otherwise ->
                         (Path.singleton ns, child)
             )

--- a/src/Share/Postgres/NameLookups/Ops.hs
+++ b/src/Share/Postgres/NameLookups/Ops.hs
@@ -102,7 +102,7 @@ relocateToNameRoot perspective query rootBh = do
             & Name.segments
             & NonEmpty.init
             & Path.fromList
-        Nothing -> Path.empty
+        Nothing -> mempty @Path
   let fullPath = perspective <> nameLocation
   Debug.debugM Debug.Server "relocateToNameRoot fullPath" fullPath
   namesPerspective@NamesPerspective {relativePerspective} <- namesPerspectiveForRootAndPath rootBh (PathSegments . fmap NameSegment.toUnescapedText . Path.toList $ fullPath)

--- a/src/Share/Web/Share/Branches/Impl.hs
+++ b/src/Share/Web/Share/Branches/Impl.hs
@@ -41,6 +41,7 @@ import Share.Web.Share.CodeBrowsing.API qualified as API
 import Share.Web.Share.Projects.Types (projectToAPI)
 import Share.Web.Share.Types
 import U.Codebase.HashTags (CausalHash)
+import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
@@ -128,7 +129,7 @@ projectBranchBrowseEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle pr
   where
     projectBranchShortHand = ProjectBranchShortHand {userHandle, projectSlug, contributorHandle = mayContributorHandle, branchName}
 
-    cacheParams = [IDs.toText projectBranchShortHand, tShow $ fromMaybe Path.empty relativeTo, tShow $ fromMaybe Path.empty namespace]
+    cacheParams = [IDs.toText projectBranchShortHand, tShow $ fromMaybe (mempty @Path) relativeTo, tShow $ fromMaybe (mempty @Path) namespace]
 
 projectBranchDefinitionsByNameEndpoint ::
   Maybe Session ->
@@ -149,10 +150,10 @@ projectBranchDefinitionsByNameEndpoint (AuthN.MaybeAuthedUserID callerUserId) us
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-branch-definitions-by-name" cacheParams causalId $ do
     Codebase.runCodebaseTransaction codebase $ do
-      ShareBackend.definitionForHQName (fromMaybe Path.empty relativeTo) causalId renderWidth (Suffixify False) rt name
+      ShareBackend.definitionForHQName (fromMaybe (mempty @Path) relativeTo) causalId renderWidth (Suffixify False) rt name
   where
     projectBranchShortHand = ProjectBranchShortHand {userHandle, projectSlug, contributorHandle, branchName}
-    cacheParams = [IDs.toText projectBranchShortHand, HQ.toTextWith Name.toText name, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectBranchShortHand, HQ.toTextWith Name.toText name, tShow $ fromMaybe (mempty @Path) relativeTo, foldMap toUrlPiece renderWidth]
 
 projectBranchDefinitionsByHashEndpoint ::
   Maybe Session ->
@@ -175,10 +176,10 @@ projectBranchDefinitionsByHashEndpoint (AuthN.MaybeAuthedUserID callerUserId) us
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-branch-definitions-by-hash" cacheParams causalId $ do
     Codebase.runCodebaseTransaction codebase $ do
-      ShareBackend.definitionForHQName (fromMaybe Path.empty relativeTo) causalId renderWidth (Suffixify False) rt query
+      ShareBackend.definitionForHQName (fromMaybe (mempty @Path) relativeTo) causalId renderWidth (Suffixify False) rt query
   where
     projectBranchShortHand = ProjectBranchShortHand {userHandle, projectSlug, contributorHandle, branchName}
-    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece referent, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece referent, tShow $ fromMaybe (mempty @Path) relativeTo, foldMap toUrlPiece renderWidth]
 
 projectBranchTermSummaryEndpoint ::
   Maybe Session ->
@@ -202,7 +203,7 @@ projectBranchTermSummaryEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHand
       serveTermSummary ref mayName causalId relativeTo renderWidth
   where
     projectBranchShortHand = ProjectBranchShortHand {userHandle, projectSlug, contributorHandle, branchName}
-    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe (mempty @Path) relativeTo, foldMap toUrlPiece renderWidth]
 
 projectBranchTypeSummaryEndpoint ::
   Maybe Session ->
@@ -226,7 +227,7 @@ projectBranchTypeSummaryEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHand
       serveTypeSummary ref mayName renderWidth
   where
     projectBranchShortHand = ProjectBranchShortHand {userHandle, projectSlug, contributorHandle, branchName}
-    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectBranchShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe (mempty @Path) relativeTo, foldMap toUrlPiece renderWidth]
 
 projectBranchFindEndpoint ::
   Maybe Session ->
@@ -241,7 +242,7 @@ projectBranchFindEndpoint ::
   Maybe CausalHash ->
   WebApp [(Fuzzy.Alignment, Fuzzy.FoundResult)]
 projectBranchFindEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug (BranchShortHand {contributorHandle, branchName}) mayRelativeTo limit renderWidth query searchDependencies rootHash = do
-  let relativeTo = fromMaybe Path.empty mayRelativeTo
+  let relativeTo = fromMaybe (mempty @Path) mayRelativeTo
   (project@Project {ownerUserId = projectOwnerUserId}, Branch {causal = branchHead, contributorId}) <- getProjectBranch projectBranchShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectBranchRead callerUserId project
   let codebaseLoc = Codebase.codebaseLocationForProjectBranchCodebase projectOwnerUserId contributorId
@@ -271,7 +272,7 @@ projectBranchNamespacesByNameEndpoint (AuthN.MaybeAuthedUserID callerUserId) use
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-branch-namespaces-by-name" cacheParams causalId $ do
     Codebase.runCodebaseTransactionOrRespondError codebase $ do
-      ND.namespaceDetails rt (fromMaybe Path.Empty path) causalId renderWidth
+      ND.namespaceDetails rt (fromMaybe (mempty @Path) path) causalId renderWidth
         `whenNothingM` throwError (EntityMissing (ErrorID "namespace-not-found") "Namespace not found")
   where
     cacheParams = [IDs.toText projectBranchShortHand, tShow path, foldMap (toUrlPiece . Pretty.widthToInt) renderWidth]
@@ -288,7 +289,7 @@ getProjectBranchReadmeEndpoint ::
 getProjectBranchReadmeEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug (BranchShortHand {contributorHandle, branchName}) rootHash = do
   (project@Project {ownerUserId = projectOwnerUserId}, Branch {causal = branchHead, contributorId}) <- getProjectBranch projectBranchShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectBranchRead callerUserId project
-  let rootPath = Path.empty
+  let rootPath = mempty @Path
   let codebaseLoc = Codebase.codebaseLocationForProjectBranchCodebase projectOwnerUserId contributorId
   let codebase = Codebase.codebaseEnv authZReceipt codebaseLoc
   causalId <- resolveRootHash codebase branchHead rootHash
@@ -367,7 +368,7 @@ getProjectBranchDocEndpoint ::
 getProjectBranchDocEndpoint cacheKey docNames (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug BranchShortHand {contributorHandle, branchName} rootHash = do
   (project@Project {ownerUserId = projectOwnerUserId}, Branch {causal = branchHead, contributorId}) <- getProjectBranch projectBranchShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectBranchRead callerUserId project
-  let rootPath = Path.empty
+  let rootPath = mempty @Path
   let codebaseLoc = Codebase.codebaseLocationForProjectBranchCodebase projectOwnerUserId contributorId
   let codebase = Codebase.codebaseEnv authZReceipt codebaseLoc
   causalId <- resolveRootHash codebase branchHead rootHash

--- a/src/Share/Web/Share/Diffs/Impl.hs
+++ b/src/Share/Web/Share/Diffs/Impl.hs
@@ -34,7 +34,7 @@ import Share.Web.Authorization (AuthZReceipt)
 import Share.Web.Errors
 import U.Codebase.Reference qualified as V2Reference
 import U.Codebase.Referent qualified as V2Referent
-import Unison.Codebase.Path qualified as Path
+import Unison.Codebase.Path (Path)
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
 import Unison.PrettyPrintEnvDecl qualified as PPED
@@ -160,7 +160,7 @@ diffTerms !_authZReceipt old@(_, _, oldName) new@(_, _, newName) = do
 
 getTermDefinition :: (Codebase.CodebaseEnv, BranchHashId, Name) -> AppM r (Maybe TermDefinition)
 getTermDefinition (codebase, bhId, name) = do
-  let perspective = Path.empty
+  let perspective = mempty @Path
   (namesPerspective, Identity relocatedName) <- PG.runTransaction $ NameLookupOps.relocateToNameRoot perspective (Identity name) bhId
   let ppedBuilder deps = (PPED.biasTo [name]) <$> lift (PPEPostgres.ppedForReferences namesPerspective deps)
   let nameSearch = PGNameSearch.nameSearchForPerspective namesPerspective
@@ -189,7 +189,7 @@ diffTypes !_authZReceipt old@(_, _, oldTypeName) new@(_, _, newTypeName) = do
 
 getTypeDefinition :: (Codebase.CodebaseEnv, BranchHashId, Name) -> AppM r (Maybe TypeDefinition)
 getTypeDefinition (codebase, bhId, name) = do
-  let perspective = Path.empty
+  let perspective = mempty @Path
   (namesPerspective, Identity relocatedName) <- PG.runTransaction $ NameLookupOps.relocateToNameRoot perspective (Identity name) bhId
   let ppedBuilder deps = (PPED.biasTo [name]) <$> lift (PPEPostgres.ppedForReferences namesPerspective deps)
   let nameSearch = PGNameSearch.nameSearchForPerspective namesPerspective

--- a/src/Share/Web/Share/Releases/Impl.hs
+++ b/src/Share/Web/Share/Releases/Impl.hs
@@ -43,6 +43,7 @@ import Share.Web.Share.Releases.Types
 import Share.Web.Share.Releases.Types qualified as API
 import Share.Web.Share.Types
 import Share.Web.UCM.Sync.Impl qualified as SyncQ
+import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
@@ -124,7 +125,7 @@ projectReleaseBrowseEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle p
   where
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
 
-    cacheParams = [IDs.toText projectReleaseShortHand, tShow $ fromMaybe Path.empty relativeTo, tShow $ fromMaybe Path.empty namespace]
+    cacheParams = [IDs.toText projectReleaseShortHand, tShow $ fromMaybe (mempty @Path) relativeTo, tShow $ fromMaybe (mempty @Path) namespace]
 
 projectReleaseDefinitionsByNameEndpoint ::
   Maybe Session ->
@@ -145,10 +146,10 @@ projectReleaseDefinitionsByNameEndpoint (AuthN.MaybeAuthedUserID callerUserId) u
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-release-definitions-by-name" cacheParams releaseHead $ do
     Codebase.runCodebaseTransaction codebase $ do
-      ShareBackend.definitionForHQName (fromMaybe Path.empty relativeTo) releaseHead renderWidth (Suffixify False) rt name
+      ShareBackend.definitionForHQName (fromMaybe (mempty @Path) relativeTo) releaseHead renderWidth (Suffixify False) rt name
   where
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
-    cacheParams = [IDs.toText projectReleaseShortHand, HQ.toTextWith Name.toText name, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectReleaseShortHand, HQ.toTextWith Name.toText name, tShow $ fromMaybe (mempty @Path) relativeTo, foldMap toUrlPiece renderWidth]
 
 projectReleaseDefinitionsByHashEndpoint ::
   Maybe Session ->
@@ -171,10 +172,10 @@ projectReleaseDefinitionsByHashEndpoint (AuthN.MaybeAuthedUserID callerUserId) u
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-release-definitions-by-hash" cacheParams releaseHead $ do
     Codebase.runCodebaseTransaction codebase $ do
-      ShareBackend.definitionForHQName (fromMaybe Path.empty relativeTo) releaseHead renderWidth (Suffixify False) rt query
+      ShareBackend.definitionForHQName (fromMaybe (mempty @Path) relativeTo) releaseHead renderWidth (Suffixify False) rt query
   where
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
-    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece referent, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece referent, tShow $ fromMaybe (mempty @Path) relativeTo, foldMap toUrlPiece renderWidth]
 
 projectReleaseTermSummaryEndpoint ::
   Maybe Session ->
@@ -198,7 +199,7 @@ projectReleaseTermSummaryEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHan
       serveTermSummary ref mayName releaseHead relativeTo renderWidth
   where
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
-    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe (mempty @Path) relativeTo, foldMap toUrlPiece renderWidth]
 
 projectReleaseTypeSummaryEndpoint ::
   Maybe Session ->
@@ -222,7 +223,7 @@ projectReleaseTypeSummaryEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHan
       serveTypeSummary ref mayName renderWidth
   where
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
-    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe Path.empty relativeTo, foldMap toUrlPiece renderWidth]
+    cacheParams = [IDs.toText projectReleaseShortHand, toUrlPiece ref, maybe "" Name.toText mayName, tShow $ fromMaybe (mempty @Path) relativeTo, foldMap toUrlPiece renderWidth]
 
 projectReleaseFindEndpoint ::
   Maybe Session ->
@@ -238,7 +239,7 @@ projectReleaseFindEndpoint ::
   WebApp [(Fuzzy.Alignment, Fuzzy.FoundResult)]
 projectReleaseFindEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug releaseVersion mayRelativeTo limit renderWidth query searchDependencies rootHash = do
   whenJust rootHash $ \ch -> respondError (InvalidParam "rootHash" (into @Text ch) "Specifying a rootHash is not supported for releases")
-  let relativeTo = fromMaybe Path.empty mayRelativeTo
+  let relativeTo = fromMaybe (mempty @Path) mayRelativeTo
   (project@Project {ownerUserId = projectOwnerUserId}, Release {squashedCausal = releaseHead}) <- getProjectRelease projectReleaseShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectReleaseRead callerUserId project
   let codebaseLoc = Codebase.codebaseLocationForProjectRelease projectOwnerUserId
@@ -267,7 +268,7 @@ projectReleaseNamespacesByNameEndpoint (AuthN.MaybeAuthedUserID callerUserId) us
   rt <- Codebase.codebaseRuntime codebase
   Codebase.cachedCodebaseResponse authZReceipt codebaseLoc "project-release-namespaces-by-name" cacheParams releaseHead $ do
     Codebase.runCodebaseTransactionOrRespondError codebase $ do
-      ND.namespaceDetails rt (fromMaybe Path.Empty path) releaseHead renderWidth `whenNothingM` throwSomeServerError (EntityMissing (ErrorID "missing-namespace") "Namespace could not be found")
+      ND.namespaceDetails rt (fromMaybe (mempty @Path) path) releaseHead renderWidth `whenNothingM` throwSomeServerError (EntityMissing (ErrorID "missing-namespace") "Namespace could not be found")
   where
     cacheParams = [IDs.toText projectReleaseShortHand, tShow path, foldMap (toUrlPiece . Pretty.widthToInt) renderWidth]
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}
@@ -304,7 +305,7 @@ getProjectReleaseReadmeEndpoint ::
 getProjectReleaseReadmeEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug releaseVersion = do
   (project@Project {ownerUserId = projectOwnerUserId}, Release {squashedCausal = releaseHead}) <- getProjectRelease projectReleaseShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectReleaseRead callerUserId project
-  let rootPath = Path.empty
+  let rootPath = mempty @Path
   let codebaseLoc = Codebase.codebaseLocationForProjectRelease projectOwnerUserId
   let codebase = Codebase.codebaseEnv authZReceipt codebaseLoc
   rt <- Codebase.codebaseRuntime codebase
@@ -341,7 +342,7 @@ getProjectReleaseDocEndpoint ::
 getProjectReleaseDocEndpoint cacheKey docNames (AuthN.MaybeAuthedUserID callerUserId) userHandle projectSlug releaseVersion = do
   (project@Project {ownerUserId = projectOwnerUserId}, Release {squashedCausal = releaseHead}) <- getProjectRelease projectReleaseShortHand
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkProjectReleaseRead callerUserId project
-  let rootPath = Path.empty
+  let rootPath = mempty @Path
   let codebaseLoc = Codebase.codebaseLocationForProjectRelease projectOwnerUserId
   let codebase = Codebase.codebaseEnv authZReceipt codebaseLoc
   rt <- Codebase.codebaseRuntime codebase

--- a/src/Unison/Server/Share/DefinitionSummary.hs
+++ b/src/Unison/Server/Share/DefinitionSummary.hs
@@ -26,6 +26,7 @@ import Share.Postgres.NameLookups.Ops qualified as NLOps
 import Share.Postgres.NameLookups.Types qualified as NameLookups
 import U.Codebase.Referent qualified as V2Referent
 import Unison.Codebase.Editor.DisplayObject (DisplayObject (..))
+import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.SqliteCodebase.Conversions qualified as CV
 import Unison.HashQualified qualified as HQ
@@ -39,9 +40,7 @@ import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
 import Unison.Server.Backend (BackendError (..))
 import Unison.Server.Share.DefinitionSummary.Types (TermSummary (..), TypeSummary (..))
-import Unison.Server.Types
-  ( mayDefaultWidth,
-  )
+import Unison.Server.Types (mayDefaultWidth)
 import Unison.Symbol (Symbol)
 import Unison.Type qualified as Type
 import Unison.Util.Pretty (Width)
@@ -72,7 +71,7 @@ termSummaryForReferent ::
 termSummaryForReferent referent typeSig mayName rootBranchHashId relativeTo mayWidth = do
   let shortHash = V2Referent.toShortHash referent
   let displayName = maybe (HQ.HashOnly shortHash) HQ.NameOnly mayName
-  let relativeToPath = fromMaybe Path.empty relativeTo
+  let relativeToPath = fromMaybe (mempty @Path) relativeTo
   let termReference = V2Referent.toReference referent
   let deps = Type.labeledDependencies typeSig
   namesPerspective <- NLOps.namesPerspectiveForRootAndPath rootBranchHashId (NameLookups.PathSegments . fmap NameSegment.toUnescapedText . Path.toList $ relativeToPath)

--- a/src/Unison/Server/Share/Definitions.hs
+++ b/src/Unison/Server/Share/Definitions.hs
@@ -258,7 +258,7 @@ hqNameQuery ::
   PG.Transaction e QueryResult
 hqNameQuery NameSearch {typeSearch, termSearch} hqs = do
   -- Split the query into hash-only and hash-qualified-name queries.
-  let (hashes, hqnames) = partitionEithers (map HQ'.fromHQ2 hqs)
+  let (hashes, hqnames) = partitionEithers (map HQ'.fromHQ hqs)
   -- Find the terms with those hashes.
   termRefs <-
     filter (not . Set.null . snd) . zip hashes

--- a/src/Unison/Server/Share/NamespaceListing.hs
+++ b/src/Unison/Server/Share/NamespaceListing.hs
@@ -35,6 +35,7 @@ import Unison.Symbol (Symbol)
 import Unison.Syntax.NameSegment qualified as NameSegment
 import Unison.Util.Pretty (Width)
 import Unison.Var (Var)
+import Unison.Codebase.Path (Path)
 
 type NamespaceListingAPI =
   "list"
@@ -173,8 +174,8 @@ serve rootCausalId mayRelativeTo mayNamespaceName = runMaybeT $ do
   -- to look up the namespace listing and present shallow name, so that the
   -- definition "base.List.Nonempty.map", simple has the name "map"
   --
-  let relativeToPath = fromMaybe Path.empty mayRelativeTo
-  let namespacePath = fromMaybe Path.empty mayNamespaceName
+  let relativeToPath = fromMaybe (mempty @Path) mayRelativeTo
+  let namespacePath = fromMaybe (mempty @Path) mayNamespaceName
   let path = relativeToPath <> namespacePath
   listingCausal <- MaybeT $ Codebase.loadCausalNamespaceAtPath rootCausalId path
   listingBranch <- lift $ V2Causal.value listingCausal


### PR DESCRIPTION
## Overview

Pulls in some changes to the "human diff" calculation. The code changes were all just dealing with `Path.empty` and its `Cons` instance being removed.

## Test coverage

I re-ran the transcripts, nothing changed.