### PR TITLE
Add Org Creation

### DIFF
--- a/share-api.cabal
+++ b/share-api.cabal
@@ -139,6 +139,7 @@ library
       Share.Web.Share.Impl
       Share.Web.Share.Orgs.API
       Share.Web.Share.Orgs.Impl
+      Share.Web.Share.Orgs.Operations
       Share.Web.Share.Orgs.Queries
       Share.Web.Share.Orgs.Types
       Share.Web.Share.Projects.API

--- a/sql/2025-03-21_superadmins.sql
+++ b/sql/2025-03-21_superadmins.sql
@@ -1,4 +1,4 @@
 -- Table for users who have enhanced privileges for administrating Share.
 CREATE TABLE superadmins (
-    user_id PRIMARY KEY REFERENCES users(id)
+    user_id UUID PRIMARY KEY REFERENCES users(id)
 );

--- a/sql/2025-03-21_superadmins.sql
+++ b/sql/2025-03-21_superadmins.sql
@@ -1,0 +1,4 @@
+-- Table for users who have enhanced privileges for administrating Share.
+CREATE TABLE superadmins (
+    user_id PRIMARY KEY REFERENCES users(id)
+);

--- a/src/Share/Codebase.hs
+++ b/src/Share/Codebase.hs
@@ -98,8 +98,8 @@ import Share.Utils.Caching qualified as Caching
 import Share.Utils.Logging
 import Share.Utils.Logging qualified as Logging
 import Share.Web.App
-import Share.Web.Authorization (AuthZReceipt)
-import Share.Web.Authorization qualified as AuthZ
+import Share.Web.Authorization.Types (AuthZReceipt)
+import Share.Web.Authorization.Types qualified as AuthZ
 import Share.Web.Errors
 import U.Codebase.Branch qualified as V2
 import U.Codebase.Causal qualified as Causal

--- a/src/Share/IDs.hs
+++ b/src/Share/IDs.hs
@@ -16,6 +16,7 @@ module Share.IDs
     PrefixedID (..),
     PrefixedHash (..),
     UserHandle (..),
+    OrgHandle (..),
     TourId (..),
     ProjectSlug (..),
     ProjectId (..),
@@ -152,6 +153,12 @@ instance IsID UserHandle where
     | Text.length handleTxt > 50 = Left "User handle must not be longer than 50 characters"
     | Just ('-', _) <- Text.uncons handleTxt = Left "User handle must not start with a hyphen"
     | otherwise = Right $ UserHandle handleTxt
+
+newtype OrgHandle = OrgHandle Text
+  deriving stock (Show, Eq, Ord)
+  deriving (Binary, Hasql.EncodeValue, Hasql.DecodeValue) via Text
+  deriving (FromHttpApiData, ToHttpApiData, ToJSON, FromJSON) via (UsingID UserHandle)
+  deriving (IsID) via UserHandle
 
 -- | The name of a project, used in URLs, when paired with a user can be resolved to a project ID
 newtype ProjectSlug = ProjectSlug (CI Text)

--- a/src/Share/Postgres.hs
+++ b/src/Share/Postgres.hs
@@ -78,7 +78,6 @@ import Control.Monad.State
 import Data.Functor.Compose (Compose (..))
 import Data.Map qualified as Map
 import Data.Maybe
-import Data.Text qualified as Text
 import Data.Time.Clock (picosecondsToDiffTime)
 import Data.Time.Clock.System (getSystemTime, systemToTAITime)
 import Data.Time.Clock.TAI (diffAbsoluteTime)
@@ -99,6 +98,7 @@ import Share.Postgres.Orphans ()
 import Share.Prelude
 import Share.Utils.Logging (Loggable (..))
 import Share.Utils.Logging qualified as Logging
+import Share.Utils.Postgres (likeEscape)
 import Share.Web.App
 import Share.Web.Errors (ErrorID (..), SomeServerError, ToServerError (..), internalServerError, respondError, someServerError)
 import System.CPUTime (getCPUTime)
@@ -433,9 +433,6 @@ newtype Only a = Only {fromOnly :: a}
 
 instance (Interp.DecodeField a) => Interp.DecodeRow (Only a) where
   decodeRow = Only <$> decodeField
-
-likeEscape :: Text -> Text
-likeEscape = Text.replace "%" "\\%" . Text.replace "_" "\\_"
 
 -- | Helper for encoding a single-column table using PG.toTable.
 --

--- a/src/Share/Postgres.hs
+++ b/src/Share/Postgres.hs
@@ -32,6 +32,7 @@ module Share.Postgres
     runTransactionMode,
     tryRunTransaction,
     tryRunTransactionMode,
+    catchTransaction,
     unliftTransaction,
     runTransactionOrRespondError,
     runSession,
@@ -505,3 +506,10 @@ timeTransaction label ma =
       transactionUnsafeIO $ putStrLn $ "Finished " ++ label ++ " in " ++ show cpuDiff ++ " (cpu), " ++ show systemDiff ++ " (system)"
       pure a
     else ma
+
+catchTransaction :: Transaction e a -> Transaction e' (Either e a)
+catchTransaction (Transaction t) = Transaction do
+  t >>= \case
+    Left (Err e) -> pure (Right (Left e))
+    Left (Unrecoverable err) -> pure (Left (Unrecoverable err))
+    Right a -> pure (Right (Right a))

--- a/src/Share/Postgres/Authorization/Queries.hs
+++ b/src/Share/Postgres/Authorization/Queries.hs
@@ -7,7 +7,7 @@
 
 module Share.Postgres.Authorization.Queries
   ( checkIsUserMaintainer,
-    isUnisonEmployee,
+    isSuperadmin,
     isOrgMember,
     causalIsInHistoryOf,
     userHasProjectPermission,
@@ -42,14 +42,11 @@ checkIsUserMaintainer requestingUserId codebaseOwnerUserId
         )
       |]
 
-isUnisonEmployee :: UserId -> PG.Transaction e Bool
-isUnisonEmployee uid = do
+isSuperadmin :: UserId -> PG.Transaction e Bool
+isSuperadmin uid = do
   PG.queryExpect1Col
     [PG.sql|
-        SELECT EXISTS (SELECT FROM org_members org
-                      JOIN users AS org_user ON org.organization_user_id = org_user.id
-                      WHERE org.member_user_id = #{uid}
-                            AND org_user.handle = 'unison')
+        SELECT EXISTS (SELECT FROM superadmins s WHERE s.user_id = #{uid})
       |]
 
 isOrgMember :: UserId -> UserId -> PG.Transaction e Bool

--- a/src/Share/Postgres/Ops.hs
+++ b/src/Share/Postgres/Ops.hs
@@ -2,17 +2,18 @@
 module Share.Postgres.Ops where
 
 import Control.Monad.Except
+import Servant
 import Share.IDs (ProjectId, ProjectSlug (..), UserHandle (..), UserId (..))
 import Share.IDs qualified as IDs
 import Share.Postgres qualified as PG
 import Share.Postgres.Queries as Q
+import Share.Postgres.Users.Queries qualified as UserQ
 import Share.Prelude
 import Share.Project
 import Share.User (User (..))
 import Share.Utils.Logging qualified as Logging
 import Share.Web.App
 import Share.Web.Errors
-import Servant
 
 data Errors
   = ProjectAlreadyExists UserId ProjectSlug ProjectId
@@ -30,15 +31,15 @@ instance ToServerError Errors where
     ProjectAlreadyExists {} -> (ErrorID "project:already-exists", err409 {errBody = "Project already exists for this user and slug"})
 
 expectUserByHandle :: UserHandle -> WebApp User
-expectUserByHandle userHandle = PG.runTransaction (Q.userByHandle userHandle) `or404` (EntityMissing (ErrorID "user-not-found-for-handle") $ "User not found for handle: " <> IDs.toText userHandle)
+expectUserByHandle userHandle = PG.runTransaction (UserQ.userByHandle userHandle) `or404` (EntityMissing (ErrorID "user-not-found-for-handle") $ "User not found for handle: " <> IDs.toText userHandle)
 
 expectUserById :: UserId -> WebApp User
-expectUserById uid = PG.runTransaction (Q.userByUserId uid) `or404` (EntityMissing (ErrorID "user-not-found-for-id") $ "User not found for id: " <> IDs.toText uid)
+expectUserById uid = PG.runTransaction (UserQ.userByUserId uid) `or404` (EntityMissing (ErrorID "user-not-found-for-id") $ "User not found for id: " <> IDs.toText uid)
 
 projectIdByUserIdAndSlug :: UserId -> ProjectSlug -> WebApp ProjectId
 projectIdByUserIdAndSlug userId slug = do
   PG.runTransactionOrRespondError $ do
-    user <- Q.userByUserId userId `whenNothingM` throwError (EntityMissing (ErrorID "no-user-for-id") $ "No found for id: " <> IDs.toText userId)
+    user <- UserQ.userByUserId userId `whenNothingM` throwError (EntityMissing (ErrorID "no-user-for-id") $ "No found for id: " <> IDs.toText userId)
     Q.projectIDFromHandleAndSlug (handle user) slug `whenNothingM` throwError (EntityMissing (ErrorID "no-project-for-handle-and-slug") $ "Project not found: " <> IDs.toText (handle user) <> "/" <> IDs.toText slug)
 
 projectIdByUserHandleAndSlug :: UserHandle -> ProjectSlug -> WebApp ProjectId

--- a/src/Share/Postgres/Users/Queries.hs
+++ b/src/Share/Postgres/Users/Queries.hs
@@ -6,16 +6,40 @@ module Share.Postgres.Users.Queries
   ( userDisplayInfoOf,
     userProfileById,
     updateUser,
+    expectUserByUserId,
+    userByUserId,
+    userByEmail,
+    userByGithubUserId,
+    userByHandle,
+    createFromGithubUser,
+    NewOrPreExisting (..),
+    getNewOrPreExisting,
+    isNew,
+    findOrCreateGithubUser,
+    searchUsersByNameOrHandlePrefix,
+    UserCreationError (..),
+    allUsers,
   )
 where
 
 import Control.Lens
+import Control.Monad.Except
+import Data.Text qualified as Text
+import Share.Codebase qualified as Codebase
+import Share.Github
 import Share.IDs
+import Share.IDs qualified as IDs
+import Share.Postgres (unrecoverableError)
 import Share.Postgres qualified as PG
+import Share.Postgres.LooseCode.Queries qualified as LCQ
 import Share.Prelude
+import Share.User
 import Share.UserProfile (UserProfile (..))
-import Share.Utils.API (NullableUpdate, fromNullableUpdate)
+import Share.Utils.API
+import Share.Utils.Postgres
 import Share.Utils.URI (URIParam (..))
+import Share.Web.Authorization qualified as AuthZ
+import Share.Web.Errors (EntityMissing (EntityMissing), ErrorID (..))
 import Share.Web.Share.Types
 
 -- | Efficiently resolve User Display Info for UserIds within a structure.
@@ -98,3 +122,147 @@ updateUser toUpdateUserId newName newAvatarUrl newBio newWebsite newLocation new
         pronouns = #{updatedPronouns}
       WHERE id = #{toUpdateUserId}
   |]
+
+expectUserByUserId :: (PG.QueryM m) => UserId -> m User
+expectUserByUserId uid = do
+  userByUserId uid >>= \case
+    Just user -> pure user
+    Nothing -> unrecoverableError $ EntityMissing (ErrorID "user:missing") ("User with id " <> IDs.toText uid <> " not found")
+
+userByUserId :: (PG.QueryM m) => UserId -> m (Maybe User)
+userByUserId uid = do
+  PG.query1Row
+    [PG.sql|
+        SELECT u.id, u.name, u.primary_email, u.avatar_url, u.handle, u.private
+        FROM users u
+        WHERE u.id = #{uid}
+      |]
+
+userByEmail :: Text -> PG.Transaction e (Maybe User)
+userByEmail email = do
+  PG.query1Row
+    [PG.sql|
+        SELECT u.id, u.name, u.primary_email, u.avatar_url, u.handle, u.private
+        FROM users u
+        WHERE lower(u.primary_email) = lower(#{email})
+        LIMIT 1
+      |]
+
+userByGithubUserId :: Int64 -> PG.Transaction e (Maybe User)
+userByGithubUserId githubUserId = do
+  PG.query1Row
+    [PG.sql|
+        SELECT u.id, u.name, u.primary_email, u.avatar_url, u.handle, u.private
+        FROM github_users gh
+          JOIN users u
+            ON gh.unison_user_id = u.id
+        WHERE gh.github_user_id = #{githubUserId}
+      |]
+
+userByHandle :: UserHandle -> PG.Transaction e (Maybe User)
+userByHandle handle = do
+  PG.query1Row
+    [PG.sql|
+        SELECT u.id, u.name, u.primary_email, u.avatar_url, u.handle, u.private
+        FROM users u
+        WHERE u.handle = lower(#{handle})
+      |]
+
+createFromGithubUser :: GithubUser -> GithubEmail -> PG.Transaction UserCreationError User
+createFromGithubUser (GithubUser githubHandle githubUserId avatar_url user_name) primaryEmail = do
+  let (GithubEmail {github_email_email = user_email, github_email_verified = emailVerified}) = primaryEmail
+  userHandle <- case IDs.fromText @UserHandle (Text.toLower githubHandle) of
+    Left err -> throwError (InvalidUserHandle err githubHandle)
+    Right handle -> pure handle
+  userId <- createUser user_email user_name (Just avatar_url) userHandle emailVerified
+  PG.execute_
+    [PG.sql|
+          INSERT INTO github_users
+            (github_user_id, unison_user_id)
+            VALUES (#{githubUserId}, #{userId})
+        |]
+  let codebase = Codebase.codebaseEnv AuthZ.userCreationOverride (Codebase.codebaseLocationForUserCodebase userId)
+  Codebase.codebaseMToTransaction codebase LCQ.initialize
+  let visibility = UserPublic
+  pure $
+    User
+      { handle = userHandle,
+        avatar_url = Just avatar_url,
+        user_id = userId,
+        user_name,
+        user_email,
+        visibility
+      }
+
+-- | Note: Since there's currently no way to choose a handle during user creation,
+-- manually creating users that aren't mapped to a github user WILL lock out any github
+-- user by that name from creating a share account. Use caution.
+createUser :: Text -> Maybe Text -> Maybe URIParam -> UserHandle -> Bool -> PG.Transaction UserCreationError UserId
+createUser userEmail userName avatarUrl userHandle emailVerified = do
+  handleExists <-
+    PG.queryExpect1Col
+      [PG.sql|
+        SELECT EXISTS (SELECT from users WHERE handle = #{userHandle})
+      |]
+  if handleExists
+    then do
+      throwError $ UserHandleTaken userHandle
+    else do
+      -- All users are created public, private users are currently only possible via
+      -- manual Postgres manipulation.
+      let private = False
+      PG.queryExpect1Col
+        [PG.sql|
+              INSERT INTO users
+                (primary_email, email_verified, avatar_url, name, handle, private)
+                VALUES (#{userEmail}, #{emailVerified}, #{avatarUrl}, #{userName}, #{userHandle}, #{private})
+              RETURNING id
+            |]
+
+data NewOrPreExisting a
+  = New a
+  | PreExisting a
+  deriving stock (Show, Eq, Functor, Foldable, Traversable)
+
+getNewOrPreExisting :: NewOrPreExisting a -> a
+getNewOrPreExisting (New a) = a
+getNewOrPreExisting (PreExisting a) = a
+
+isNew :: NewOrPreExisting a -> Bool
+isNew New {} = True
+isNew _ = False
+
+findOrCreateGithubUser :: GithubUser -> GithubEmail -> PG.Transaction UserCreationError (NewOrPreExisting User)
+findOrCreateGithubUser ghu@(GithubUser _login githubUserId _avatarUrl _name) primaryEmail = do
+  user <- userByGithubUserId githubUserId
+  case user of
+    Just user' -> pure (PreExisting user')
+    Nothing -> do
+      New <$> createFromGithubUser ghu primaryEmail
+
+searchUsersByNameOrHandlePrefix :: Query -> Limit -> PG.Transaction e [User]
+searchUsersByNameOrHandlePrefix (Query prefix) (Limit limit) = do
+  let q = likeEscape prefix <> "%"
+  PG.queryListRows
+    [PG.sql|
+    SELECT u.id, u.name, u.primary_email, u.avatar_url, u.handle, u.private
+      FROM users u
+      WHERE (u.handle ILIKE #{q}
+             OR u.name ILIKE #{q}
+            ) AND NOT u.private
+      LIMIT #{limit}
+      |]
+
+data UserCreationError
+  = UserHandleTaken UserHandle
+  | -- A given user handle isn't valid according to Share.
+    -- This shouldn't happen for Github Handles, but in the case it does, we throw an error.
+    -- (Error Message, Invalid Handle)
+    InvalidUserHandle Text Text
+
+allUsers :: PG.Transaction e [UserId]
+allUsers = do
+  PG.queryListCol
+    [PG.sql|
+        SELECT id FROM users
+      |]

--- a/src/Share/Utils/Caching.hs
+++ b/src/Share/Utils/Caching.hs
@@ -26,7 +26,7 @@ import Servant
 import Share.Postgres.IDs (BranchHashId (..), CausalId (..))
 import Share.Prelude
 import Share.Web.App
-import Share.Web.Authorization qualified as AuthZ
+import Share.Web.Authorization.Types qualified as AuthZ
 
 data Cached ct a
   = Cached BS.ByteString

--- a/src/Share/Utils/Postgres.hs
+++ b/src/Share/Utils/Postgres.hs
@@ -3,10 +3,12 @@ module Share.Utils.Postgres
     ordered,
     RawBytes (..),
     RawLazyBytes (..),
+    likeEscape,
   )
 where
 
 import Data.ByteString.Lazy qualified as BL
+import Data.Text qualified as Text
 import Hasql.Decoders qualified as Decoders
 import Hasql.Encoders qualified as Encoders
 import Hasql.Interpolate qualified as Hasql
@@ -48,3 +50,6 @@ instance Hasql.EncodeValue RawLazyBytes where
 
 instance Hasql.DecodeValue RawLazyBytes where
   decodeValue = RawLazyBytes . BL.fromStrict <$> Decoders.bytea
+
+likeEscape :: Text -> Text
+likeEscape = Text.replace "%" "\\%" . Text.replace "_" "\\_"

--- a/src/Share/Web/Authorization/Types.hs
+++ b/src/Share/Web/Authorization/Types.hs
@@ -26,6 +26,10 @@ module Share.Web.Authorization.Types
     RemoveRolesResponse (..),
     AddRolesRequest (..),
     RemoveRolesRequest (..),
+
+    -- * AuthZReceipt
+    AuthZReceipt (..),
+    CachingToken (..),
   )
 where
 
@@ -404,3 +408,10 @@ instance FromJSON RemoveRolesRequest where
   parseJSON = Aeson.withObject "RemoveRolesRequest" $ \o -> do
     roleAssignments <- o Aeson..: "role_assignments"
     pure RemoveRolesRequest {..}
+
+-- | Proof that an auth check has been run at some point.
+data AuthZReceipt = UnsafeAuthZReceipt {getCacheability :: Maybe CachingToken}
+
+-- | Requests should only be cached if they're for a public endpoint.
+-- Obtaining a caching token is proof that the resource was public and can be cached.
+data CachingToken = CachingToken

--- a/src/Share/Web/Local/Impl.hs
+++ b/src/Share/Web/Local/Impl.hs
@@ -20,7 +20,7 @@ import Share.OAuth.Session (Session)
 import Share.OAuth.Session qualified as Session
 import Share.OAuth.Types (AccessToken (..))
 import Share.Postgres qualified as PG
-import Share.Postgres.Queries qualified as Q
+import Share.Postgres.Users.Queries qualified as UserQ
 import Share.Prelude
 import Share.User
 import Share.Utils.Deployment qualified as Deployment
@@ -38,7 +38,7 @@ localLoginEndpoint ::
   UserHandle -> WebApp (Headers '[Header "Set-Cookie" SetCookie] Text)
 localLoginEndpoint userHandle = do
   (User {user_id}) <-
-    PG.runTransaction (Q.userByHandle userHandle) >>= \case
+    PG.runTransaction (UserQ.userByHandle userHandle) >>= \case
       Nothing -> Errors.respondError $ Errors.EntityMissing (ErrorID "no-user-for-handle") "No user for this handle"
       Just u -> pure u
 
@@ -66,7 +66,7 @@ localAccessTokenEndpoint ::
   WebApp Text
 localAccessTokenEndpoint userHandle = do
   (User {user_id}) <-
-    PG.runTransaction (Q.userByHandle userHandle) >>= \case
+    PG.runTransaction (UserQ.userByHandle userHandle) >>= \case
       Nothing -> Errors.respondError $ Errors.EntityMissing (ErrorID "no-user-for-handle") "No user for this handle"
       Just u -> pure u
   sessionID <- randomIO

--- a/src/Share/Web/OAuth/Impl.hs
+++ b/src/Share/Web/OAuth/Impl.hs
@@ -48,6 +48,7 @@ import Share.Utils.URI (URIParam (URIParam), unpackURI)
 import Share.Utils.URI qualified as URI
 import Share.Web.App
 import Share.Web.Authentication.AccessToken qualified as AccessToken
+import Share.Web.Authorization qualified as AuthZ
 import Share.Web.Errors
 import Share.Web.OAuth.Clients (validateOAuthClientForTokenExchange, validateOAuthClientRedirectURI)
 import Web.Cookie as Cookie (SetCookie (..))
@@ -198,7 +199,7 @@ redirectReceiverEndpoint mayGithubCode mayStatePSID _errorType@Nothing _mayError
       token <- Github.githubTokenForCode githubCode
       ghUser <- Github.githubUser token
       ghEmail <- Github.primaryGithubEmail token
-      PG.tryRunTransaction (UserQ.findOrCreateGithubUser ghUser ghEmail) >>= \case
+      PG.tryRunTransaction (UserQ.findOrCreateGithubUser AuthZ.userCreationOverride ghUser ghEmail) >>= \case
         Left (UserQ.UserHandleTaken _) -> do
           errorRedirect AccountCreationHandleAlreadyTaken
         Left (UserQ.InvalidUserHandle err handle) -> do

--- a/src/Share/Web/Share/Orgs/API.hs
+++ b/src/Share/Web/Share/Orgs/API.hs
@@ -1,18 +1,23 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Share.Web.Share.Orgs.API (API, Routes (..), OrgRolesRoutes (..)) where
+module Share.Web.Share.Orgs.API (API, ResourceRoutes (..), OrgRolesRoutes (..)) where
 
 import GHC.Generics (Generic)
 import Servant
 import Share.IDs
 import Share.OAuth.Session (AuthenticatedUserId)
 import Share.Web.Authorization.Types (AddRolesRequest, ListRolesResponse, RemoveRolesRequest)
+import Share.Web.Share.Orgs.Types
+import Share.Web.Share.Types (OrgDisplayInfo)
 
-type API = Capture "orgHandle" UserHandle :> NamedRoutes Routes
+type API =
+  CreateOrgEndpoint
+    :<|> ( Capture "orgHandle" UserHandle :> NamedRoutes ResourceRoutes
+         )
 
-data Routes mode
-  = Routes
+data ResourceRoutes mode
+  = ResourceRoutes
   { roles :: mode :- "roles" :> NamedRoutes OrgRolesRoutes
   }
   deriving stock (Generic)
@@ -38,3 +43,8 @@ type OrgRolesRemoveEndpoint =
 type OrgRolesListEndpoint =
   AuthenticatedUserId
     :> Get '[JSON] ListRolesResponse
+
+type CreateOrgEndpoint =
+  AuthenticatedUserId
+    :> ReqBody '[JSON] CreateOrgRequest
+    :> Post '[JSON] OrgDisplayInfo

--- a/src/Share/Web/Share/Orgs/Impl.hs
+++ b/src/Share/Web/Share/Orgs/Impl.hs
@@ -6,22 +6,32 @@ import Servant
 import Servant.Server.Generic
 import Share.IDs
 import Share.Postgres qualified as PG
+import Share.Postgres.Queries qualified as Q
+import Share.Postgres.Users.Queries qualified as UserQ
 import Share.Prelude
+import Share.User (User (..))
 import Share.Web.App
 import Share.Web.Authorization qualified as AuthZ
 import Share.Web.Authorization.Types
 import Share.Web.Errors
 import Share.Web.Share.Orgs.API as API
 import Share.Web.Share.Orgs.Queries qualified as OrgQ
-import Share.Web.Share.Orgs.Types (Org (..))
+import Share.Web.Share.Orgs.Types (CreateOrgRequest (..), Org (..))
 import Share.Web.Share.Roles (canonicalRoleAssignmentOrdering)
 import Share.Web.Share.Roles.Queries (displaySubjectsOf)
+import Share.Web.Share.Types
 
 server :: ServerT API.API WebApp
-server orgHandle =
-  API.Routes
-    { API.roles = rolesServer orgHandle
-    }
+server =
+  let orgResourceServer orgHandle = API.ResourceRoutes {API.roles = rolesServer orgHandle}
+   in orgCreateEndpoint :<|> orgResourceServer
+
+orgCreateEndpoint :: UserId -> CreateOrgRequest -> WebApp OrgDisplayInfo
+orgCreateEndpoint callerUserId (CreateOrgRequest {name, handle, avatarUrl, owner = ownerHandle}) = do
+  User {user_id = ownerUserId} <- PG.runTransaction (UserQ.userByHandle ownerHandle) `whenNothingM` respondError (EntityMissing (ErrorID "missing-user") "Owner not found")
+  _authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkCreateOrg callerUserId ownerUserId
+  orgId <- PG.runTransaction $ OrgQ.createOrg name handle avatarUrl owner
+  pure $ OrgDisplayInfo orgId name handle avatarUrl
 
 rolesServer :: UserHandle -> API.OrgRolesRoutes (AsServerT WebApp)
 rolesServer orgHandle =

--- a/src/Share/Web/Share/Orgs/Operations.hs
+++ b/src/Share/Web/Share/Orgs/Operations.hs
@@ -20,7 +20,7 @@ createOrg !authZReceipt name (OrgHandle handle) email avatarUrl owner = do
     queryExpect1Row
       [sql|
     INSERT INTO orgs (user_id) VALUES (#{orgUserId})
-      RETURNING (id, resource_id)
+      RETURNING id, resource_id
     |]
   RoleQ.assignUserRoleMembership authZReceipt owner orgResourceId AuthZ.RoleOrgOwner
   pure orgId

--- a/src/Share/Web/Share/Orgs/Operations.hs
+++ b/src/Share/Web/Share/Orgs/Operations.hs
@@ -1,0 +1,26 @@
+module Share.Web.Share.Orgs.Operations
+  ( createOrg,
+  )
+where
+
+import Share.IDs (OrgHandle (..), OrgId, UserHandle (..), UserId)
+import Share.Postgres
+import Share.Postgres.Users.Queries (UserCreationError)
+import Share.Postgres.Users.Queries qualified as UserQ
+import Share.Prelude
+import Share.Utils.URI
+import Share.Web.Authorization.Types qualified as AuthZ
+import Share.Web.Share.Roles.Queries qualified as RoleQ
+
+createOrg :: AuthZ.AuthZReceipt -> Text -> OrgHandle -> Text -> Maybe URIParam -> UserId -> Transaction UserCreationError OrgId
+createOrg !authZReceipt name (OrgHandle handle) email avatarUrl owner = do
+  let emailVerified = False
+  orgUserId <- UserQ.createUser authZReceipt email (Just name) avatarUrl (UserHandle handle) emailVerified
+  (orgId, orgResourceId) <-
+    queryExpect1Row
+      [sql|
+    INSERT INTO orgs (user_id) VALUES (#{orgUserId})
+      RETURNING (id, resource_id)
+    |]
+  RoleQ.assignUserRoleMembership authZReceipt owner orgResourceId AuthZ.RoleOrgOwner
+  pure orgId

--- a/src/Share/Web/Share/Orgs/Types.hs
+++ b/src/Share/Web/Share/Orgs/Types.hs
@@ -22,7 +22,8 @@ data CreateOrgRequest = CreateOrgRequest
   { name :: Text,
     handle :: OrgHandle,
     avatarUrl :: Maybe URIParam,
-    owner :: UserHandle
+    owner :: UserHandle,
+    email :: Text
   }
   deriving (Show, Eq)
 
@@ -32,4 +33,5 @@ instance FromJSON CreateOrgRequest where
     handle <- o .: "handle"
     avatarUrl <- o .:? "avatarUrl"
     owner <- o .: "owner"
+    email <- o .: "email"
     pure CreateOrgRequest {..}

--- a/src/Share/Web/Share/Orgs/Types.hs
+++ b/src/Share/Web/Share/Orgs/Types.hs
@@ -1,10 +1,35 @@
-module Share.Web.Share.Orgs.Types (Org (..)) where
+{-# LANGUAGE RecordWildCards #-}
 
+module Share.Web.Share.Orgs.Types
+  ( Org (..),
+    CreateOrgRequest (..),
+  )
+where
+
+import Data.Aeson
+import Data.Text (Text)
 import Share.IDs
 import Share.Postgres (DecodeRow (..), decodeField)
+import Share.Utils.URI (URIParam)
 
 newtype Org = Org {orgId :: OrgId}
   deriving (Show, Eq)
 
 instance DecodeRow Org where
   decodeRow = Org <$> decodeField
+
+data CreateOrgRequest = CreateOrgRequest
+  { name :: Text,
+    handle :: OrgHandle,
+    avatarUrl :: Maybe URIParam,
+    owner :: UserHandle
+  }
+  deriving (Show, Eq)
+
+instance FromJSON CreateOrgRequest where
+  parseJSON = withObject "CreateOrgRequest" $ \o -> do
+    name <- o .: "name"
+    handle <- o .: "handle"
+    avatarUrl <- o .:? "avatarUrl"
+    owner <- o .: "owner"
+    pure CreateOrgRequest {..}

--- a/src/Share/Web/Share/Roles/Queries.hs
+++ b/src/Share/Web/Share/Roles/Queries.hs
@@ -1,11 +1,17 @@
 {-# LANGUAGE TypeOperators #-}
 
-module Share.Web.Share.Roles.Queries (displaySubjectsOf) where
+module Share.Web.Share.Roles.Queries
+  ( displaySubjectsOf,
+    assignUserRoleMembership,
+    assignRoleMembership,
+  )
+where
 
 import Control.Lens
+import Share.IDs
 import Share.Postgres
 import Share.Postgres.Users.Queries (userDisplayInfoOf)
-import Share.Web.Authorization.Types (DisplayAuthSubject, ResolvedAuthSubject, _OrgSubject, _TeamSubject, _UserSubject)
+import Share.Web.Authorization.Types (AuthZReceipt, DisplayAuthSubject, ResolvedAuthSubject, RoleRef, _OrgSubject, _TeamSubject, _UserSubject)
 import Share.Web.Share.Orgs.Queries (orgDisplayInfoOf)
 import Share.Web.Share.Teams.Queries (teamDisplayInfoOf)
 
@@ -24,3 +30,20 @@ displaySubjectsOf trav s = pipelined do
           & unsafePartsOf (traversed . _TeamSubject) .~ newTeams
           & unsafePartsOf (traversed . _OrgSubject) .~ newOrgs
       )
+
+-- | Add a role to a user for a specific resource.
+assignUserRoleMembership :: AuthZReceipt -> UserId -> ResourceId -> RoleRef -> Transaction e ()
+assignUserRoleMembership authZReceipt userId resourceId roleRef = do
+  subjectId <- queryExpect1Col [sql| SELECT u.subject_id FROM users u WHERE u.id = #{userId} LIMIT 1|]
+  assignRoleMembership authZReceipt subjectId resourceId roleRef
+
+-- | Add a role to a subject for a specific resource.
+assignRoleMembership :: AuthZReceipt -> SubjectId -> ResourceId -> RoleRef -> Transaction e ()
+assignRoleMembership !_authZReceipt subjectId resourceId roleRef = do
+  execute_
+    [sql|
+    INSERT INTO role_memberships (subject_id, resource_id, role_id)
+      SELECT #{subjectId}, #{resourceId}, r.id
+      FROM roles r
+      WHERE r.ref = #{roleRef}
+    |]

--- a/src/Share/Web/Share/Roles/Queries.hs
+++ b/src/Share/Web/Share/Roles/Queries.hs
@@ -45,5 +45,5 @@ assignRoleMembership !_authZReceipt subjectId resourceId roleRef = do
     INSERT INTO role_memberships (subject_id, resource_id, role_id)
       SELECT #{subjectId}, #{resourceId}, r.id
       FROM roles r
-      WHERE r.ref = #{roleRef}
+      WHERE r.ref = #{roleRef}::role_ref
     |]

--- a/src/Share/Web/UCM/Projects/Impl.hs
+++ b/src/Share/Web/UCM/Projects/Impl.hs
@@ -24,6 +24,7 @@ import Share.Postgres.NameLookups.Ops qualified as NLOps
 import Share.Postgres.NameLookups.Types (NameLookupReceipt)
 import Share.Postgres.Ops qualified as PGO
 import Share.Postgres.Queries qualified as Q
+import Share.Postgres.Users.Queries qualified as UserQ
 import Share.Prelude
 import Share.Project
 import Share.Release (Release (..))
@@ -65,7 +66,7 @@ getProjectEndpoint (AuthN.MaybeAuthedUserID callerUserId) mayUcmProjectId mayUcm
   projectId <- lift (runMaybeT (projectIdByName <|> projectIdQueryParam)) `whenNothingM` throwError (UCMProjects.GetProjectResponseNotFound (UCMProjects.NotFound "Project not found"))
   (Project {slug = projectSlug}, User {handle}, defaultBranch, latestRelease) <- pgT $ do
     (project@Project {ownerUserId}, _favData, _projectOwner, defaultBranch, latestRelease) <- Q.projectByIdWithMetadata callerUserId projectId `orThrow` UCMProjects.GetProjectResponseNotFound (UCMProjects.NotFound "Project not found")
-    user <- Q.userByUserId ownerUserId `orThrow` UCMProjects.GetProjectResponseNotFound (UCMProjects.NotFound "User not found")
+    user <- UserQ.userByUserId ownerUserId `orThrow` UCMProjects.GetProjectResponseNotFound (UCMProjects.NotFound "User not found")
     pure (project, user, fmap IDs.toText defaultBranch, fmap IDs.toText latestRelease)
   _authZReceipt <- AuthZ.checkProjectGet callerUserId projectId `ifUnauthorized` UCMProjects.GetProjectResponseUnauthorized
   let apiProject = UCMProjects.Project {projectId = IDs.toText projectId, projectName = IDs.toText (ProjectShortHand {userHandle = handle, projectSlug}), latestRelease, defaultBranch}
@@ -87,7 +88,7 @@ createProjectEndpoint :: Maybe Session -> UCMProjects.CreateProjectRequest -> We
 createProjectEndpoint (AuthN.MaybeAuthedUserID callerUserId) (UCMProjects.CreateProjectRequest {projectName}) = toResponse do
   ProjectShortHand {userHandle, projectSlug} <- lift $ parseParam @ProjectShortHand "projectName" projectName
   User {user_id = targetUserId} <- pgT do
-    Q.userByHandle userHandle `orThrow` UCMProjects.CreateProjectResponseNotFound (UCMProjects.NotFound "User not found")
+    UserQ.userByHandle userHandle `orThrow` UCMProjects.CreateProjectResponseNotFound (UCMProjects.NotFound "User not found")
   AuthZ.checkProjectCreate callerUserId targetUserId `ifUnauthorized` UCMProjects.CreateProjectResponseUnauthorized
   let visibility = ProjectPrivate
   let summary = Nothing
@@ -105,11 +106,11 @@ getProjectBranchEndpoint (AuthN.MaybeAuthedUserID mayCallerUserId) projectIdPara
     -- We lump the project not found and user not found errors together here because if the
     -- project exists, the user MUST exist because of the foreign key constraint,
     -- so this error should never happen.
-    projectOwnerUser <- Q.userByUserId ownerUserId `orThrow` UCMProjects.GetProjectBranchResponseProjectNotFound (UCMProjects.NotFound "User not found")
+    projectOwnerUser <- UserQ.userByUserId ownerUserId `orThrow` UCMProjects.GetProjectBranchResponseProjectNotFound (UCMProjects.NotFound "User not found")
     let contributorId = case branchOrRelease of
           Left Branch {contributorId} -> contributorId
           Right _ -> Nothing
-    mayContributorUser <- for contributorId \cid -> Q.userByUserId cid `orThrow` UCMProjects.GetProjectBranchResponseProjectNotFound (UCMProjects.NotFound "User not found")
+    mayContributorUser <- for contributorId \cid -> UserQ.userByUserId cid `orThrow` UCMProjects.GetProjectBranchResponseProjectNotFound (UCMProjects.NotFound "User not found")
     pure (project, projectOwnerUser, mayContributorUser)
 
   authZReceipt <- case branchOrRelease of
@@ -233,7 +234,7 @@ createProjectBranch
       (project@Project {projectId, ownerUserId, slug}, mayContributorUserId) <- pgT $ do
         project <- Q.projectById projectId `orThrow` UCMProjects.CreateProjectBranchResponseNotFound (UCMProjects.NotFound "Project not found")
         mayContributorUserId <- for contributorHandle \ch -> do
-          User {user_id = contributorUserId} <- Q.userByHandle ch `orThrow` UCMProjects.CreateProjectBranchResponseNotFound (UCMProjects.NotFound "Contributor not found")
+          User {user_id = contributorUserId} <- UserQ.userByHandle ch `orThrow` UCMProjects.CreateProjectBranchResponseNotFound (UCMProjects.NotFound "Contributor not found")
           pure contributorUserId
         pure (project, mayContributorUserId)
       let codebaseLoc = Codebase.codebaseLocationForProjectBranchCodebase ownerUserId mayContributorUserId
@@ -257,7 +258,7 @@ createProjectBranch
       signedBranchHead <- lift $ HashJWT.signHashForUser (Just callerUserId) (causalHashToHash32 branchCausalHash)
       apiBranch <- pgT $ do
         branchId <- Q.createBranch nameLookupReceipt projectId branchName mayContributorUserId branchCausalId mayMergeMergeTargetBranchId callerUserId
-        User {handle = projectOwnerHandle} <- Q.userByUserId ownerUserId `orThrow` UCMProjects.CreateProjectBranchResponseNotFound (UCMProjects.NotFound "Project owner not found")
+        User {handle = projectOwnerHandle} <- UserQ.userByUserId ownerUserId `orThrow` UCMProjects.CreateProjectBranchResponseNotFound (UCMProjects.NotFound "Project owner not found")
         let projectShortHand =
               ProjectShortHand
                 { userHandle = projectOwnerHandle,
@@ -299,7 +300,7 @@ createProjectRelease callerUserId projectId unsquashedCausalHash releaseName = t
   signedSquashedCausalHash <- lift $ HashJWT.signHashForUser (Just callerUserId) (causalHashToHash32 squashedCausalHash)
   apiRelease <- pgT $ do
     Release {releaseId} <- Q.createRelease nlReceipt projectId releaseName squashedCausalId unsquashedCausalId callerUserId
-    User {handle = projectOwnerHandle} <- Q.userByUserId ownerUserId `orThrow` UCMProjects.CreateProjectBranchResponseNotFound (UCMProjects.NotFound "Project owner not found")
+    User {handle = projectOwnerHandle} <- UserQ.userByUserId ownerUserId `orThrow` UCMProjects.CreateProjectBranchResponseNotFound (UCMProjects.NotFound "Project owner not found")
     let projectShortHand =
           ProjectShortHand
             { userHandle = projectOwnerHandle,
@@ -360,7 +361,7 @@ setProjectBranchHead callerUserId projectId branchId mayOldCausalHash newCausalH
             -- No-op
             pure ()
         | otherwise -> do
-            User {handle = callingUserHandle} <- Q.userByUserId callerUserId `orThrow` UCMProjects.SetProjectBranchHeadResponseNotFound (UCMProjects.NotFound "User not found")
+            User {handle = callingUserHandle} <- UserQ.userByUserId callerUserId `orThrow` UCMProjects.SetProjectBranchHeadResponseNotFound (UCMProjects.NotFound "User not found")
             let description = "Pushed by " <> (IDs.toText $ PrefixedID @"@" callingUserHandle)
             newNamespaceId <- HashQ.expectNamespaceIdsByCausalIdsOf id newCausalId
             nlReceipt <- NLOps.ensureNameLookupForBranchId newNamespaceId

--- a/src/Share/Web/UCM/SyncV2/Impl.hs
+++ b/src/Share/Web/UCM/SyncV2/Impl.hs
@@ -25,6 +25,7 @@ import Share.Postgres qualified as PG
 import Share.Postgres.Causal.Queries qualified as CausalQ
 import Share.Postgres.Cursors qualified as Cursor
 import Share.Postgres.Queries qualified as PGQ
+import Share.Postgres.Users.Queries qualified as UserQ
 import Share.Prelude
 import Share.Project (Project (..))
 import Share.User (User (..))
@@ -172,7 +173,7 @@ codebaseForBranchRef branchRef = do
       let projectShortHand = ProjectShortHand {userHandle, projectSlug}
       (Project {ownerUserId = projectOwnerUserId}, contributorId) <- ExceptT . PG.tryRunTransaction $ do
         project <- (PGQ.projectByShortHand projectShortHand) `whenNothingM` throwError (CodebaseLoadingErrorProjectNotFound projectShortHand)
-        mayContributorUserId <- for contributorHandle \ch -> fmap user_id $ (PGQ.userByHandle ch) `whenNothingM` throwError (CodebaseLoadingErrorUserNotFound ch)
+        mayContributorUserId <- for contributorHandle \ch -> fmap user_id $ (UserQ.userByHandle ch) `whenNothingM` throwError (CodebaseLoadingErrorUserNotFound ch)
         pure (project, mayContributorUserId)
       authZToken <- lift AuthZ.checkDownloadFromProjectBranchCodebase `whenLeftM` \_err -> throwError (CodebaseLoadingErrorNoReadPermission branchRef)
       let codebaseLoc = Codebase.codebaseLocationForProjectBranchCodebase projectOwnerUserId contributorId

--- a/transcripts/run-transcripts.zsh
+++ b/transcripts/run-transcripts.zsh
@@ -28,6 +28,7 @@ transcripts=(
     code-browse transcripts/share-apis/code-browse/
     roles transcripts/share-apis/roles/
     sync-apis transcripts/sync-apis/
+    orgs transcripts/share-apis/orgs/
 )
 
 for transcript dir in "${(@kv)transcripts}"; do

--- a/transcripts/share-apis/orgs/org-create-by-admin.json
+++ b/transcripts/share-apis/orgs/org-create-by-admin.json
@@ -1,0 +1,16 @@
+{
+  "body": {
+    "orgId": "ORG-<UUID>",
+    "user": {
+      "avatarUrl": "https://example.com/anvil.png",
+      "handle": "acme",
+      "name": "ACME",
+      "userId": "U-<UUID>"
+    }
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/orgs/org-create-unauthorized.json
+++ b/transcripts/share-apis/orgs/org-create-unauthorized.json
@@ -1,0 +1,8 @@
+{
+  "body": "Permission Denied: Not permitted to create an org for this user",
+  "status": [
+    {
+      "status_code": 403
+    }
+  ]
+}

--- a/transcripts/share-apis/orgs/run.zsh
+++ b/transcripts/share-apis/orgs/run.zsh
@@ -1,0 +1,25 @@
+#!/usr/bin/env zsh
+
+set -e
+
+source "../../transcript_helpers.sh"
+
+# Org creation workflow
+
+# Should fail
+fetch "$unauthorized_user" POST org-create-unauthorized '/orgs' '{
+  "name": "ACME",
+  "handle": "acme",
+  "avatarUrl": "https://example.com/anvil.png",
+  "owner": "unauthorized",
+  "email": "wile.e.coyote@example.com"
+}'
+
+# Admin can create an org and assign any owner.
+fetch "$admin_user" POST org-create-by-admin '/orgs' '{
+  "name": "ACME",
+  "handle": "acme",
+  "avatarUrl": "https://example.com/anvil.png",
+  "owner": "transcripts",
+  "email": "wile.e.coyote@example.com"
+}'

--- a/transcripts/sql/inserts.sql
+++ b/transcripts/sql/inserts.sql
@@ -472,3 +472,6 @@ CSV HEADER;
 
 INSERT INTO public.cloud_subscribers(user_id, is_active, tier_name) VALUES
   ('d32f4ddf-2423-4f10-a4de-465939951354', true, 'Starter');
+
+INSERT INTO superadmins(user_id) VALUES
+  ('fe8921ca-aee7-40a2-8020-241ca78f2a5c');


### PR DESCRIPTION
Adds the ability for Unison Admins to create a new organization.

E.g.

```
POST '/orgs' '{
  "name": "ACME",
  "handle": "acme",
  "avatarUrl": "https://example.com/anvil.png",
  "owner": "transcripts",
  "email": "wile.e.coyote@example.com"
}'
```

```
Response
{
    "orgId": "ORG-<UUID>",
    "user": {
      "avatarUrl": "https://example.com/anvil.png",
      "handle": "acme",
      "name": "ACME",
      "userId": "U-<UUID>"
    }
  }
```

Implementation changes:

* Adds the `superadmins` table, it started to feel dangerous using the Unison Org for admins, since we may eventually add maintainers or contributors there
* Refactors/moves a bunch of queries around to avoid cyclic imports
* Adds the `CreateOrgEndpoint`