### PR TITLE
Add type of user and permissions for that user in the user-profile endpoint

### DIFF
--- a/share-api.cabal
+++ b/share-api.cabal
@@ -136,6 +136,7 @@ library
       Share.Web.Share.DefinitionSearch
       Share.Web.Share.Diffs.Impl
       Share.Web.Share.Diffs.Types
+      Share.Web.Share.DisplayInfo
       Share.Web.Share.Impl
       Share.Web.Share.Orgs.API
       Share.Web.Share.Orgs.Impl

--- a/src/Share/Postgres/Users/Queries.hs
+++ b/src/Share/Postgres/Users/Queries.hs
@@ -45,7 +45,7 @@ import Share.Utils.Postgres
 import Share.Utils.URI (URIParam (..))
 import Share.Web.Authorization.Types qualified as AuthZ
 import Share.Web.Errors (EntityMissing (EntityMissing), ErrorID (..), ToServerError (..))
-import Share.Web.Share.Types
+import Share.Web.Share.DisplayInfo (UserDisplayInfo (..))
 
 -- | Efficiently resolve User Display Info for UserIds within a structure.
 userDisplayInfoOf :: (PG.QueryA m) => Traversal s t UserId UserDisplayInfo -> s -> m t

--- a/src/Share/Web/Authorization/Types.hs
+++ b/src/Share/Web/Authorization/Types.hs
@@ -48,7 +48,7 @@ import Share.IDs
 import Share.Postgres qualified as PG
 import Share.Prelude
 import Share.Utils.API (AtKey (..))
-import Share.Web.Share.Types (OrgDisplayInfo, TeamDisplayInfo, UserDisplayInfo)
+import Share.Web.Share.DisplayInfo
 
 data SubjectKind = UserSubjectKind | OrgSubjectKind | TeamSubjectKind
   deriving (Show)

--- a/src/Share/Web/Share/Branches/Types.hs
+++ b/src/Share/Web/Share/Branches/Types.hs
@@ -14,8 +14,8 @@ import Share.IDs
 import Share.IDs qualified as IDs
 import Share.Postgres.IDs
 import Share.Web.Share.Contributions.Types (ShareContribution)
+import Share.Web.Share.DisplayInfo (UserDisplayInfo)
 import Share.Web.Share.Projects.Types
-import Share.Web.Share.Types (UserDisplayInfo)
 
 branchToShareBranch :: BranchShortHand -> Branch CausalHash -> APIProject -> [ShareContribution UserDisplayInfo] -> ShareBranch
 branchToShareBranch branchShortHand Branch {createdAt, updatedAt, causal} project contributions = do

--- a/src/Share/Web/Share/Comments/API.hs
+++ b/src/Share/Web/Share/Comments/API.hs
@@ -3,11 +3,11 @@
 
 module Share.Web.Share.Comments.API (CommentsServer) where
 
+import Servant
 import Share.IDs
 import Share.Web.Share.Comments
 import Share.Web.Share.Comments.Types
-import Share.Web.Share.Types (UserDisplayInfo)
-import Servant
+import Share.Web.Share.DisplayInfo (UserDisplayInfo)
 
 type CommentResourceServer = UpdateComment :<|> DeleteComment
 

--- a/src/Share/Web/Share/Comments/Impl.hs
+++ b/src/Share/Web/Share/Comments/Impl.hs
@@ -21,7 +21,7 @@ import Share.Web.Authorization qualified as AuthZ
 import Share.Web.Errors
 import Share.Web.Share.Comments
 import Share.Web.Share.Comments.Types
-import Share.Web.Share.Types
+import Share.Web.Share.DisplayInfo (UserDisplayInfo (..))
 
 createCommentEndpoint ::
   Maybe Session ->

--- a/src/Share/Web/Share/Comments/Types.hs
+++ b/src/Share/Web/Share/Comments/Types.hs
@@ -9,7 +9,7 @@ module Share.Web.Share.Comments.Types where
 import Data.Aeson
 import Share.Prelude
 import Share.Web.Share.Comments (CommentEvent (..), RevisionNumber)
-import Share.Web.Share.Types (UserDisplayInfo)
+import Share.Web.Share.DisplayInfo (UserDisplayInfo)
 
 data CreateCommentRequest = CreateCommentRequest
   { content :: Text

--- a/src/Share/Web/Share/Contributions/API.hs
+++ b/src/Share/Web/Share/Contributions/API.hs
@@ -14,7 +14,7 @@ import Share.Utils.Servant (RequiredQueryParam)
 import Share.Web.Share.Comments.API qualified as Comments
 import Share.Web.Share.Contributions.Types
 import Share.Web.Share.Diffs.Types (ShareNamespaceDiffResponse, ShareTermDiffResponse, ShareTypeDiffResponse)
-import Share.Web.Share.Types (UserDisplayInfo)
+import Share.Web.Share.DisplayInfo (UserDisplayInfo)
 import Unison.Name (Name)
 
 type ContributionsByUserAPI = ListContributionsByUserEndpoint

--- a/src/Share/Web/Share/Contributions/Impl.hs
+++ b/src/Share/Web/Share/Contributions/Impl.hs
@@ -53,7 +53,7 @@ import Share.Web.Share.Contributions.MergeDetection qualified as MergeDetection
 import Share.Web.Share.Contributions.Types
 import Share.Web.Share.Diffs.Impl qualified as Diffs
 import Share.Web.Share.Diffs.Types (ShareNamespaceDiffResponse (..), ShareTermDiffResponse (..), ShareTypeDiffResponse (..))
-import Share.Web.Share.Types (UserDisplayInfo)
+import Share.Web.Share.DisplayInfo (UserDisplayInfo (..))
 import Unison.Name (Name)
 import Unison.Server.Types
 import Unison.Syntax.Name qualified as Name

--- a/src/Share/Web/Share/Contributions/Types.hs
+++ b/src/Share/Web/Share/Contributions/Types.hs
@@ -20,7 +20,7 @@ import Share.Utils.API (NullableUpdate, parseNullableUpdate)
 import Share.Utils.Logging qualified as Logging
 import Share.Web.Errors qualified as Err
 import Share.Web.Share.Comments (CommentEvent (..), commentEventTimestamp)
-import Share.Web.Share.Types (UserDisplayInfo)
+import Share.Web.Share.DisplayInfo (UserDisplayInfo)
 import U.Codebase.HashTags (CausalHash (..))
 import Unison.Hash qualified as Hash
 import Web.HttpApiData (ToHttpApiData (..))

--- a/src/Share/Web/Share/DisplayInfo.hs
+++ b/src/Share/Web/Share/DisplayInfo.hs
@@ -1,0 +1,63 @@
+-- Standard ways of displaying core Share concepts.
+--
+-- This was consolidated to this module mostly to avoid circular imports.
+module Share.Web.Share.DisplayInfo
+  ( UserDisplayInfo (..),
+    OrgDisplayInfo (..),
+    TeamDisplayInfo (..),
+  )
+where
+
+import Data.Aeson (ToJSON (..))
+import Data.Aeson qualified as Aeson
+import Network.URI (URI)
+import Share.IDs
+import Share.Prelude
+import Share.Utils.URI (URIParam (..))
+
+-- | Common type for displaying a user.
+data UserDisplayInfo = UserDisplayInfo
+  { handle :: UserHandle,
+    name :: Maybe Text,
+    avatarUrl :: Maybe URI,
+    userId :: UserId
+  }
+  deriving (Show, Eq, Ord)
+
+instance ToJSON UserDisplayInfo where
+  toJSON UserDisplayInfo {handle, name, avatarUrl, userId} =
+    Aeson.object
+      [ "handle" Aeson..= handle,
+        "name" Aeson..= name,
+        "avatarUrl" Aeson..= (URIParam <$> avatarUrl),
+        "userId" Aeson..= userId
+      ]
+
+-- | Common type for displaying an Org.
+data OrgDisplayInfo = OrgDisplayInfo
+  { user :: UserDisplayInfo,
+    orgId :: OrgId
+  }
+  deriving (Show, Eq, Ord)
+
+instance ToJSON OrgDisplayInfo where
+  toJSON OrgDisplayInfo {user, orgId} =
+    Aeson.object
+      [ "user" Aeson..= user,
+        "orgId" Aeson..= orgId
+      ]
+
+data TeamDisplayInfo = TeamDisplayInfo
+  { teamId :: TeamId,
+    name :: Text,
+    avatarUrl :: Maybe URI
+  }
+  deriving (Show, Eq, Ord)
+
+instance ToJSON TeamDisplayInfo where
+  toJSON TeamDisplayInfo {teamId, name, avatarUrl} =
+    Aeson.object
+      [ "teamId" Aeson..= teamId,
+        "name" Aeson..= name,
+        "avatarUrl" Aeson..= (URIParam <$> avatarUrl)
+      ]

--- a/src/Share/Web/Share/Orgs/API.hs
+++ b/src/Share/Web/Share/Orgs/API.hs
@@ -8,8 +8,8 @@ import Servant
 import Share.IDs
 import Share.OAuth.Session (AuthenticatedUserId)
 import Share.Web.Authorization.Types (AddRolesRequest, ListRolesResponse, RemoveRolesRequest)
+import Share.Web.Share.DisplayInfo (OrgDisplayInfo)
 import Share.Web.Share.Orgs.Types
-import Share.Web.Share.Types (OrgDisplayInfo)
 
 type API =
   CreateOrgEndpoint

--- a/src/Share/Web/Share/Orgs/Impl.hs
+++ b/src/Share/Web/Share/Orgs/Impl.hs
@@ -13,13 +13,13 @@ import Share.Web.App
 import Share.Web.Authorization qualified as AuthZ
 import Share.Web.Authorization.Types
 import Share.Web.Errors
+import Share.Web.Share.DisplayInfo (OrgDisplayInfo)
 import Share.Web.Share.Orgs.API as API
 import Share.Web.Share.Orgs.Operations qualified as OrgOps
 import Share.Web.Share.Orgs.Queries qualified as OrgQ
 import Share.Web.Share.Orgs.Types (CreateOrgRequest (..), Org (..))
 import Share.Web.Share.Roles (canonicalRoleAssignmentOrdering)
 import Share.Web.Share.Roles.Queries (displaySubjectsOf)
-import Share.Web.Share.Types
 
 server :: ServerT API.API WebApp
 server =

--- a/src/Share/Web/Share/Orgs/Queries.hs
+++ b/src/Share/Web/Share/Orgs/Queries.hs
@@ -18,8 +18,8 @@ import Share.Postgres
 import Share.Prelude
 import Share.Utils.URI
 import Share.Web.Authorization.Types
+import Share.Web.Share.DisplayInfo (OrgDisplayInfo (..), UserDisplayInfo (..))
 import Share.Web.Share.Orgs.Types (Org)
-import Share.Web.Share.Types (OrgDisplayInfo (..), UserDisplayInfo (..))
 
 orgByUserId :: UserId -> Transaction e (Maybe Org)
 orgByUserId orgUserId = do

--- a/src/Share/Web/Share/Roles.hs
+++ b/src/Share/Web/Share/Roles.hs
@@ -6,7 +6,7 @@ where
 import Data.List qualified as List
 import Share.IDs qualified as IDs
 import Share.Web.Authorization.Types
-import Share.Web.Share.Types
+import Share.Web.Share.DisplayInfo (OrgDisplayInfo (..), TeamDisplayInfo (..), UserDisplayInfo (..))
 
 -- | The ordering isn't necessary logic, it just makes transcript tests much easier.
 canonicalRoleAssignmentOrdering :: [RoleAssignment DisplayAuthSubject] -> [RoleAssignment DisplayAuthSubject]

--- a/src/Share/Web/Share/Teams/Queries.hs
+++ b/src/Share/Web/Share/Teams/Queries.hs
@@ -5,7 +5,7 @@ import Share.IDs
 import Share.Postgres
 import Share.Prelude
 import Share.Utils.URI (URIParam (..))
-import Share.Web.Share.Types
+import Share.Web.Share.DisplayInfo (TeamDisplayInfo (..))
 
 -- | Efficiently resolve Team Display Info for TeamIds within a structure.
 teamDisplayInfoOf :: (QueryA m) => Traversal s t TeamId TeamDisplayInfo -> s -> m t

--- a/src/Share/Web/Share/Tickets/API.hs
+++ b/src/Share/Web/Share/Tickets/API.hs
@@ -9,8 +9,8 @@ import Share.IDs
 import Share.Ticket
 import Share.Utils.API
 import Share.Web.Share.Comments.API qualified as Comments
+import Share.Web.Share.DisplayInfo (UserDisplayInfo (..))
 import Share.Web.Share.Tickets.Types
-import Share.Web.Share.Types (UserDisplayInfo)
 
 type TicketsByUserAPI = ListTicketsByUserEndpoint
 

--- a/src/Share/Web/Share/Tickets/Impl.hs
+++ b/src/Share/Web/Share/Tickets/Impl.hs
@@ -31,10 +31,10 @@ import Share.Web.Errors
 import Share.Web.Share.Comments
 import Share.Web.Share.Comments.Impl qualified as Comments
 import Share.Web.Share.Comments.Types
+import Share.Web.Share.DisplayInfo (UserDisplayInfo (..))
 import Share.Web.Share.Tickets.API
 import Share.Web.Share.Tickets.API qualified as API
 import Share.Web.Share.Tickets.Types
-import Share.Web.Share.Types (UserDisplayInfo)
 
 ticketsByProjectServer :: Maybe Session -> UserHandle -> ProjectSlug -> ServerT API.TicketsByProjectAPI WebApp
 ticketsByProjectServer session handle projectSlug =

--- a/src/Share/Web/Share/Tickets/Types.hs
+++ b/src/Share/Web/Share/Tickets/Types.hs
@@ -14,7 +14,7 @@ import Share.Prelude
 import Share.Ticket (TicketStatus)
 import Share.Utils.API (NullableUpdate, parseNullableUpdate)
 import Share.Web.Share.Comments
-import Share.Web.Share.Types (UserDisplayInfo)
+import Share.Web.Share.DisplayInfo (UserDisplayInfo (..))
 
 data ShareTicket user = ShareTicket
   { ticketId :: TicketId,
@@ -70,7 +70,7 @@ data StatusChangeEvent user = StatusChangeEvent
   }
   deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
 
-instance PG.DecodeField user => PG.DecodeRow (StatusChangeEvent user) where
+instance (PG.DecodeField user) => PG.DecodeRow (StatusChangeEvent user) where
   decodeRow = do
     oldStatus <- PG.decodeField
     newStatus <- PG.decodeField
@@ -88,7 +88,7 @@ eventTimestamp = \case
   TicketTimelineStatusChange StatusChangeEvent {timestamp} -> timestamp
   TicketTimelineComment commentEvent -> commentEventTimestamp commentEvent
 
-instance ToJSON user => ToJSON (TicketTimelineEvent user) where
+instance (ToJSON user) => ToJSON (TicketTimelineEvent user) where
   toJSON = \case
     TicketTimelineStatusChange StatusChangeEvent {..} ->
       object

--- a/src/Share/Web/Share/Types.hs
+++ b/src/Share/Web/Share/Types.hs
@@ -6,7 +6,6 @@ module Share.Web.Share.Types where
 
 import Data.Aeson (KeyValue ((.=)), ToJSON (..))
 import Data.Aeson qualified as Aeson
-import Network.URI (URI)
 import Share.BackgroundJobs.Search.DefinitionSync.Types (TermOrTypeTag)
 import Share.BackgroundJobs.Search.DefinitionSync.Types qualified as DefSync
 import Share.IDs
@@ -14,6 +13,8 @@ import Share.Prelude
 import Share.Project (ProjectVisibility)
 import Share.Utils.API (NullableUpdate, parseNullableUpdate)
 import Share.Utils.URI
+import Share.Web.Authorization.Types (RolePermission)
+import Share.Web.Share.DisplayInfo (UserDisplayInfo (..))
 import Unison.Name (Name)
 import Unison.Server.Doc (Doc)
 import Unison.Server.Share.DefinitionSummary.Types (TermSummary (..), TypeSummary (..))
@@ -40,6 +41,14 @@ instance Aeson.FromJSON UpdateUserRequest where
     pronouns <- parseNullableUpdate o "pronouns"
     pure UpdateUserRequest {..}
 
+data UserKind = UserKind | OrgKind
+  deriving (Show, Eq, Ord)
+
+instance ToJSON UserKind where
+  toJSON = \case
+    UserKind -> "user"
+    OrgKind -> "org"
+
 data DescribeUserProfile = DescribeUserProfile
   { handle :: UserHandle,
     name :: Maybe Text,
@@ -48,7 +57,9 @@ data DescribeUserProfile = DescribeUserProfile
     website :: Maybe Text,
     location :: Maybe Text,
     twitterHandle :: Maybe Text,
-    pronouns :: Maybe Text
+    pronouns :: Maybe Text,
+    kind :: UserKind,
+    permissions :: Set RolePermission
   }
   deriving (Show)
 
@@ -137,53 +148,6 @@ instance ToJSON UserAccountInfo where
       ]
 
 type PathSegment = Text
-
--- | Common type for displaying a user.
-data UserDisplayInfo = UserDisplayInfo
-  { handle :: UserHandle,
-    name :: Maybe Text,
-    avatarUrl :: Maybe URI,
-    userId :: UserId
-  }
-  deriving (Show, Eq, Ord)
-
-instance ToJSON UserDisplayInfo where
-  toJSON UserDisplayInfo {handle, name, avatarUrl, userId} =
-    Aeson.object
-      [ "handle" Aeson..= handle,
-        "name" Aeson..= name,
-        "avatarUrl" Aeson..= avatarUrl,
-        "userId" Aeson..= userId
-      ]
-
--- | Common type for displaying an Org.
-data OrgDisplayInfo = OrgDisplayInfo
-  { user :: UserDisplayInfo,
-    orgId :: OrgId
-  }
-  deriving (Show, Eq, Ord)
-
-instance ToJSON OrgDisplayInfo where
-  toJSON OrgDisplayInfo {user, orgId} =
-    Aeson.object
-      [ "user" Aeson..= user,
-        "orgId" Aeson..= orgId
-      ]
-
-data TeamDisplayInfo = TeamDisplayInfo
-  { teamId :: TeamId,
-    name :: Text,
-    avatarUrl :: Maybe URI
-  }
-  deriving (Show, Eq, Ord)
-
-instance ToJSON TeamDisplayInfo where
-  toJSON TeamDisplayInfo {teamId, name, avatarUrl} =
-    Aeson.object
-      [ "teamId" Aeson..= teamId,
-        "name" Aeson..= name,
-        "avatarUrl" Aeson..= avatarUrl
-      ]
 
 data DefinitionNameSearchResult = DefinitionNameSearchResult
   { token :: Name,

--- a/src/Share/Web/Share/Types.hs
+++ b/src/Share/Web/Share/Types.hs
@@ -64,7 +64,7 @@ data DescribeUserProfile = DescribeUserProfile
   deriving (Show)
 
 instance ToJSON DescribeUserProfile where
-  toJSON DescribeUserProfile {..} =
+  toJSON (DescribeUserProfile handle name avatarUrl bio website location twitterHandle pronouns kind permissions) =
     Aeson.object
       [ "handle" .= fromId @UserHandle @Text handle,
         "name" .= name,
@@ -73,7 +73,9 @@ instance ToJSON DescribeUserProfile where
         "website" .= website,
         "location" .= location,
         "twitterHandle" .= twitterHandle,
-        "pronouns" .= pronouns
+        "pronouns" .= pronouns,
+        "kind" .= kind,
+        "permissions" Aeson..= permissions
       ]
 
 data ReadmeResponse = ReadmeResponse

--- a/transcripts/share-apis/orgs/org-get-profile.json
+++ b/transcripts/share-apis/orgs/org-get-profile.json
@@ -1,0 +1,33 @@
+{
+  "body": {
+    "avatarUrl": "https://example.com/anvil.png",
+    "bio": null,
+    "handle": "acme",
+    "kind": "org",
+    "location": null,
+    "name": "ACME",
+    "permissions": [
+      "project:view",
+      "project:manage",
+      "project:contribute",
+      "project:maintain",
+      "project:delete",
+      "org:view",
+      "org:manage",
+      "org:admin",
+      "org:delete",
+      "org:change_owner",
+      "org:create_project",
+      "team:view",
+      "team:manage"
+    ],
+    "pronouns": null,
+    "twitterHandle": null,
+    "website": null
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/orgs/run.zsh
+++ b/transcripts/share-apis/orgs/run.zsh
@@ -23,3 +23,6 @@ fetch "$admin_user" POST org-create-by-admin '/orgs' '{
   "owner": "transcripts",
   "email": "wile.e.coyote@example.com"
 }'
+
+# Permissions within an org should show in the get-user endpoint
+fetch "$transcript_user" GET org-get-profile '/users/acme' 

--- a/transcripts/share-apis/users/user-profile-update.json
+++ b/transcripts/share-apis/users/user-profile-update.json
@@ -3,8 +3,10 @@
     "avatarUrl": "http://updated.com",
     "bio": "Updated bio",
     "handle": "transcripts",
+    "kind": "user",
     "location": "Updated location",
     "name": "Updated Transcripts",
+    "permissions": [],
     "pronouns": "updated/pronouns",
     "twitterHandle": "updated-twitter",
     "website": "http://updated-website.com"

--- a/transcripts/share-apis/users/user-profile.json
+++ b/transcripts/share-apis/users/user-profile.json
@@ -3,8 +3,10 @@
     "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
     "bio": "A transcript!",
     "handle": "transcripts",
+    "kind": "user",
     "location": "Unison Share",
     "name": "Transcript User",
+    "permissions": [],
     "pronouns": "they/them",
     "twitterHandle": "@unisonTranscript",
     "website": "https://unison-lang.org"


### PR DESCRIPTION
On the user-profile endpoint, adds a `kind` which is `user` or `org`, if `org`, includes the permissions the caller has for that user. (The permissions list is included on kind = user, but will always be empty ATM.)

```
GET /users/acme

{
    "avatarUrl": "https://example.com/anvil.png",
    "bio": null,
    "handle": "acme",
    "kind": "org",
    "location": null,
    "name": "ACME",
    "permissions": [
      "project:view",
      "project:manage",
      "project:contribute",
      "project:maintain",
      "project:delete",
      "org:view",
      "org:manage",
      "org:admin",
      "org:delete",
      "org:change_owner",
      "org:create_project",
      "team:view",
      "team:manage"
    ],
    "pronouns": null,
    "twitterHandle": null,
    "website": null
  }
```