### PR TITLE
Add ability to specify a "handle" param on login to pick preferred handle if Github Handle is taken

### DIFF
--- a/share-auth/src/Share/OAuth/API.hs
+++ b/share-auth/src/Share/OAuth/API.hs
@@ -17,12 +17,12 @@ module Share.OAuth.API
 where
 
 import Data.Text (Text)
+import Servant
 import Share.OAuth.Scopes
 import Share.OAuth.Session
 import Share.OAuth.Types
 import Share.Utils.Servant.Cookies (Cookie)
 import Share.Utils.URI (URIParam)
-import Servant
 import Web.Cookie (SetCookie)
 
 type RequiredQueryParam = QueryParam' '[Required, Strict]
@@ -47,6 +47,7 @@ type IdentityProviderAPI =
 type LoginEndpoint =
   -- Where to redirect to after login
   QueryParam "return_to" URIParam
+    :> QueryParam "handle" Text
     :> Verb 'GET 302 '[PlainText] (Headers '[Header "Set-Cookie" SetCookie, Header "Location" String] NoContent)
 
 -- | GET /logout

--- a/share-auth/src/Share/OAuth/ServiceProvider.hs
+++ b/share-auth/src/Share/OAuth/ServiceProvider.hs
@@ -22,10 +22,12 @@ where
 import Control.Monad.Except
 import Control.Monad.Trans (MonadTrans (..))
 import Crypto.JWT (JWTError)
-import Data.Aeson (ToJSON (toJSON))
+import Data.Aeson (ToJSON (..))
 import Data.Aeson qualified as Aeson
 import Data.Function ((&))
+import Data.Functor ((<&>))
 import Data.Maybe (fromMaybe)
+import Data.Map qualified as Map
 import Data.Text (Text)
 import Database.Redis qualified as Redis
 import Servant
@@ -133,13 +135,14 @@ loginEndpoint ::
   IdentityProviderConfig ->
   ServiceProviderConfig ->
   Maybe URIParam ->
+  Maybe Text ->
   m
     ( Headers
         '[Header "Set-Cookie" SetCookie, Header "Location" String]
         NoContent
     )
-loginEndpoint idpConfig spConfig returnToURI = do
-  loginEndpointWithData idpConfig spConfig (Nothing :: Maybe Aeson.Value) returnToURI
+loginEndpoint idpConfig spConfig returnToURI preferredHandle = do
+  loginEndpointWithData idpConfig spConfig (preferredHandle <&> \handle -> toJSON $ Map.singleton ("handle" :: Text) handle) returnToURI
 
 -- | Log in the user and set a session cookie, propagating a value to the session callback.
 loginEndpointWithData ::

--- a/src/Share/Postgres/Users/Queries.hs
+++ b/src/Share/Postgres/Users/Queries.hs
@@ -194,12 +194,14 @@ userByHandle handle = do
         WHERE u.handle = lower(#{handle})
       |]
 
-createFromGithubUser :: AuthZ.AuthZReceipt -> GithubUser -> GithubEmail -> PG.Transaction UserCreationError User
-createFromGithubUser !authzReceipt (GithubUser githubHandle githubUserId avatar_url user_name) primaryEmail = do
+createFromGithubUser :: AuthZ.AuthZReceipt -> GithubUser -> GithubEmail -> Maybe UserHandle -> PG.Transaction UserCreationError User
+createFromGithubUser !authzReceipt (GithubUser githubHandle githubUserId avatar_url user_name) primaryEmail mayPreferredHandle = do
   let (GithubEmail {github_email_email = user_email, github_email_verified = emailVerified}) = primaryEmail
-  userHandle <- case IDs.fromText @UserHandle (Text.toLower githubHandle) of
-    Left err -> throwError (InvalidUserHandle err githubHandle)
-    Right handle -> pure handle
+  userHandle <- case mayPreferredHandle of
+    Just handle -> pure handle
+    Nothing -> case IDs.fromText @UserHandle (Text.toLower githubHandle) of
+      Left err -> throwError (InvalidUserHandle err githubHandle)
+      Right handle -> pure handle
   userId <- createUser authzReceipt user_email user_name (Just avatar_url) userHandle emailVerified
   PG.execute_
     [PG.sql|
@@ -258,13 +260,13 @@ isNew :: NewOrPreExisting a -> Bool
 isNew New {} = True
 isNew _ = False
 
-findOrCreateGithubUser :: AuthZ.AuthZReceipt -> GithubUser -> GithubEmail -> PG.Transaction UserCreationError (NewOrPreExisting User)
-findOrCreateGithubUser authZReceipt ghu@(GithubUser _login githubUserId _avatarUrl _name) primaryEmail = do
+findOrCreateGithubUser :: AuthZ.AuthZReceipt -> GithubUser -> GithubEmail -> Maybe UserHandle -> PG.Transaction UserCreationError (NewOrPreExisting User)
+findOrCreateGithubUser authZReceipt ghu@(GithubUser _login githubUserId _avatarUrl _name) primaryEmail mayPreferredHandle = do
   user <- userByGithubUserId githubUserId
   case user of
     Just user' -> pure (PreExisting user')
     Nothing -> do
-      New <$> createFromGithubUser authZReceipt ghu primaryEmail
+      New <$> createFromGithubUser authZReceipt ghu primaryEmail mayPreferredHandle
 
 searchUsersByNameOrHandlePrefix :: Query -> Limit -> PG.Transaction e [User]
 searchUsersByNameOrHandlePrefix (Query prefix) (Limit limit) = do


### PR DESCRIPTION
## Overview

By default we use the Github Handle to create a user's Share handle, but there are cases where the Github Handle may be taken or invalid, this allows selecting an alternative handle during registration.

## Implementation notes

* Add "handle" query param to the `login` endpoint
* If specified, create the user with the "handle" param instead of their github user handle.
* Only proceeds if the handle specified doesn't exist.
* Only creates a new user if the user logging in doesn't already have one, otherwise the handle is ignored.
