### PR TITLE
Add Org Tags in User Search

### DIFF
--- a/src/Share/Web/Share/Impl.hs
+++ b/src/Share/Web/Share/Impl.hs
@@ -47,7 +47,7 @@ import Share.Web.Share.Branches.Impl qualified as Branches
 import Share.Web.Share.CodeBrowsing.API (CodeBrowseAPI)
 import Share.Web.Share.Contributions.Impl qualified as Contributions
 import Share.Web.Share.DefinitionSearch qualified as DefinitionSearch
-import Share.Web.Share.DisplayInfo (UserDisplayInfo (..))
+import Share.Web.Share.DisplayInfo (OrgDisplayInfo (..), UserDisplayInfo (..))
 import Share.Web.Share.Orgs.Queries qualified as OrgQ
 import Share.Web.Share.Orgs.Types (Org (..))
 import Share.Web.Share.Projects.Impl qualified as Projects
@@ -368,8 +368,10 @@ searchEndpoint (MaybeAuthedUserID callerUserId) (Query query) (fromMaybe (Limit 
     pure (users, projects)
   let userResults =
         users
-          <&> \User {user_name = name, avatar_url = avatarUrl, handle, user_id = userId} ->
-            SearchResultUser (UserDisplayInfo {handle, name, avatarUrl = unpackURI <$> avatarUrl, userId})
+          <&> \(User {user_name = name, avatar_url = avatarUrl, handle, user_id = userId}, mayOrgId) ->
+            case mayOrgId of
+              Just orgId -> SearchResultOrg (OrgDisplayInfo {user = UserDisplayInfo {handle, name, avatarUrl = unpackURI <$> avatarUrl, userId}, orgId})
+              Nothing -> SearchResultUser (UserDisplayInfo {handle, name, avatarUrl = unpackURI <$> avatarUrl, userId})
   let projectResults =
         projects
           <&> \(Project {slug, summary, visibility}, ownerHandle) ->

--- a/src/Share/Web/Share/Types.hs
+++ b/src/Share/Web/Share/Types.hs
@@ -14,7 +14,7 @@ import Share.Project (ProjectVisibility)
 import Share.Utils.API (NullableUpdate, parseNullableUpdate)
 import Share.Utils.URI
 import Share.Web.Authorization.Types (RolePermission)
-import Share.Web.Share.DisplayInfo (UserDisplayInfo (..))
+import Share.Web.Share.DisplayInfo (OrgDisplayInfo (..), UserDisplayInfo (..))
 import Unison.Name (Name)
 import Unison.Server.Doc (Doc)
 import Unison.Server.Share.DefinitionSummary.Types (TermSummary (..), TypeSummary (..))
@@ -105,6 +105,7 @@ data SearchResult
   = SearchResultUser UserDisplayInfo
   | -- | shorthand summary visibility
     SearchResultProject ProjectShortHand (Maybe Text) ProjectVisibility
+  | SearchResultOrg OrgDisplayInfo
   deriving (Show)
 
 instance ToJSON SearchResult where
@@ -116,6 +117,15 @@ instance ToJSON SearchResult where
           "avatarUrl" .= avatarUrl,
           "userId" .= userId,
           "tag" .= ("User" :: Text)
+        ]
+    SearchResultOrg (OrgDisplayInfo {user = UserDisplayInfo {handle, name, avatarUrl, userId}, orgId}) ->
+      Aeson.object
+        [ "handle" .= fromId @UserHandle @Text handle,
+          "name" .= name,
+          "avatarUrl" .= avatarUrl,
+          "userId" .= userId,
+          "orgId" .= orgId,
+          "tag" .= ("Org" :: Text)
         ]
     SearchResultProject shorthand summary visibility ->
       Aeson.object

--- a/transcripts/share-apis/search/omni-search-orgs.json
+++ b/transcripts/share-apis/search/omni-search-orgs.json
@@ -1,0 +1,23 @@
+{
+  "body": [
+    {
+      "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+      "handle": "unison",
+      "name": "Unison Org",
+      "orgId": "ORG-<UUID>",
+      "tag": "Org",
+      "userId": "U-<UUID>"
+    },
+    {
+      "projectRef": "@unison/privateorgproject",
+      "summary": "Private Unison Project",
+      "tag": "Project",
+      "visibility": "private"
+    }
+  ],
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/search/omni-search-users.json
+++ b/transcripts/share-apis/search/omni-search-users.json
@@ -1,0 +1,22 @@
+{
+  "body": [
+    {
+      "avatarUrl": null,
+      "handle": "test",
+      "name": null,
+      "tag": "User",
+      "userId": "U-<UUID>"
+    },
+    {
+      "projectRef": "@test/publictestproject",
+      "summary": "test project summary",
+      "tag": "Project",
+      "visibility": "public"
+    }
+  ],
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/search/run.zsh
+++ b/transcripts/share-apis/search/run.zsh
@@ -87,3 +87,9 @@ fetch "$transcript_user" GET 'defn-search-project-filter-sad' '/search-definitio
 # Release filter
 fetch "$transcript_user" GET 'defn-search-release-filter-happy' '/search-definitions?query=map&project-filter=@transcripts%2Fsearch&release-filter=1.2.3'
 fetch "$transcript_user" GET 'defn-search-release-filter-sad' '/search-definitions?query=map&project-filter=@test%2Fpublictestproject&release-filter=1.0.0'
+
+# Omni search should find org users
+fetch "$transcript_user" GET 'omni-search-orgs' '/search?query=%40uni'
+
+# Omni search should find regular users
+fetch "$transcript_user" GET 'omni-search-users' '/search?query=%40tes'


### PR DESCRIPTION
## Overview

Previously orgs were treated as regular users in the omnisearch, now they have an `Org` tag and include the orgId.

E.g.

```
GET /search?query=uni
[
    {
      "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
      "handle": "unison",
      "name": "Unison Org",
      "orgId": "ORG-<UUID>",
      "tag": "Org",
      "userId": "U-<UUID>"
    },

```

## Test coverage

See transcripts
