### PR TITLE
Skip Github flow on local for easier testing of user creation flows

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     environment:
       # Placeholder values for development
       - SHARE_DEPLOYMENT=local
-      - SHARE_API_ORIGIN=http://share:5424
+      - SHARE_API_ORIGIN=http://localhost:5424
       - SHARE_SERVER_PORT=5424
       - SHARE_REDIS=redis://redis:6379
       - SHARE_POSTGRES=postgresql://postgres:sekrit@postgres:5432

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,13 +48,13 @@ services:
 
     environment:
       # Placeholder values for development
-      - SHARE_API_ORIGIN=http://share-api
+      - SHARE_DEPLOYMENT=local
+      - SHARE_API_ORIGIN=http://share:5424
       - SHARE_SERVER_PORT=5424
       - SHARE_REDIS=redis://redis:6379
       - SHARE_POSTGRES=postgresql://postgres:sekrit@postgres:5432
       - SHARE_HMAC_KEY=hmac-key-test-key-test-key-test-
       - SHARE_EDDSA_KEY=eddsa-key-test-key-test-key-test
-      - SHARE_DEPLOYMENT=local
       - SHARE_POSTGRES_CONN_TTL=30
       - SHARE_POSTGRES_CONN_MAX=10
       - SHARE_SHARE_UI_ORIGIN=http://localhost:1234

--- a/src/Share/Github.hs
+++ b/src/Share/Github.hs
@@ -45,10 +45,10 @@ instance ToServerError GithubError where
     GithubDecodeError _ce -> (ErrorID "github:decode-error", err500 {errBody = "Github returned an unexpected response. Please try again."})
 
 data GithubUser = GithubUser
-  { github_user_login :: Text,
-    github_user_id :: Int64,
-    github_user_avatar_url :: URIParam,
-    github_user_name :: Maybe Text
+  { githubHandle :: Text,
+    githubUserId :: Int64,
+    githubUserAvatarUrl :: URIParam,
+    githubUserName :: Maybe Text
   }
   deriving (Show)
 
@@ -56,21 +56,21 @@ instance FromJSON GithubUser where
   parseJSON = withObject "GithubUser" $ \u ->
     GithubUser
       <$> u
-      .: "login"
+        .: "login"
       <*> u
-      .: "id"
+        .: "id"
       <*> u
-      .: "avatar_url"
+        .: "avatar_url"
       -- We don't use this email because it's the "publicly visible" email, instead we fetch
       -- the primary email using the emails API.
       -- <*> u .: "email"
       <*> u
-      .:? "name"
+        .:? "name"
 
 data GithubEmail = GithubEmail
-  { github_email_email :: Text,
-    github_email_primary :: Bool,
-    github_email_verified :: Bool
+  { githubEmailEmail :: Text,
+    githubEmailIsPrimary :: Bool,
+    githubEmailIsVerified :: Bool
   }
   deriving (Show)
 
@@ -78,11 +78,11 @@ instance FromJSON GithubEmail where
   parseJSON = withObject "GithubEmail" $ \u ->
     GithubEmail
       <$> u
-      .: "email"
+        .: "email"
       <*> u
-      .: "primary"
+        .: "primary"
       <*> u
-      .: "verified"
+        .: "verified"
 
 type GithubTokenApi =
   "login"
@@ -190,7 +190,7 @@ primaryGithubEmail auth = do
   emails <- runGithubClient githubAPIBaseURL (githubEmailsClient auth)
   -- Github's api docs suggest there will always be a primary email.
   -- https://docs.github.com/en/rest/users/emails#list-email-addresses-for-the-authenticated-user
-  case find github_email_primary emails of
+  case find githubEmailIsPrimary emails of
     Nothing -> respondError GithubUserWithoutPrimaryEmail
     Just email -> pure email
 

--- a/src/Share/Postgres/Users/Queries.hs
+++ b/src/Share/Postgres/Users/Queries.hs
@@ -197,7 +197,7 @@ userByHandle handle = do
 
 createFromGithubUser :: AuthZ.AuthZReceipt -> GithubUser -> GithubEmail -> Maybe UserHandle -> PG.Transaction UserCreationError User
 createFromGithubUser !authzReceipt (GithubUser githubHandle githubUserId avatar_url user_name) primaryEmail mayPreferredHandle = do
-  let (GithubEmail {github_email_email = user_email, github_email_verified = emailVerified}) = primaryEmail
+  let (GithubEmail {githubEmailEmail = user_email, githubEmailIsVerified = emailVerified}) = primaryEmail
   userHandle <- case mayPreferredHandle of
     Just handle -> pure handle
     Nothing -> case IDs.fromText @UserHandle (Text.toLower githubHandle) of

--- a/transcripts/run-transcripts.zsh
+++ b/transcripts/run-transcripts.zsh
@@ -16,6 +16,7 @@ transcripts=(
     contribution-merge transcripts/share-apis/contribution-merge/
     search transcripts/share-apis/search/
     users transcripts/share-apis/users/
+    user-creation transcripts/share-apis/user-creation/
     contribution-diffs transcripts/share-apis/contribution-diffs/
     definition-diffs transcripts/share-apis/definition-diffs/
     tickets transcripts/share-apis/tickets/

--- a/transcripts/share-apis/user-creation/new-user-login.json
+++ b/transcripts/share-apis/user-creation/new-user-login.json
@@ -1,0 +1,1 @@
+{"status_code": 200, "result_url": "http://localhost:1234/?event=new-user-log-in"}

--- a/transcripts/share-apis/user-creation/new-user-login.json
+++ b/transcripts/share-apis/user-creation/new-user-login.json
@@ -1,1 +1,0 @@
-{"result_url": "http://localhost:1234/?event=new-user-log-in"}

--- a/transcripts/share-apis/user-creation/new-user-login.json
+++ b/transcripts/share-apis/user-creation/new-user-login.json
@@ -1,1 +1,1 @@
-{"status_code": 200, "result_url": "http://localhost:1234/?event=new-user-log-in"}
+{"result_url": "http://localhost:1234/?event=new-user-log-in"}

--- a/transcripts/share-apis/user-creation/new-user-profile.json
+++ b/transcripts/share-apis/user-creation/new-user-profile.json
@@ -3,6 +3,7 @@
     "avatarUrl": "https://avatars.githubusercontent.com/u/0?v=4",
     "completedTours": [],
     "handle": "localgithubuser",
+    "isSuperadmin": false,
     "name": "Local Github User",
     "organizationMemberships": [],
     "primaryEmail": "local@example.com",

--- a/transcripts/share-apis/user-creation/new-user-profile.json
+++ b/transcripts/share-apis/user-creation/new-user-profile.json
@@ -1,0 +1,16 @@
+{
+  "body": {
+    "avatarUrl": "https://avatars.githubusercontent.com/u/0?v=4",
+    "completedTours": [],
+    "handle": "localgithubuser",
+    "name": "Local Github User",
+    "organizationMemberships": [],
+    "primaryEmail": "local@example.com",
+    "userId": "U-<UUID>"
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/user-creation/run.zsh
+++ b/transcripts/share-apis/user-creation/run.zsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-set -ex
+set -e
 
 source "../../transcript_helpers.sh"
 
@@ -8,12 +8,9 @@ source "../../transcript_helpers.sh"
 new_user_cookie_jar=$(cookie_jar_for_user_id "new_user")
 
 # Should be able to create a new user via the login flow by following redirects.
-curl -v -s -L -I -o /dev/null -w '{"status_code": %{http_code}, "result_url": "%{url_effective}"}' --request "GET" --cookie "$new_user_cookie_jar" --cookie-jar "$new_user_cookie_jar" "localhost:5424/login" > ./new-user-login.json
-
-echo "Created new user!"
+# Note that the end of the redirect chain ends up on the Share UI (localhost:1234) which may or may not be running, so
+# we just ignore bad status codes from that server.
+curl -s -L -I -o /dev/null -w '{"result_url": "%{url_effective}"}' --request "GET" --cookie "$new_user_cookie_jar" --cookie-jar "$new_user_cookie_jar" "localhost:5424/login" > ./new-user-login.json || true
 
 # user should now be logged in as the local github user.
 fetch "new_user" GET new-user-profile /account
-
-
-echo "DONE"

--- a/transcripts/share-apis/user-creation/run.zsh
+++ b/transcripts/share-apis/user-creation/run.zsh
@@ -1,0 +1,19 @@
+#!/usr/bin/env zsh
+
+set -ex
+
+source "../../transcript_helpers.sh"
+
+# Create a cookie jar we can use to store cookies for the new user we're goin to create.
+new_user_cookie_jar=$(cookie_jar_for_user_id "new_user")
+
+# Should be able to create a new user via the login flow by following redirects.
+curl -v -s -L -I -o /dev/null -w '{"status_code": %{http_code}, "result_url": "%{url_effective}"}' --request "GET" --cookie "$new_user_cookie_jar" --cookie-jar "$new_user_cookie_jar" "localhost:5424/login" > ./new-user-login.json
+
+echo "Created new user!"
+
+# user should now be logged in as the local github user.
+fetch "new_user" GET new-user-profile /account
+
+
+echo "DONE"

--- a/transcripts/share-apis/user-creation/run.zsh
+++ b/transcripts/share-apis/user-creation/run.zsh
@@ -10,7 +10,7 @@ new_user_cookie_jar=$(cookie_jar_for_user_id "new_user")
 # Should be able to create a new user via the login flow by following redirects.
 # Note that the end of the redirect chain ends up on the Share UI (localhost:1234) which may or may not be running, so
 # we just ignore bad status codes from that server.
-curl -s -L -I -o /dev/null -w '{"result_url": "%{url_effective}"}' --request "GET" --cookie "$new_user_cookie_jar" --cookie-jar "$new_user_cookie_jar" "localhost:5424/login" > ./new-user-login.json || true
+curl -s -L -I -o /dev/null -w '{"result_url": "%{url_effective}"}' --request "GET" --cookie "$new_user_cookie_jar" --cookie-jar "$new_user_cookie_jar" "localhost:5424/login" || true
 
 # user should now be logged in as the local github user.
 fetch "new_user" GET new-user-profile /account

--- a/transcripts/share-apis/user-creation/run.zsh
+++ b/transcripts/share-apis/user-creation/run.zsh
@@ -10,7 +10,7 @@ new_user_cookie_jar=$(cookie_jar_for_user_id "new_user")
 # Should be able to create a new user via the login flow by following redirects.
 # Note that the end of the redirect chain ends up on the Share UI (localhost:1234) which may or may not be running, so
 # we just ignore bad status codes from that server.
-curl -s -L -I -o /dev/null -w '{"result_url": "%{url_effective}"}' --request "GET" --cookie "$new_user_cookie_jar" --cookie-jar "$new_user_cookie_jar" "localhost:5424/login" || true
+curl -v -L -I -o /dev/null -w '{"result_url": "%{url_effective}"}' --request "GET" --cookie "$new_user_cookie_jar" --cookie-jar "$new_user_cookie_jar" "http://localhost:5424/login" || true
 
 # user should now be logged in as the local github user.
 fetch "new_user" GET new-user-profile /account


### PR DESCRIPTION
## Overview

When running in the local deployment, going through the "login" flow will short-circuit going to github and will instead complete the auth flow using dummy github user info, which helps make testing the user creation flow a lot easier.

## Implementation notes

The only difference is that it skips redirecting through Github, and doesn't call the github APIs to get the user data and instead uses constant dummy user info.

## Test coverage

I added a new user creation transcript to ensure we don't break the user creation flow.

## Loose Ends

@hojberg  you could optionally wire up the "Login", "Register" and "Logout" buttons in the local UI if you like :)