### PR TITLE
Allow null emails on orgs.

### DIFF
--- a/sql/2025-02-20_authz.sql
+++ b/sql/2025-02-20_authz.sql
@@ -213,7 +213,6 @@ CREATE TRIGGER users_create_subject
 
 CREATE TABLE orgs (
   id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
-  -- There's no subject_id on the org, since the org is a user, and the user has a subject_id.
   user_id UUID UNIQUE NOT NULL REFERENCES users (id) ON DELETE CASCADE,
   -- Subject representing the org itself.
   -- Note that orgs also have a subject on their associated user, but since you can't log in as a subject that

--- a/sql/2025-05-01_org-emails.sql
+++ b/sql/2025-05-01_org-emails.sql
@@ -1,0 +1,23 @@
+ALTER TABLE users
+  -- Add is_org column
+  ADD COLUMN is_org boolean NOT NULL DEFAULT false,
+  -- Add check that primary_email is not null unless is_org is true
+  ADD CONSTRAINT primary_email_not_null_unless_org CHECK (
+    is_org OR primary_email IS NOT NULL
+  ),
+  -- Make primary_email nullable
+  ALTER COLUMN primary_email DROP NOT NULL;
+
+-- Update the is_org column for existing users
+WITH org_users(user_id) AS (
+  SELECT DISTINCT o.user_id
+  FROM orgs o
+) UPDATE users
+  SET is_org = true
+  WHERE id IN (SELECT ou.user_id FROM org_users ou);
+
+-- Add a 'creator_user_id' to orgs just to track where they came from.
+-- This is distinct from the owners in the auth roles.
+ALTER TABLE orgs
+  ADD COLUMN creator_user_id uuid NULL REFERENCES users (id) ON DELETE SET NULL
+;

--- a/sql/2025-05-01_org-updates.sql
+++ b/sql/2025-05-01_org-updates.sql
@@ -21,3 +21,7 @@ WITH org_users(user_id) AS (
 ALTER TABLE orgs
   ADD COLUMN creator_user_id uuid NULL REFERENCES users (id) ON DELETE SET NULL
 ;
+
+ALTER TABLE orgs
+  ADD COLUMN is_commercial boolean NOT NULL DEFAULT false
+;

--- a/src/Share/Postgres/Users/Queries.hs
+++ b/src/Share/Postgres/Users/Queries.hs
@@ -219,7 +219,7 @@ createFromGithubUser !authzReceipt (GithubUser githubHandle githubUserId avatar_
         avatar_url = Just avatar_url,
         user_id = userId,
         user_name,
-        user_email,
+        user_email = Just $ Email user_email,
         visibility
       }
 

--- a/src/Share/User.hs
+++ b/src/Share/User.hs
@@ -31,7 +31,7 @@ instance Hasql.EncodeValue UserVisibility where
 data User = User
   { user_id :: UserId,
     user_name :: Maybe Text,
-    user_email :: Text,
+    user_email :: Maybe Email,
     avatar_url :: Maybe URIParam,
     handle :: UserHandle,
     visibility :: UserVisibility

--- a/src/Share/Web/Share/DisplayInfo.hs
+++ b/src/Share/Web/Share/DisplayInfo.hs
@@ -36,15 +36,17 @@ instance ToJSON UserDisplayInfo where
 -- | Common type for displaying an Org.
 data OrgDisplayInfo = OrgDisplayInfo
   { user :: UserDisplayInfo,
-    orgId :: OrgId
+    orgId :: OrgId,
+    isCommercial :: Bool
   }
   deriving (Show, Eq, Ord)
 
 instance ToJSON OrgDisplayInfo where
-  toJSON OrgDisplayInfo {user, orgId} =
+  toJSON OrgDisplayInfo {user, orgId, isCommercial} =
     Aeson.object
       [ "user" Aeson..= user,
-        "orgId" Aeson..= orgId
+        "orgId" Aeson..= orgId,
+        "isCommercial" Aeson..= isCommercial
       ]
 
 data TeamDisplayInfo = TeamDisplayInfo

--- a/src/Share/Web/Share/Orgs/Impl.hs
+++ b/src/Share/Web/Share/Orgs/Impl.hs
@@ -59,10 +59,10 @@ server =
    in orgCreateEndpoint :<|> orgResourceServer
 
 orgCreateEndpoint :: UserId -> CreateOrgRequest -> WebApp OrgDisplayInfo
-orgCreateEndpoint callerUserId (CreateOrgRequest {name, handle, avatarUrl, email, owner = ownerHandle}) = do
+orgCreateEndpoint callerUserId (CreateOrgRequest {name, handle, avatarUrl, email, owner = ownerHandle, isCommercial}) = do
   User {user_id = ownerUserId} <- PG.runTransaction (UserQ.userByHandle ownerHandle) `whenNothingM` respondError (EntityMissing (ErrorID "missing-user") "Owner not found")
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkCreateOrg callerUserId ownerUserId
-  orgId <- PG.runTransactionOrRespondError $ OrgOps.createOrg authZReceipt name handle email avatarUrl ownerUserId callerUserId
+  orgId <- PG.runTransactionOrRespondError $ OrgOps.createOrg authZReceipt name handle email avatarUrl ownerUserId callerUserId isCommercial
   PG.runTransaction $ OrgQ.orgDisplayInfoOf id orgId
 
 rolesServer :: UserHandle -> API.OrgRolesRoutes (AsServerT WebApp)

--- a/src/Share/Web/Share/Orgs/Impl.hs
+++ b/src/Share/Web/Share/Orgs/Impl.hs
@@ -62,7 +62,7 @@ orgCreateEndpoint :: UserId -> CreateOrgRequest -> WebApp OrgDisplayInfo
 orgCreateEndpoint callerUserId (CreateOrgRequest {name, handle, avatarUrl, email, owner = ownerHandle}) = do
   User {user_id = ownerUserId} <- PG.runTransaction (UserQ.userByHandle ownerHandle) `whenNothingM` respondError (EntityMissing (ErrorID "missing-user") "Owner not found")
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkCreateOrg callerUserId ownerUserId
-  orgId <- PG.runTransactionOrRespondError $ OrgOps.createOrg authZReceipt name handle email avatarUrl ownerUserId
+  orgId <- PG.runTransactionOrRespondError $ OrgOps.createOrg authZReceipt name handle email avatarUrl ownerUserId callerUserId
   PG.runTransaction $ OrgQ.orgDisplayInfoOf id orgId
 
 rolesServer :: UserHandle -> API.OrgRolesRoutes (AsServerT WebApp)

--- a/src/Share/Web/Share/Orgs/Operations.hs
+++ b/src/Share/Web/Share/Orgs/Operations.hs
@@ -14,15 +14,16 @@ import Share.Web.Authorization.Types qualified as AuthZ
 import Share.Web.Share.Orgs.Queries qualified as OrgQ
 import Share.Web.Share.Roles.Queries qualified as RoleQ
 
-createOrg :: AuthZ.AuthZReceipt -> Text -> OrgHandle -> Maybe Email -> Maybe URIParam -> UserId -> Transaction UserCreationError OrgId
-createOrg !authZReceipt name (OrgHandle handle) email avatarUrl owner = do
+createOrg :: AuthZ.AuthZReceipt -> Text -> OrgHandle -> Maybe Email -> Maybe URIParam -> UserId -> UserId -> Transaction UserCreationError OrgId
+createOrg !authZReceipt name (OrgHandle handle) email avatarUrl owner creator = do
   let emailVerified = False
   let isOrg = True
   orgUserId <- UserQ.createUser authZReceipt isOrg email (Just name) avatarUrl (UserHandle handle) emailVerified
   (orgId, orgResourceId) <-
     queryExpect1Row
       [sql|
-    INSERT INTO orgs (user_id) VALUES (#{orgUserId})
+    INSERT INTO orgs (user_id, creator_user_id) 
+      VALUES (#{orgUserId}, #{creator})
       RETURNING id, resource_id
     |]
   RoleQ.assignUserRoleMembership authZReceipt owner orgResourceId AuthZ.RoleOrgOwner

--- a/src/Share/Web/Share/Orgs/Operations.hs
+++ b/src/Share/Web/Share/Orgs/Operations.hs
@@ -4,7 +4,7 @@ module Share.Web.Share.Orgs.Operations
 where
 
 import Data.Set qualified as Set
-import Share.IDs (OrgHandle (..), OrgId, UserHandle (..), UserId)
+import Share.IDs (Email, OrgHandle (..), OrgId, UserHandle (..), UserId)
 import Share.Postgres
 import Share.Postgres.Users.Queries (UserCreationError)
 import Share.Postgres.Users.Queries qualified as UserQ
@@ -14,10 +14,11 @@ import Share.Web.Authorization.Types qualified as AuthZ
 import Share.Web.Share.Orgs.Queries qualified as OrgQ
 import Share.Web.Share.Roles.Queries qualified as RoleQ
 
-createOrg :: AuthZ.AuthZReceipt -> Text -> OrgHandle -> Text -> Maybe URIParam -> UserId -> Transaction UserCreationError OrgId
+createOrg :: AuthZ.AuthZReceipt -> Text -> OrgHandle -> Maybe Email -> Maybe URIParam -> UserId -> Transaction UserCreationError OrgId
 createOrg !authZReceipt name (OrgHandle handle) email avatarUrl owner = do
   let emailVerified = False
-  orgUserId <- UserQ.createUser authZReceipt email (Just name) avatarUrl (UserHandle handle) emailVerified
+  let isOrg = True
+  orgUserId <- UserQ.createUser authZReceipt isOrg email (Just name) avatarUrl (UserHandle handle) emailVerified
   (orgId, orgResourceId) <-
     queryExpect1Row
       [sql|

--- a/src/Share/Web/Share/Orgs/Types.hs
+++ b/src/Share/Web/Share/Orgs/Types.hs
@@ -16,11 +16,14 @@ import Share.Postgres (DecodeRow (..), decodeField)
 import Share.Utils.URI (URIParam)
 import Share.Web.Share.DisplayInfo (UserDisplayInfo)
 
-newtype Org = Org {orgId :: OrgId}
-  deriving (Show, Eq)
+data Org = Org {orgId :: OrgId, isCommercial :: Bool}
+  deriving (Show, Eq, Ord)
 
 instance DecodeRow Org where
-  decodeRow = Org <$> decodeField
+  decodeRow = do
+    orgId <- decodeField
+    isCommercial <- decodeField
+    pure Org {..}
 
 data CreateOrgRequest = CreateOrgRequest
   { name :: Text,

--- a/src/Share/Web/Share/Orgs/Types.hs
+++ b/src/Share/Web/Share/Orgs/Types.hs
@@ -27,7 +27,7 @@ data CreateOrgRequest = CreateOrgRequest
     handle :: OrgHandle,
     avatarUrl :: Maybe URIParam,
     owner :: UserHandle,
-    email :: Text
+    email :: Maybe Email
   }
   deriving (Show, Eq)
 
@@ -37,7 +37,7 @@ instance FromJSON CreateOrgRequest where
     handle <- o .: "handle"
     avatarUrl <- o .:? "avatarUrl"
     owner <- o .: "owner"
-    email <- o .: "email"
+    email <- o .:? "email"
     pure CreateOrgRequest {..}
 
 data OrgMembersAddRequest = OrgMembersAddRequest

--- a/src/Share/Web/Share/Orgs/Types.hs
+++ b/src/Share/Web/Share/Orgs/Types.hs
@@ -27,7 +27,8 @@ data CreateOrgRequest = CreateOrgRequest
     handle :: OrgHandle,
     avatarUrl :: Maybe URIParam,
     owner :: UserHandle,
-    email :: Maybe Email
+    email :: Maybe Email,
+    isCommercial :: Bool
   }
   deriving (Show, Eq)
 
@@ -38,6 +39,7 @@ instance FromJSON CreateOrgRequest where
     avatarUrl <- o .:? "avatarUrl"
     owner <- o .: "owner"
     email <- o .:? "email"
+    isCommercial <- o .: "isCommercial"
     pure CreateOrgRequest {..}
 
 data OrgMembersAddRequest = OrgMembersAddRequest

--- a/src/Share/Web/Share/Types.hs
+++ b/src/Share/Web/Share/Types.hs
@@ -140,7 +140,7 @@ data UserAccountInfo = UserAccountInfo
     name :: Maybe Text,
     avatarUrl :: Maybe URIParam,
     userId :: UserId,
-    primaryEmail :: Text,
+    primaryEmail :: Maybe Email,
     -- List of tours which the user has completed.
     completedTours :: [TourId],
     organizationMemberships :: [UserHandle],

--- a/src/Share/Web/Support/Zendesk.hs
+++ b/src/Share/Web/Support/Zendesk.hs
@@ -9,14 +9,14 @@ module Share.Web.Support.Zendesk where
 import Control.Monad.Reader
 import Data.Aeson
 import Data.Either (fromRight)
+import Servant
+import Servant.Client
 import Share.Env qualified as Env
 import Share.IDs
 import Share.Prelude
 import Share.Utils.Servant.Client (runClient)
 import Share.Web.App
 import Share.Web.Support.Types
-import Servant
-import Servant.Client
 
 -- | Field Id for the Share Handle custom ticket field. See https://unison-computing.zendesk.com/admin/objects-rules/tickets/ticket-fields
 zendeskShareHandleFieldId :: Int
@@ -42,7 +42,7 @@ data ZendeskTicket = ZendeskTicket
     body :: Text,
     priority :: Priority,
     requesterName :: Text,
-    requesterEmail :: Text,
+    requesterEmail :: Maybe Email,
     shareHandle :: UserHandle,
     shareUserId :: UserId
   }

--- a/src/Share/Web/Types.hs
+++ b/src/Share/Web/Types.hs
@@ -41,7 +41,7 @@ data UserInfo = UserInfo
     name :: Maybe Text,
     picture :: Maybe URIParam,
     profile :: URIParam, -- Link to the user's profile page
-    email :: Text,
+    email :: Maybe Email,
     -- Additional claims
     handle :: UserHandle
   }

--- a/transcripts/share-apis/orgs/org-create-by-admin.json
+++ b/transcripts/share-apis/orgs/org-create-by-admin.json
@@ -1,5 +1,6 @@
 {
   "body": {
+    "isCommercial": true,
     "orgId": "ORG-<UUID>",
     "user": {
       "avatarUrl": "https://example.com/anvil.png",

--- a/transcripts/share-apis/orgs/run.zsh
+++ b/transcripts/share-apis/orgs/run.zsh
@@ -23,8 +23,7 @@ fetch "$admin_user" POST org-create-by-admin '/orgs' '{
   "name": "ACME",
   "handle": "acme",
   "avatarUrl": "https://example.com/anvil.png",
-  "owner": "transcripts",
-  "email": "wile.e.coyote@example.com"
+  "owner": "transcripts"
 }'
 
 

--- a/transcripts/share-apis/orgs/run.zsh
+++ b/transcripts/share-apis/orgs/run.zsh
@@ -15,7 +15,8 @@ fetch "$unauthorized_user" POST org-create-unauthorized '/orgs' '{
   "handle": "acme",
   "avatarUrl": "https://example.com/anvil.png",
   "owner": "unauthorized",
-  "email": "wile.e.coyote@example.com"
+  "email": "wile.e.coyote@example.com",
+  "isCommercial": false
 }'
 
 # Admin can create an org and assign any owner.
@@ -23,7 +24,8 @@ fetch "$admin_user" POST org-create-by-admin '/orgs' '{
   "name": "ACME",
   "handle": "acme",
   "avatarUrl": "https://example.com/anvil.png",
-  "owner": "transcripts"
+  "owner": "transcripts",
+  "isCommercial": true
 }'
 
 

--- a/transcripts/share-apis/roles/grant-project-contributor.json
+++ b/transcripts/share-apis/roles/grant-project-contributor.json
@@ -36,6 +36,7 @@
         ],
         "subject": {
           "data": {
+            "isCommercial": false,
             "orgId": "ORG-<UUID>",
             "user": {
               "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",

--- a/transcripts/share-apis/roles/org-roles-list.json
+++ b/transcripts/share-apis/roles/org-roles-list.json
@@ -22,6 +22,7 @@
         ],
         "subject": {
           "data": {
+            "isCommercial": false,
             "orgId": "ORG-<UUID>",
             "user": {
               "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",

--- a/transcripts/share-apis/roles/revoke-project-contributor.json
+++ b/transcripts/share-apis/roles/revoke-project-contributor.json
@@ -22,6 +22,7 @@
         ],
         "subject": {
           "data": {
+            "isCommercial": false,
             "orgId": "ORG-<UUID>",
             "user": {
               "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",


### PR DESCRIPTION
## Overview

There are a couple annoying complications at the moment:

* Creating an org also creates a row in the user table, since that's how we track project and code ownership
* Users _must_ have an email
* It's weird to require a unique email when creating an org

Solution: Allow a null email, but only for orgs

## Implementation notes

* Remove the `NOT NULL` constraint on emails
* Add an `is_org` column to the users table
* Add a check constraint so EITHER an email is required, or the row is an org user.