### PR TITLE
Store source/target causals on contribution itself, so they stay frozen once merged

### DIFF
--- a/share-api.cabal
+++ b/share-api.cabal
@@ -28,8 +28,9 @@ library
       Share.App
       Share.Backend
       Share.BackgroundJobs
-      Share.BackgroundJobs.Diffs.ContributionDiffs
+      Share.BackgroundJobs.Diffs.CausalDiffs
       Share.BackgroundJobs.Diffs.Queries
+      Share.BackgroundJobs.Diffs.Types
       Share.BackgroundJobs.Errors
       Share.BackgroundJobs.Monad
       Share.BackgroundJobs.Search.DefinitionSync

--- a/sql/2025-05-09_track_contribution_causals.sql
+++ b/sql/2025-05-09_track_contribution_causals.sql
@@ -1,0 +1,31 @@
+-- Track the causals on the contribution itself; this is useful because the branches may change _after_ the
+-- contribution is merged or closed.
+ALTER TABLE contributions 
+  ADD COLUMN source_causal_id INTEGER NULL REFERENCES causals (id) ON DELETE NO ACTION,
+  ADD COLUMN target_causal_id INTEGER NULL REFERENCES causals (id) ON DELETE NO ACTION
+;
+
+-- Backfill the new columns with current causal of each contribution, this will be incorrect for old contributions
+-- where we can't infer what the source branch _was_ at when it was merged.
+UPDATE contributions
+  SET source_causal_id = (
+    SELECT pb.causal_id
+    FROM project_branches pb
+    WHERE pb.id = contributions.source_branch
+    LIMIT 1
+  ),
+  target_causal_id = (
+    SELECT pb.causal_id
+    FROM project_branches pb
+    WHERE pb.id = contributions.target_branch
+    LIMIT 1
+  )
+  WHERE source_causal_id IS NULL
+    AND target_causal_id IS NULL
+;
+
+-- Make the new columns non-nullable
+ALTER TABLE contributions
+  ALTER COLUMN source_causal_id SET NOT NULL,
+  ALTER COLUMN target_causal_id SET NOT NULL
+  ;

--- a/sql/2025-05-12_causal_diff_queue.sql
+++ b/sql/2025-05-12_causal_diff_queue.sql
@@ -1,0 +1,12 @@
+-- Table for causal diffs we want to compute.
+-- Also keyed by the codebase owner of each side of the diff since 
+-- the sandboxed terms may affect how the diff looks.
+CREATE TABLE causal_diff_queue (
+  from_causal_id INTEGER NOT NULL REFERENCES causals(id) ON DELETE CASCADE,
+  to_causal_id INTEGER NOT NULL REFERENCES causals(id) ON DELETE CASCADE,
+  from_codebase_owner UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  to_codebase_owner UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (from_causal_id, to_causal_id, from_codebase_owner, to_codebase_owner)
+);

--- a/sql/2025-05-12_causal_diff_queue.sql
+++ b/sql/2025-05-12_causal_diff_queue.sql
@@ -1,3 +1,5 @@
+DROP TABLE contribution_diff_queue;
+
 -- Table for causal diffs we want to compute.
 -- Also keyed by the codebase owner of each side of the diff since 
 -- the sandboxed terms may affect how the diff looks.

--- a/src/Share/BackgroundJobs.hs
+++ b/src/Share/BackgroundJobs.hs
@@ -1,7 +1,7 @@
 module Share.BackgroundJobs (startWorkers) where
 
 import Ki.Unlifted qualified as Ki
-import Share.BackgroundJobs.Diffs.ContributionDiffs qualified as ContributionDiffs
+import Share.BackgroundJobs.Diffs.CausalDiffs qualified as ContributionDiffs
 import Share.BackgroundJobs.Monad (Background)
 import Share.BackgroundJobs.Search.DefinitionSync qualified as DefnSearch
 import Share.BackgroundJobs.Webhooks.Worker qualified as Webhooks

--- a/src/Share/BackgroundJobs/Diffs/CausalDiffs.hs
+++ b/src/Share/BackgroundJobs/Diffs/CausalDiffs.hs
@@ -1,27 +1,24 @@
-module Share.BackgroundJobs.Diffs.ContributionDiffs (worker) where
+module Share.BackgroundJobs.Diffs.CausalDiffs (worker) where
 
 import Control.Lens
-import Control.Monad.Except
 import Ki.Unlifted qualified as Ki
 import Share.BackgroundJobs.Diffs.Queries qualified as DQ
+import Share.BackgroundJobs.Diffs.Types (CausalDiffInfo (..))
 import Share.BackgroundJobs.Errors (reportError)
-import Share.BackgroundJobs.Monad (Background, withTag)
+import Share.BackgroundJobs.Monad (Background, withTags)
 import Share.BackgroundJobs.Workers (newWorker)
 import Share.Codebase qualified as Codebase
-import Share.Contribution (Contribution (..))
 import Share.Env qualified as Env
-import Share.IDs
 import Share.IDs qualified as IDs
 import Share.Metrics qualified as Metrics
 import Share.Postgres qualified as PG
+import Share.Postgres.Causal.Queries qualified as CausalQ
 import Share.Postgres.Contributions.Queries qualified as ContributionsQ
 import Share.Postgres.Notifications qualified as Notif
-import Share.Postgres.Queries (DeletionFilter (IncludeDeleted))
-import Share.Postgres.Queries qualified as Q
 import Share.Prelude
 import Share.Utils.Logging qualified as Logging
 import Share.Web.Authorization qualified as AuthZ
-import Share.Web.Errors (EntityMissing (..), ErrorID (..))
+import Share.Web.Errors (EntityMissing (..))
 import Share.Web.Share.Diffs.Impl qualified as Diffs
 import System.Clock qualified as Clock
 
@@ -39,8 +36,8 @@ worker scope = do
       makeRuntime codebase = do
         runtime <- Codebase.codebaseRuntimeTransaction unisonRuntime codebase
         pure (badUnliftCodebaseRuntime runtime)
-  newWorker scope "diffs:contributions" $ forever do
-    Notif.waitOnChannel Notif.ContributionDiffChannel (maxPollingIntervalSeconds * 1000000)
+  newWorker scope "causal-diffs" $ forever do
+    Notif.waitOnChannel Notif.CausalDiffChannel (maxPollingIntervalSeconds * 1000000)
     processDiffs authZReceipt makeRuntime
 
 -- Process diffs until we run out of them. We claim a diff in a transaction and compute the diff in the same
@@ -52,20 +49,26 @@ processDiffs authZReceipt makeRuntime = do
       loop = do
         result <-
           PG.runTransactionMode PG.RepeatableRead PG.ReadWrite do
-            DQ.claimContributionToDiff >>= \case
+            DQ.claimCausalDiff >>= \case
               Nothing -> pure Nothing
-              Just contributionId -> do
+              Just causalDiffInfo -> do
                 startTime <- PG.transactionUnsafeIO (Clock.getTime Clock.Monotonic)
-                result <- PG.catchTransaction (maybeComputeAndStoreCausalDiff authZReceipt makeRuntime contributionId)
-                pure (Just (contributionId, startTime, result))
-        whenJust result \(contributionId, startTime, result) -> do
-          withTag "contribution-id" (IDs.toText contributionId) do
+                result <- PG.catchTransaction (maybeComputeAndStoreCausalDiff authZReceipt makeRuntime causalDiffInfo)
+                pure (Just (causalDiffInfo, startTime, result))
+        whenJust result \(CausalDiffInfo {fromCausalId, toCausalId, fromCodebaseOwner, toCodebaseOwner}, startTime, result) -> do
+          let tags =
+                [ ("from-causal-id", IDs.toText fromCausalId),
+                  ("to-causal-id", IDs.toText toCausalId),
+                  ("from-codebase-owner", IDs.toText fromCodebaseOwner),
+                  ("to-codebase-owner", IDs.toText toCodebaseOwner)
+                ]
+          withTags tags do
             case result of
               Left err -> reportError err
               Right didWork -> do
                 when didWork do
-                  liftIO (Metrics.recordContributionDiffDuration startTime)
-                  Logging.textLog "Computed contribution diff"
+                  liftIO (Metrics.recordCausalDiffDuration startTime)
+                  Logging.textLog "Computed causal diff"
                     & Logging.withSeverity Logging.Info
                     & Logging.logMsg
           loop
@@ -76,27 +79,21 @@ processDiffs authZReceipt makeRuntime = do
 maybeComputeAndStoreCausalDiff ::
   AuthZ.AuthZReceipt ->
   (Codebase.CodebaseEnv -> IO (Codebase.CodebaseRuntime IO)) ->
-  ContributionId ->
+  CausalDiffInfo ->
   PG.Transaction EntityMissing Bool
-maybeComputeAndStoreCausalDiff authZReceipt makeRuntime contributionId = do
-  Contribution {bestCommonAncestorCausalId, sourceBranchId = newBranchId, targetBranchId = oldBranchId, sourceCausalId = newCausalId, targetCausalId = oldCausalId, projectId} <-
-    ContributionsQ.contributionById contributionId
-  project <- Q.projectById projectId `whenNothingM` throwError (EntityMissing (ErrorID "project:missing") "Project not found")
-  -- We fetch the branch even if it's soft-deleted because we just need it to know the owner's
-  -- codebase.
-  newBranch <- Q.branchById IncludeDeleted newBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
-  oldBranch <- Q.branchById IncludeDeleted oldBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
-  let oldCodebase = Codebase.codebaseForProjectBranch authZReceipt project oldBranch
-  let newCodebase = Codebase.codebaseForProjectBranch authZReceipt project newBranch
-  ContributionsQ.existsPrecomputedNamespaceDiff (oldCodebase, oldCausalId) (newCodebase, newCausalId) >>= \case
+maybeComputeAndStoreCausalDiff authZReceipt makeRuntime (CausalDiffInfo {fromCausalId, toCausalId, fromCodebaseOwner, toCodebaseOwner}) = do
+  bestCommonAncestorCausalId <- CausalQ.bestCommonAncestor fromCausalId toCausalId
+  let fromCodebase = Codebase.codebaseEnv authZReceipt $ Codebase.codebaseLocationForUserCodebase fromCodebaseOwner
+  let toCodebase = Codebase.codebaseEnv authZReceipt $ Codebase.codebaseLocationForUserCodebase toCodebaseOwner
+  ContributionsQ.existsPrecomputedNamespaceDiff (fromCodebase, fromCausalId) (toCodebase, toCausalId) >>= \case
     True -> pure False
     False -> do
-      oldRuntime <- PG.transactionUnsafeIO (makeRuntime oldCodebase)
-      newRuntime <- PG.transactionUnsafeIO (makeRuntime newCodebase)
+      fromRuntime <- PG.transactionUnsafeIO (makeRuntime fromCodebase)
+      toRuntime <- PG.transactionUnsafeIO (makeRuntime toCodebase)
       _ <-
         Diffs.computeAndStoreCausalDiff
           authZReceipt
-          (oldCodebase, oldRuntime, oldCausalId)
-          (newCodebase, newRuntime, newCausalId)
+          (fromCodebase, fromRuntime, fromCausalId)
+          (toCodebase, toRuntime, toCausalId)
           bestCommonAncestorCausalId
       pure True

--- a/src/Share/BackgroundJobs/Diffs/Queries.hs
+++ b/src/Share/BackgroundJobs/Diffs/Queries.hs
@@ -21,8 +21,8 @@ submitContributionsToBeDiffed contributions = do
         SELECT c.source_causal_id, c.target_causal_id, COALESCE(source_branch.contributor_id, source_project.owner_user_id), COALESCE(target_branch.contributor_id, target_project.owner_user_id)
           FROM new_contributions nc
           JOIN contributions c ON c.id = nc.contribution_id
-          JOIN project_branches source_branch ON source_branch.id = c.source_branch_id
-          JOIN project_branches target_branch ON target_branch.id = c.target_branch_id
+          JOIN project_branches source_branch ON source_branch.id = c.source_branch
+          JOIN project_branches target_branch ON target_branch.id = c.target_branch
           JOIN projects source_project ON source_project.id = source_branch.project_id
           JOIN projects target_project ON target_project.id = target_branch.project_id
         ON CONFLICT DO NOTHING

--- a/src/Share/BackgroundJobs/Diffs/Queries.hs
+++ b/src/Share/BackgroundJobs/Diffs/Queries.hs
@@ -1,9 +1,10 @@
 module Share.BackgroundJobs.Diffs.Queries
   ( submitContributionsToBeDiffed,
-    claimContributionToDiff,
+    claimCausalDiff,
   )
 where
 
+import Share.BackgroundJobs.Diffs.Types
 import Share.IDs
 import Share.Postgres
 import Share.Postgres.Notifications qualified as Notif
@@ -16,27 +17,36 @@ submitContributionsToBeDiffed contributions = do
       WITH new_contributions(contribution_id) AS (
         SELECT * FROM ^{singleColumnTable (toList contributions)}
       )
-      INSERT INTO contribution_diff_queue (contribution_id)
-        SELECT nc.contribution_id FROM new_contributions nc
+      INSERT INTO causal_diff_queue (from_causal_id, to_causal_id, from_codebase_owner, to_codebase_owner)
+        SELECT c.source_causal_id, c.target_causal_id, COALESCE(source_branch.contributor_id, source_project.owner_user_id), COALESCE(target_branch.contributor_id, target_project.owner_user_id)
+          FROM new_contributions nc
+          JOIN contributions c ON c.id = nc.contribution_id
+          JOIN project_branches source_branch ON source_branch.id = c.source_branch_id
+          JOIN project_branches target_branch ON target_branch.id = c.target_branch_id
+          JOIN projects source_project ON source_project.id = source_branch.project_id
+          JOIN projects target_project ON target_project.id = target_branch.project_id
         ON CONFLICT DO NOTHING
     |]
-  Notif.notifyChannel Notif.ContributionDiffChannel
+  Notif.notifyChannel Notif.CausalDiffChannel
 
 -- | Claim the oldest contribution in the queue to be diffed.
-claimContributionToDiff :: Transaction e (Maybe ContributionId)
-claimContributionToDiff = do
-  query1Col
+claimCausalDiff :: Transaction e (Maybe CausalDiffInfo)
+claimCausalDiff = do
+  query1Row
     [sql|
-      WITH chosen_contribution(contribution_id) AS (
-        SELECT q.contribution_id
-        FROM contribution_diff_queue q
+      WITH chosen(from_causal_id, to_causal_id, from_codebase_owner, to_codebase_owner) AS (
+        SELECT q.from_causal_id, q.to_causal_id, q.from_codebase_owner, q.to_codebase_owner
+        FROM causal_diff_queue q
         ORDER BY q.created_at ASC
         LIMIT 1
         -- Skip any that are being synced by other workers.
         FOR UPDATE SKIP LOCKED
       )
-      DELETE FROM contribution_diff_queue
-        USING chosen_contribution
-        WHERE contribution_diff_queue.contribution_id = chosen_contribution.contribution_id
-      RETURNING chosen_contribution.contribution_id
+      DELETE FROM causal_diff_queue
+        USING chosen
+        WHERE causal_diff_queue.from_causal_id = chosen.from_causal_id
+          AND causal_diff_queue.to_causal_id = chosen.to_causal_id
+          AND causal_diff_queue.from_codebase_owner = chosen.from_codebase_owner
+          AND causal_diff_queue.to_codebase_owner = chosen.to_codebase_owner
+      RETURNING chosen.from_causal_id, chosen.to_causal_id, chosen.from_codebase_owner, chosen.to_codebase_owner
     |]

--- a/src/Share/BackgroundJobs/Diffs/Queries.hs
+++ b/src/Share/BackgroundJobs/Diffs/Queries.hs
@@ -18,7 +18,7 @@ submitContributionsToBeDiffed contributions = do
         SELECT * FROM ^{singleColumnTable (toList contributions)}
       )
       INSERT INTO causal_diff_queue (from_causal_id, to_causal_id, from_codebase_owner, to_codebase_owner)
-        SELECT c.source_causal_id, c.target_causal_id, COALESCE(source_branch.contributor_id, source_project.owner_user_id), COALESCE(target_branch.contributor_id, target_project.owner_user_id)
+        SELECT c.target_causal_id, c.source_causal_id, COALESCE(target_branch.contributor_id, target_project.owner_user_id), COALESCE(source_branch.contributor_id, source_project.owner_user_id)
           FROM new_contributions nc
           JOIN contributions c ON c.id = nc.contribution_id
           JOIN project_branches source_branch ON source_branch.id = c.source_branch

--- a/src/Share/BackgroundJobs/Diffs/Types.hs
+++ b/src/Share/BackgroundJobs/Diffs/Types.hs
@@ -1,0 +1,20 @@
+module Share.BackgroundJobs.Diffs.Types (CausalDiffInfo (..)) where
+
+import Share.IDs
+import Share.Postgres qualified as PG
+import Share.Postgres.IDs
+
+data CausalDiffInfo = CausalDiffInfo
+  { fromCausalId :: CausalId,
+    toCausalId :: CausalId,
+    fromCodebaseOwner :: UserId,
+    toCodebaseOwner :: UserId
+  }
+
+instance PG.DecodeRow CausalDiffInfo where
+  decodeRow =
+    CausalDiffInfo
+      <$> PG.decodeField
+      <*> PG.decodeField
+      <*> PG.decodeField
+      <*> PG.decodeField

--- a/src/Share/BackgroundJobs/Monad.hs
+++ b/src/Share/BackgroundJobs/Monad.hs
@@ -5,6 +5,7 @@ module Share.BackgroundJobs.Monad
     withWorkerName,
     runBackground,
     withTag,
+    withTags,
   )
 where
 
@@ -29,7 +30,10 @@ withWorkerName :: Text -> Background a -> Background a
 withWorkerName name = localBackgroundCtx \ctx -> ctx {workerName = name}
 
 withTag :: Text -> Text -> Background a -> Background a
-withTag key value = localBackgroundCtx \ctx -> ctx {loggingTags = Map.insert key value (loggingTags ctx)}
+withTag key value = withTags [(key, value)]
+
+withTags :: [(Text, Text)] -> Background a -> Background a
+withTags tags = localBackgroundCtx \ctx -> ctx {loggingTags = Map.union (Map.fromList tags) (loggingTags ctx)}
 
 instance Logging.MonadLogger Background where
   logMsg msg = do

--- a/src/Share/Contribution.hs
+++ b/src/Share/Contribution.hs
@@ -77,6 +77,8 @@ data Contribution = Contribution
     status :: ContributionStatus,
     sourceBranchId :: BranchId,
     targetBranchId :: BranchId,
+    sourceCausalId :: CausalId,
+    targetCausalId :: CausalId,
     bestCommonAncestorCausalId :: Maybe CausalId,
     createdAt :: UTCTime,
     updatedAt :: UTCTime,
@@ -94,6 +96,8 @@ instance Hasql.DecodeRow Contribution where
     status <- PG.decodeField
     sourceBranchId <- PG.decodeField
     targetBranchId <- PG.decodeField
+    sourceCausalId <- PG.decodeField
+    targetCausalId <- PG.decodeField
     bestCommonAncestorCausalId <- PG.decodeField
     createdAt <- PG.decodeField
     updatedAt <- PG.decodeField

--- a/src/Share/Metrics.hs
+++ b/src/Share/Metrics.hs
@@ -10,7 +10,7 @@ module Share.Metrics
     tickUserSignup,
     recordBackgroundImportDuration,
     recordDefinitionSearchIndexDuration,
-    recordContributionDiffDuration,
+    recordCausalDiffDuration,
     recordWebhookSendingDuration,
   )
 where
@@ -445,8 +445,8 @@ recordBackgroundImportDuration = timeActionIntoHistogram backgroundImportDuratio
 recordDefinitionSearchIndexDuration :: (MonadUnliftIO m) => m r -> m r
 recordDefinitionSearchIndexDuration = timeActionIntoHistogram definitionSearchIndexDurationSeconds (deployment, service)
 
-recordContributionDiffDuration :: Clock.TimeSpec -> IO ()
-recordContributionDiffDuration startTime = do
+recordCausalDiffDuration :: Clock.TimeSpec -> IO ()
+recordCausalDiffDuration startTime = do
   endTime <- Clock.getTime Monotonic
   recordLatency contributionDiffDurationSeconds (deployment, service) startTime endTime
 

--- a/src/Share/Postgres/Contributions/Queries.hs
+++ b/src/Share/Postgres/Contributions/Queries.hs
@@ -291,11 +291,7 @@ updateContribution callerUserId contributionId newTitle newDescription newStatus
     -- messes with the diffs.
     -- But we do want to update them if the source or target branch has changed.
     when
-      ( updatedStatus == InReview
-          || updatedStatus == Draft
-          || newSourceBranchId /= (Just sourceBranchId)
-          || newTargetBranchId /= (Just targetBranchId)
-      )
+      (updatedStatus == InReview || updatedStatus == Draft)
       do
         lift $
           PG.execute_
@@ -543,7 +539,11 @@ rebaseContributionsFromMergedBranches mergedContributions = do
       )
       UPDATE contributions contr
         SET target_branch = merged_contribution.target_branch,
-            target_causal_id = new_target_branch.causal_id
+            target_causal_id = new_target_branch.causal_id,
+            best_common_ancestor_causal_id = best_common_causal_ancestor(
+              contr.source_causal_id,
+              new_target_branch.causal_id
+            )
         -- Update all open contributions which are merging into a branch that was just merged
         FROM merged_contribution_ids
           JOIN contributions merged_contribution ON merged_contribution.id = merged_contribution_ids.contribution_id

--- a/src/Share/Postgres/IDs.hs
+++ b/src/Share/Postgres/IDs.hs
@@ -40,6 +40,7 @@ where
 
 import Control.Lens
 import Data.Coerce (Coercible)
+import Share.IDs (IsID (..))
 import Share.Postgres qualified as PG
 import Share.Prelude
 import U.Codebase.HashTags (BranchHash (..), CausalHash (..), ComponentHash (..), PatchHash (..))
@@ -49,7 +50,7 @@ import Unison.Hash32 qualified as Hash32
 
 newtype CausalId = CausalId {unCausalId :: Int32}
   deriving stock (Eq, Ord, Show)
-  deriving (PG.DecodeValue, PG.EncodeValue) via Int32
+  deriving (PG.DecodeValue, PG.EncodeValue, IsID) via Int32
 
 newtype BranchHashId = BranchHashId {unBranchHashId :: Int32}
   deriving stock (Eq, Ord, Show)

--- a/src/Share/Postgres/Notifications.hs
+++ b/src/Share/Postgres/Notifications.hs
@@ -64,20 +64,20 @@ initialize scope = Ki.fork_ scope $ forever do
 
 data ChannelKind
   = DefinitionSyncChannel
-  | ContributionDiffChannel
+  | CausalDiffChannel
   | WebhooksChannel
   deriving stock (Eq, Ord, Show, Bounded, Enum)
 
 toChannelText :: ChannelKind -> Text
 toChannelText = \case
   DefinitionSyncChannel -> "definition_sync"
-  ContributionDiffChannel -> "contribution_diff"
+  CausalDiffChannel -> "contribution_diff"
   WebhooksChannel -> "webhooks"
 
 fromChannelText :: Text -> Maybe ChannelKind
 fromChannelText = \case
   "definition_sync" -> Just DefinitionSyncChannel
-  "contribution_diff" -> Just ContributionDiffChannel
+  "contribution_diff" -> Just CausalDiffChannel
   "webhooks" -> Just WebhooksChannel
   _ -> Nothing
 

--- a/src/Share/Web/Share/Contributions/Impl.hs
+++ b/src/Share/Web/Share/Contributions/Impl.hs
@@ -270,8 +270,8 @@ contributionDiffEndpoint (AuthN.MaybeAuthedUserID mayCallerUserId) userHandle pr
     ) <- PG.runTransactionOrRespondError $ do
     project@Project {projectId} <- Q.projectByShortHand projectShorthand `whenNothingM` throwError (EntityMissing (ErrorID "project:missing") "Project not found")
     contribution@Contribution {sourceBranchId = newBranchId, targetBranchId = oldBranchId} <- ContributionsQ.contributionByProjectIdAndNumber projectId contributionNumber `whenNothingM` throwError (EntityMissing (ErrorID "contribution:missing") "Contribution not found")
-    newBranch <- Q.branchById newBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
-    oldBranch <- Q.branchById oldBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
+    newBranch <- Q.branchById Q.IncludeDeleted newBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
+    oldBranch <- Q.branchById Q.IncludeDeleted oldBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
     pure (project, contribution, oldBranch, newBranch)
   authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkContributionDiffRead mayCallerUserId projectId
   let oldCodebase = Codebase.codebaseForProjectBranch authZReceipt project oldBranch
@@ -324,8 +324,8 @@ contributionDiffTermsEndpoint (AuthN.MaybeAuthedUserID mayCallerUserId) userHand
       ) <- PG.runTransactionOrRespondError $ do
       project@Project {projectId} <- Q.projectByShortHand projectShorthand `whenNothingM` throwError (EntityMissing (ErrorID "project:missing") "Project not found")
       contribution@Contribution {sourceBranchId = newBranchId, targetBranchId = oldBranchId} <- ContributionsQ.contributionByProjectIdAndNumber projectId contributionNumber `whenNothingM` throwError (EntityMissing (ErrorID "contribution:missing") "Contribution not found")
-      newBranch <- Q.branchById newBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
-      oldBranch <- Q.branchById oldBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
+      newBranch <- Q.branchById Q.IncludeDeleted newBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
+      oldBranch <- Q.branchById Q.IncludeDeleted oldBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
       pure (project, contribution, oldBranch, newBranch)
     authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkContributionDiffRead mayCallerUserId projectId
     let oldCodebase = Codebase.codebaseForProjectBranch authZReceipt project oldBranch
@@ -382,8 +382,8 @@ contributionDiffTypesEndpoint (AuthN.MaybeAuthedUserID mayCallerUserId) userHand
       ) <- PG.runTransactionOrRespondError $ do
       project@Project {projectId} <- Q.projectByShortHand projectShorthand `whenNothingM` throwError (EntityMissing (ErrorID "project:missing") "Project not found")
       contribution@Contribution {sourceBranchId = newBranchId, targetBranchId = oldBranchId} <- ContributionsQ.contributionByProjectIdAndNumber projectId contributionNumber `whenNothingM` throwError (EntityMissing (ErrorID "contribution:missing") "Contribution not found")
-      newBranch <- Q.branchById newBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
-      oldBranch <- Q.branchById oldBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
+      newBranch <- Q.branchById Q.IncludeDeleted newBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
+      oldBranch <- Q.branchById Q.IncludeDeleted oldBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
       pure (project, contribution, oldBranch, newBranch)
     authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkContributionDiffRead mayCallerUserId projectId
     let oldCodebase = Codebase.codebaseForProjectBranch authZReceipt project oldBranch
@@ -437,8 +437,8 @@ mergeContributionEndpoint session userHandle projectSlug contributionNumber (AtK
     currentContributionStateToken <- ContributionsQ.contributionStateTokenById contribution.contributionId
     when (currentContributionStateToken /= contributionStateToken) do
       throwSomeServerError (ContributionStateChangedError contributionStateToken currentContributionStateToken)
-    sourceBranch <- Q.branchById contribution.sourceBranchId `whenNothingM` throwSomeServerError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
-    targetBranch <- Q.branchById contribution.targetBranchId `whenNothingM` throwSomeServerError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
+    sourceBranch <- Q.branchById Q.IncludeDeleted contribution.sourceBranchId `whenNothingM` throwSomeServerError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
+    targetBranch <- Q.branchById Q.IncludeDeleted contribution.targetBranchId `whenNothingM` throwSomeServerError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
     isFastForward <- CausalQ.isFastForward targetBranch.causal sourceBranch.causal
     if isFastForward
       then do
@@ -472,8 +472,8 @@ checkMergeContributionEndpoint session userHandle projectSlug contributionNumber
     Merged -> pure $ CheckMergeContributionResponse {mergeability = AlreadyMerged}
     _ -> do
       isFastForward <- PG.runTransactionOrRespondError do
-        sourceBranch <- Q.branchById contribution.sourceBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
-        targetBranch <- Q.branchById contribution.targetBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
+        sourceBranch <- Q.branchById Q.IncludeDeleted contribution.sourceBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Source branch not found")
+        targetBranch <- Q.branchById Q.IncludeDeleted contribution.targetBranchId `whenNothingM` throwError (EntityMissing (ErrorID "branch:missing") "Target branch not found")
         CausalQ.isFastForward targetBranch.causal sourceBranch.causal
       if isFastForward
         then pure CheckMergeContributionResponse {mergeability = CanFastForward}

--- a/src/Share/Web/Share/Contributions/MergeDetection.hs
+++ b/src/Share/Web/Share/Contributions/MergeDetection.hs
@@ -14,7 +14,7 @@ import Share.Postgres.Contributions.Queries qualified as ContributionQ
 updateContributionsFromBranchUpdate :: UserId -> BranchId -> PG.Transaction e ()
 updateContributionsFromBranchUpdate callerUserId branchId = do
   contributionsWithUpdatedBCAs <- ContributionQ.performMergesAndBCAUpdatesFromBranchPush callerUserId branchId
-  _rebasedContributions <- ContributionQ.rebaseContributionsFromMergedBranches contributionsWithUpdatedBCAs
+  rebasedContributions <- ContributionQ.rebaseContributionsFromMergedBranches contributionsWithUpdatedBCAs
   affectedContributions <- ContributionQ.contributionsRelatedToBranches (Set.singleton branchId)
-  DiffsQ.submitContributionsToBeDiffed (Set.fromList affectedContributions)
+  DiffsQ.submitContributionsToBeDiffed (Set.fromList affectedContributions <> rebasedContributions)
   pure ()

--- a/src/Share/Web/UCM/Sync/Impl.hs
+++ b/src/Share/Web/UCM/Sync/Impl.hs
@@ -130,7 +130,7 @@ getCausalHashByPathEndpoint callerUserId (GetCausalHashByPathRequest sharePath) 
         Left {} -> throwError (GetCausalHashByPathNoReadPermission sharePath)
         Right authZReceipt -> do
           let codebase = Codebase.codebaseEnv authZReceipt codebaseLoc
-          lift . Codebase.runCodebaseTransactionMode PG.ReadCommitted PG.ReadWrite codebase $ do
+          lift . Codebase.runCodebaseTransaction codebase $ do
             (codebaseLooseCodeRootCausalId, _) <- Codebase.expectLooseCodeRoot
             Codebase.loadCausalNamespaceAtPath codebaseLooseCodeRootCausalId localPath
     case mayCausalAtPath of
@@ -184,7 +184,7 @@ downloadEntitiesEndpoint mayUserId DownloadEntitiesRequest {repoInfo, hashes = h
       HashJWT.verifyHashJWT mayUserId hashJWT >>= \case
         Left ae -> respondError ae
         Right HashJWTClaims {hash} -> do
-          entity <- Codebase.runCodebaseTransactionMode PG.ReadCommitted PG.Read codebase $ SyncQ.expectEntity hash
+          entity <- Codebase.runCodebaseTransaction codebase $ SyncQ.expectEntity hash
           pure (hash, entity)
 
 uploadEntitiesEndpoint :: UserId -> UploadEntitiesRequest -> WebApp UploadEntitiesResponse

--- a/src/Share/Web/UCM/SyncV2/Queries.hs
+++ b/src/Share/Web/UCM/SyncV2/Queries.hs
@@ -219,7 +219,7 @@ allSerializedDependenciesOfCausalCursor cid exceptCausalHashes = do
 spineAndLibDependenciesOfCausalCursor :: CausalId -> CodebaseM e (PGCursor (Hash32, IsCausalSpine, IsLibRoot))
 spineAndLibDependenciesOfCausalCursor cid = do
   ownerUserId <- asks codebaseOwner
-  libSegmentTextId <- queryExpect1Col @Int64 [sql| SELECT text.id FROM text WHERE content_hash = text_hash('lib') |]
+  libSegmentTextId <- query1Col @Int64 [sql| SELECT text.id FROM text WHERE content_hash = text_hash('lib') |]
   PGCursor.newRowCursor
     "causal_dependencies"
     [sql|

--- a/transcripts/share-apis/contribution-merge/contribution-after-merge.json
+++ b/transcripts/share-apis/contribution-merge/contribution-after-merge.json
@@ -6,7 +6,7 @@
       "name": null,
       "userId": "U-<UUID>"
     },
-    "contributionStateToken": "C-<UUID>:B-<UUID>:B-<UUID>:glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8:glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8:merged",
+    "contributionStateToken": "C-<UUID>:B-<UUID>:B-<UUID>:glncbgqvg94ktnvdddlk96osvlnfi62dnm8u70vit40gk9htt683s2a4afcl13k2t14ah0ks02gp7qu4q6l1bapspju5eiu8q81ova8:rl08e4s9jm58fhj7uslg0qlndg2qhlp6gdd2thjicgpakqbkeumgeo220hgrh27jcd3kqh1o9b24dimpssr9eq2pe2icdu7nffkabsg:merged",
     "createdAt": "<TIMESTAMP>",
     "description": "My description",
     "id": "C-<UUID>",

--- a/transcripts/share-apis/contributions/merged-contribution-diff.json
+++ b/transcripts/share-apis/contributions/merged-contribution-diff.json
@@ -1,0 +1,15 @@
+{
+  "body": {
+    "newRef": "feature-one",
+    "newRefHash": "#7shvkj0gn9mfne1pemp3oudmo23vio4d8ualvbah6avr7m5471rssu9cd4o6i4pn91bgc62vgnm0oper0itgtmopqmff7c0b40ui1s0",
+    "oldRef": "main",
+    "oldRefHash": "#7shvkj0gn9mfne1pemp3oudmo23vio4d8ualvbah6avr7m5471rssu9cd4o6i4pn91bgc62vgnm0oper0itgtmopqmff7c0b40ui1s0",
+    "project": "@transcripts/bca-updates",
+    "tag": "computing"
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/contributions/merged-contribution.json
+++ b/transcripts/share-apis/contributions/merged-contribution.json
@@ -6,7 +6,7 @@
       "name": "Transcript User",
       "userId": "U-<UUID>"
     },
-    "contributionStateToken": "C-<UUID>:B-<UUID>:B-<UUID>:7shvkj0gn9mfne1pemp3oudmo23vio4d8ualvbah6avr7m5471rssu9cd4o6i4pn91bgc62vgnm0oper0itgtmopqmff7c0b40ui1s0:7shvkj0gn9mfne1pemp3oudmo23vio4d8ualvbah6avr7m5471rssu9cd4o6i4pn91bgc62vgnm0oper0itgtmopqmff7c0b40ui1s0:merged",
+    "contributionStateToken": "C-<UUID>:B-<UUID>:B-<UUID>:7shvkj0gn9mfne1pemp3oudmo23vio4d8ualvbah6avr7m5471rssu9cd4o6i4pn91bgc62vgnm0oper0itgtmopqmff7c0b40ui1s0:rl08e4s9jm58fhj7uslg0qlndg2qhlp6gdd2thjicgpakqbkeumgeo220hgrh27jcd3kqh1o9b24dimpssr9eq2pe2icdu7nffkabsg:merged",
     "createdAt": "<TIMESTAMP>",
     "description": "description",
     "id": "C-<UUID>",

--- a/transcripts/share-apis/contributions/run.zsh
+++ b/transcripts/share-apis/contributions/run.zsh
@@ -129,10 +129,8 @@ for i in {1..5}; do
   fi
 done
 
-# Temporarily commenting this test out
-
 # BCA of contribution diff should still be frozen at it's pre-merge hash. The bca and source hash should be different (or else we'd see no diff!)
-# fetch "$transcripts_user" GET merged-contribution-diff '/users/transcripts/projects/bca-updates/contributions/1/diff'
+fetch "$transcripts_user" GET merged-contribution-diff '/users/transcripts/projects/bca-updates/contributions/1/diff'
 
 # Fetch the contribution for feature-two which was based on feature-one, which was just merged.
 # It should now be marked as merging into main.

--- a/transcripts/sql/clean.sql
+++ b/transcripts/sql/clean.sql
@@ -2,6 +2,8 @@
 -- Doesn't clean codebase tables since that just slows things down, but does clean out codebase ownership.
 SET client_min_messages TO WARNING;
 TRUNCATE TABLE users CASCADE;
+TRUNCATE TABLE superadmins CASCADE;
+TRUNCATE TABLE role_memberships CASCADE;
 TRUNCATE TABLE loose_code_roots CASCADE;
 TRUNCATE TABLE org_members CASCADE;
 TRUNCATE TABLE tours CASCADE;
@@ -22,9 +24,18 @@ TRUNCATE TABLE contribution_status_events CASCADE;
 TRUNCATE TABLE tickets CASCADE;
 TRUNCATE TABLE comments CASCADE;
 TRUNCATE TABLE comment_revisions CASCADE;
+TRUNCATE TABLE teams CASCADE;
+TRUNCATE TABLE team_members CASCADE;
+TRUNCATE TABLE orgs CASCADE;
+TRUNCATE TABLE subjects CASCADE;
+TRUNCATE TABLE resources CASCADE;
+TRUNCATE TABLE contribution_diff_queue CASCADE;
+TRUNCATE TABLE namespace_diffs CASCADE;
 
 TRUNCATE TABLE namespace_ownership CASCADE;
 TRUNCATE TABLE causal_ownership CASCADE;
+-- Transcripts should generally behave the same with or without truncating these, and leaving them in place saves
+-- time when rerunning tests.
 -- TRUNCATE TABLE branch_hashes CASCADE;
 -- TRUNCATE TABLE namespaces CASCADE;
 -- TRUNCATE TABLE causals CASCADE;

--- a/transcripts/sql/clean.sql
+++ b/transcripts/sql/clean.sql
@@ -29,7 +29,7 @@ TRUNCATE TABLE team_members CASCADE;
 TRUNCATE TABLE orgs CASCADE;
 TRUNCATE TABLE subjects CASCADE;
 TRUNCATE TABLE resources CASCADE;
-TRUNCATE TABLE contribution_diff_queue CASCADE;
+TRUNCATE TABLE causal_diff_queue CASCADE;
 TRUNCATE TABLE namespace_diffs CASCADE;
 
 TRUNCATE TABLE namespace_ownership CASCADE;

--- a/transcripts/sql/inserts.sql
+++ b/transcripts/sql/inserts.sql
@@ -287,6 +287,8 @@ INSERT INTO contributions (
     status,
     source_branch,
     target_branch,
+    source_causal_id,
+    target_causal_id,
     author_id)
 VALUES (
     '511fbf1c-5353-4e01-ba23-b94e6092ede5',
@@ -307,6 +309,8 @@ I tested this change locally on my development environment and confirmed that us
     'in_review',
     'bb343b05-2da8-47a4-b008-d45b8b367116',
     'a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d',
+    (SELECT pb.causal_id FROM project_branches pb WHERE pb.id = 'bb343b05-2da8-47a4-b008-d45b8b367116' LIMIT 1),
+    (SELECT pb.causal_id FROM project_branches pb WHERE pb.id = 'a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d' LIMIT 1),
     'd32f4ddf-2423-4f10-a4de-465939951354');
 
 INSERT INTO contribution_status_events (
@@ -359,6 +363,8 @@ INSERT INTO contributions (
     status,
     source_branch,
     target_branch,
+    source_causal_id,
+    target_causal_id,
     author_id)
 VALUES (
     '3560fa5d-d29d-49b8-bf4f-1045fef31c81',
@@ -379,6 +385,8 @@ I tested the pagination feature with a large dataset to ensure it functions corr
     'in_review',
     'bb343b05-2da8-47a4-b008-d45b8b367116',
     'a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d',
+    (SELECT pb.causal_id FROM project_branches pb WHERE pb.id = 'bb343b05-2da8-47a4-b008-d45b8b367116' LIMIT 1),
+    (SELECT pb.causal_id FROM project_branches pb WHERE pb.id = 'a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d' LIMIT 1),
     'd32f4ddf-2423-4f10-a4de-465939951354');
 
 INSERT INTO contribution_status_events (


### PR DESCRIPTION
## Overview

Now that contribution diffs depend on the target causal and not just the BCA we need to track that on the contribution itself so we can freeze it once merged.

## Implementation notes

* Store the current `source_causal_id` and `target_causal_id` on the contribution itself and update them when necessary
Use these causals when computing diffs rather than the _current_ state of the referenced branches.
* Carefully avoid updating these columns on contributions when the contribution is merged or is in the process of being merged.
* Replace `contribution_diff_queue` with a generic `causal_diff_queue` so we ensure no diff calculations get accidentally rolled together, and also so we can use it for generic namespace diffs



## Test coverage

* [x] Updated transcripts
