### PR TITLE
Add metric tracking causal diff queue size

### DIFF
--- a/src/Share/Postgres/Metrics/Queries.hs
+++ b/src/Share/Postgres/Metrics/Queries.hs
@@ -162,3 +162,8 @@ WITH namespaces(handle, slug, name, namespace_hash_id, private) AS (
 ) :: bigint, 0 :: bigint) as num
   FROM namespaces
     |]
+
+numCausalDiffQueueEntries :: PG.Transaction e Int64
+numCausalDiffQueueEntries =
+  PG.queryExpect1Col
+    [PG.sql| SELECT COUNT(*) FROM causal_diff_queue |]


### PR DESCRIPTION
## Overview

* [x] ~NOTE: merge #69  first~

* Adds a new gauge for the current diff queue size
* Changes slow-metric refresh interval to 5 mins from 10 mins

