### PR TITLE
Some basic fixups for search

### DIFF
--- a/share-utils/src/Share/Debug.hs
+++ b/share-utils/src/Share/Debug.hs
@@ -4,6 +4,7 @@
 
 module Share.Debug
   ( debug,
+    debugOther,
     debugM,
     whenDebug,
     debugLog,
@@ -59,6 +60,14 @@ debug :: (Show a) => DebugFlag -> String -> a -> a
 debug flag msg a =
   if shouldDebug flag
     then (trace (msg <> ":\n" <> into @String (pShow a)) a)
+    else a
+
+-- | Use for trace-style selective debugging.
+-- Like 'debug' but allows debugging something other than the result.
+debugOther :: (Show x) => DebugFlag -> String -> x -> a -> a
+debugOther flag msg x a =
+  if shouldDebug flag
+    then (trace (msg <> ":\n" <> into @String (pShow x)) a)
     else a
 
 -- | Use for selective debug logging in monadic contexts.

--- a/src/Share/Postgres/NameLookups/Ops.hs
+++ b/src/Share/Postgres/NameLookups/Ops.hs
@@ -36,7 +36,6 @@ import U.Codebase.Reference (Reference)
 import U.Codebase.Referent (ConstructorType, Referent)
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
-import Unison.Debug qualified as Debug
 import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.NameSegment.Internal (NameSegment (..))
@@ -109,7 +108,6 @@ relocateToNameRoot perspective query rootBh = do
             & Path.fromList
         Nothing -> mempty
   let fullPath = perspective <> nameLocation
-  Debug.debugM Debug.Server "relocateToNameRoot fullPath" fullPath
   namesPerspective@NamesPerspective {relativePerspective} <- namesPerspectiveForRootAndPath rootBh (PathSegments . fmap NameSegment.toUnescapedText . Path.toList $ fullPath)
   let reprefixName name = Name.fromReverseSegments $ (NonEmpty.head $ Name.reverseSegments name) NonEmpty.:| (reverse $ coerce relativePerspective)
   pure (namesPerspective, reprefixName <$> query)

--- a/src/Unison/Server/Share/FuzzyFind.hs
+++ b/src/Unison/Server/Share/FuzzyFind.hs
@@ -301,15 +301,19 @@ computeMatchSegments query (NamedRef {reversedSegments}) =
 -- names.
 --
 -- >>> prepareQuery "foo bar baz"
+-- (["foo","bar","baz"],Just "baz")
 --
 -- Split camel-case style words into segments.
 -- >>> prepareQuery "fMap"
+-- (["f","Map"],Just "fMap")
 --
 -- Collapse multiple spaces
 -- >>> prepareQuery "foo barBaz    boom"
+-- (["foo","bar","Baz","boom"],Just "boom")
 --
 -- Split namespaces into segments with a required dot in between.
 -- >>> prepareQuery "List.map"
+-- (["List",".","map"],Just "map")
 --
 -- Shouldn't get multiple splits for capitalized letters
 -- >>> prepareQuery "List.Map"

--- a/transcripts/share-apis/branch-browse/branch-find.json
+++ b/transcripts/share-apis/branch-browse/branch-find.json
@@ -61,6 +61,47 @@
         "result": {
           "segments": [
             {
+              "contents": "other.",
+              "tag": "Gap"
+            },
+            {
+              "contents": "remote",
+              "tag": "Match"
+            },
+            {
+              "contents": "Map",
+              "tag": "Gap"
+            }
+          ]
+        },
+        "score": 0
+      },
+      {
+        "contents": {
+          "bestFoundTermName": "other.remoteMap",
+          "namedTerm": {
+            "termHash": "#pi25gcdv0oq0no6k2ahe6t849u7ht4lopeg5fve58ga5t17a49f1dkbmdm6dn063bn3tsd4adijr4ltf7ad6do8u71oa72i27oack2o",
+            "termName": "other.remoteMap",
+            "termTag": "Plain",
+            "termType": [
+              {
+                "annotation": {
+                  "contents": "##Nat",
+                  "tag": "HashQualifier"
+                },
+                "segment": "##Nat"
+              }
+            ]
+          }
+        },
+        "tag": "FoundTermResult"
+      }
+    ],
+    [
+      {
+        "result": {
+          "segments": [
+            {
               "contents": "Remote",
               "tag": "Match"
             },
@@ -74,7 +115,7 @@
       },
       {
         "contents": {
-          "bestFoundTermName": "at",
+          "bestFoundTermName": "Remote.at",
           "namedTerm": {
             "termHash": "#r7hq9rqc3hebqailf77f656vbgice0716c6f0j7bj06muhj5ac1pq103gdh5974f14fcbmvp44fai5in1ajp5j3ejckfp6bffd3fpoo#0",
             "termName": "Remote.at",
@@ -126,47 +167,6 @@
         "result": {
           "segments": [
             {
-              "contents": "other.",
-              "tag": "Gap"
-            },
-            {
-              "contents": "remote",
-              "tag": "Match"
-            },
-            {
-              "contents": "Map",
-              "tag": "Gap"
-            }
-          ]
-        },
-        "score": 0
-      },
-      {
-        "contents": {
-          "bestFoundTermName": "remoteMap",
-          "namedTerm": {
-            "termHash": "#pi25gcdv0oq0no6k2ahe6t849u7ht4lopeg5fve58ga5t17a49f1dkbmdm6dn063bn3tsd4adijr4ltf7ad6do8u71oa72i27oack2o",
-            "termName": "other.remoteMap",
-            "termTag": "Plain",
-            "termType": [
-              {
-                "annotation": {
-                  "contents": "##Nat",
-                  "tag": "HashQualifier"
-                },
-                "segment": "##Nat"
-              }
-            ]
-          }
-        },
-        "tag": "FoundTermResult"
-      }
-    ],
-    [
-      {
-        "result": {
-          "segments": [
-            {
               "contents": "Remote",
               "tag": "Match"
             },
@@ -180,7 +180,7 @@
       },
       {
         "contents": {
-          "bestFoundTypeName": "()",
+          "bestFoundTypeName": "Remote.Location",
           "namedType": {
             "typeHash": "#00nv2kob8f",
             "typeName": "Remote.Location",
@@ -244,7 +244,7 @@
       },
       {
         "contents": {
-          "bestFoundTermName": "map",
+          "bestFoundTermName": "something.Remote.map",
           "namedTerm": {
             "termHash": "#cp6ri8mtg0iooorjj3dgc8ungobkjddnb7ooirmb5s3dvg1ip8eurar6lbkh1kn7ejb82ttmus39der955mf6hj47l1l9hr6itdmrv8",
             "termName": "something.Remote.map",
@@ -281,7 +281,7 @@
       },
       {
         "contents": {
-          "bestFoundTermName": "()",
+          "bestFoundTermName": "Remote.Location.Location",
           "namedTerm": {
             "termHash": "#00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g#0",
             "termName": "Remote.Location.Location",

--- a/transcripts/share-apis/code-browse/codebase-find.json
+++ b/transcripts/share-apis/code-browse/codebase-find.json
@@ -30,7 +30,7 @@
       },
       {
         "contents": {
-          "bestFoundTermName": "two",
+          "bestFoundTermName": "names.oranges.two",
           "namedTerm": {
             "termHash": "#dcgdua2lj6upd1ah5v0qp09gjsej0d77d87fu6qn8e2qrssnlnmuinoio46hiu53magr7qn8vnqke8ndt0v76700o5u8gcvo7st28jg",
             "termName": "names.oranges.two",


### PR DESCRIPTION
## Overview

Paul was getting some weird search results within the project:

<img width="876" alt="image" src="https://github.com/user-attachments/assets/bbce5846-e9ca-4e85-ab78-d566ee75f02b" />

This PR improves matching based on the final search segment a bit. It's still not as good as the main term search, ideally we'll switch over project search to use that mechanism but that's a more time intensive ordeal, so this is just a short-term patch for now.

## Implementation notes

* Fix a bug in the infix-pattern matcher so the LIKE queries work as expected
* use the entire last segment of a dot-separated search when doing exact matching on last segment
* Return the name that matched in the results rather than the 'best name'

## Test coverage

Transcripts and local testing.