### PR TITLE
Update auth lib to allow multiple issuers

### DIFF
--- a/app/Env.hs
+++ b/app/Env.hs
@@ -93,6 +93,7 @@ withEnv action = do
             | otherwise = Nothing
        in r {Redis.connectTLSParams = tlsParams}
   let acceptedAudiences = Set.singleton apiOrigin
+  let acceptedIssuers = Set.singleton apiOrigin
   let legacyKey = JWT.KeyDescription {JWT.key = hs256Key, JWT.alg = JWT.HS256}
   let signingKey = JWT.KeyDescription {JWT.key = edDSAKey, JWT.alg = JWT.Ed25519}
   hashJWTJWK <- case JWT.keyDescToJWK legacyKey of
@@ -102,7 +103,7 @@ withEnv action = do
   -- version of the key is used for validation, which is needed for HashJWTs which are signed
   -- with a 'kid'.
   let validationKeys = Set.fromList [legacyKey]
-  jwtSettings <- case JWT.defaultJWTSettings signingKey (Just legacyKey) validationKeys acceptedAudiences apiOrigin of
+  jwtSettings <- case JWT.defaultJWTSettings signingKey (Just legacyKey) validationKeys acceptedAudiences acceptedIssuers of
     Left cryptoError -> throwIO cryptoError
     Right settings -> pure settings
   let cookieSettings = Cookies.defaultCookieSettings Deployment.onLocal (Just (realToFrac cookieSessionTTL))

--- a/share-auth/example/src/Lib.hs
+++ b/share-auth/example/src/Lib.hs
@@ -78,7 +78,7 @@ main = do
   redisConn <- R.checkedConnect R.defaultConnectInfo
   putStrLn "booting up"
 
-  jwtSettings <- case JWT.defaultJWTSettings signingKey (Just legacyKey) rotatedKeys acceptedAudiences issuer of
+  jwtSettings <- case JWT.defaultJWTSettings signingKey (Just legacyKey) rotatedKeys acceptedAudiences acceptedIssuers of
     Left cryptoError -> throwIO cryptoError
     Right jwtS -> do
       pure jwtS
@@ -138,3 +138,4 @@ main = do
     serviceAudience = api
     acceptedAudiences = Set.singleton serviceAudience
     issuer = unsafeURI "http://localhost:5424"
+    acceptedIssuers = Set.singleton issuer

--- a/share-auth/src/Share/JWT/Types.hs
+++ b/share-auth/src/Share/JWT/Types.hs
@@ -135,12 +135,10 @@ data JWTSettings = JWTSettings
     signingJWK :: Jose.JWK,
     -- | Keys used to validate JWT.
     validationKeys :: KeyMap,
-    -- | An @aud@ predicate. The @aud@ is a string or URI that identifies the
-    -- intended recipient of the JWT.
-    audienceMatches :: JWT.StringOrURI -> Bool,
     -- | The set of audiences the app accepts tokens for.
     acceptedAudiences :: Set URI,
-    issuer :: URI
+    -- | The set of issuers the app accepts tokens from.
+    acceptedIssuers :: Set URI
   }
   deriving (Show) via Censored JWTSettings
 


### PR DESCRIPTION
## Overview

cloud-api is issuing its own tokens now, but still needs to validate Share tokens, so we must allow validating multiple issuers.

## Implementation notes

Accept a set of issuers rather than a single one.


## Test coverage

We should test this on staging in cloud-api; but it should be strictly more lax.

## Loose ends

Need to pull this into cloud-api