### PR TITLE
Project search fixups

### DIFF
--- a/transcripts/share-apis/search/omni-search-projects.json
+++ b/transcripts/share-apis/search/omni-search-projects.json
@@ -1,0 +1,15 @@
+{
+  "body": [
+    {
+      "projectRef": "@transcripts/search",
+      "summary": null,
+      "tag": "project",
+      "visibility": "private"
+    }
+  ],
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/search/run.zsh
+++ b/transcripts/share-apis/search/run.zsh
@@ -93,3 +93,5 @@ fetch "$transcripts_user" GET 'omni-search-orgs' '/search?query=%40uni'
 
 # Omni search should find regular users
 fetch "$transcripts_user" GET 'omni-search-users' '/search?query=%40tes'
+# Omni search should find projects by infix
+fetch "$transcripts_user" GET 'omni-search-projects' '/search?query=%40ear'


### PR DESCRIPTION
## Overview

Retools project search so:

* Projects in the catalog get a boost,
* Projects in the Unison org get priority
* Searches include infix matches on project slug

## Implementation notes

Just reworks the query abit.

## Test Coverage

See transcript