### PR TITLE
Rework paging for all paged endpoints

### DIFF
--- a/src/Share/Postgres/Contributions/Queries.hs
+++ b/src/Share/Postgres/Contributions/Queries.hs
@@ -28,7 +28,7 @@ import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Time (UTCTime)
-import Safe (lastMay)
+import Safe (headMay, lastMay)
 import Share.Codebase.Types (CodebaseEnv (..))
 import Share.Contribution (Contribution (..), ContributionStatus (..))
 import Share.IDs
@@ -111,7 +111,7 @@ listContributionsByProjectId ::
   Maybe UserId ->
   Maybe ContributionStatus ->
   Maybe ContributionKindFilter ->
-  PG.Transaction e (Maybe (Cursor ListContributionsCursor), [ShareContribution UserId])
+  PG.Transaction e (Paged ListContributionsCursor (ShareContribution UserId))
 listContributionsByProjectId projectId limit mayCursor mayUserFilter mayStatusFilter mayKindFilter = do
   let kindFilter = case mayKindFilter of
         Nothing -> "true"
@@ -121,11 +121,15 @@ listContributionsByProjectId projectId limit mayCursor mayUserFilter mayStatusFi
           OnlyContributorContributions -> [PG.sql| source_branch.contributor_id IS NOT NULL |]
   let cursorFilter = case mayCursor of
         Nothing -> "true"
-        Just (Cursor (beforeTime, contributionId)) ->
+        Just (Cursor (beforeTime, contributionId) Next) ->
           [PG.sql|
           (contribution.updated_at, contribution.id) < (#{beforeTime}, #{contributionId})
           |]
-  addCursor
+        Just (Cursor (afterTime, contributionId) Previous) ->
+          [PG.sql|
+          (contribution.updated_at, contribution.id) > (#{afterTime}, #{contributionId})
+          |]
+  paged
     <$> PG.queryListRows @(ShareContribution UserId)
       [PG.sql|
         SELECT
@@ -161,12 +165,15 @@ listContributionsByProjectId projectId limit mayCursor mayUserFilter mayStatusFi
         LIMIT #{limit}
       |]
   where
-    addCursor :: [ShareContribution UserId] -> (Maybe (Cursor ListContributionsCursor), [ShareContribution UserId])
-    addCursor xs =
-      ( lastMay xs <&> \(ShareContribution {updatedAt, contributionId}) ->
-          Cursor (updatedAt, contributionId),
-        xs
-      )
+    paged :: [ShareContribution UserId] -> Paged ListContributionsCursor (ShareContribution UserId)
+    paged items =
+      let prevCursor = headMay items <&> \(ShareContribution {updatedAt, contributionId}) -> Cursor (updatedAt, contributionId) Previous
+          nextCursor = lastMay items <&> \(ShareContribution {updatedAt, contributionId}) -> Cursor (updatedAt, contributionId) Next
+       in Paged
+            { items,
+              prevCursor,
+              nextCursor
+            }
 
 contributionById :: (PG.QueryA m) => ContributionId -> m Contribution
 contributionById contributionId = do
@@ -267,7 +274,7 @@ listContributionsByUserId ::
   Maybe (Cursor (UTCTime, ContributionId)) ->
   Maybe ContributionStatus ->
   Maybe ContributionKindFilter ->
-  PG.Transaction e (Maybe (Cursor (UTCTime, ContributionId)), [ShareContribution UserId])
+  PG.Transaction e (Paged (UTCTime, ContributionId) (ShareContribution UserId))
 listContributionsByUserId callerUserId userId limit mayCursor mayStatusFilter mayKindFilter = do
   let kindFilter = case mayKindFilter of
         Nothing -> "true"
@@ -277,11 +284,15 @@ listContributionsByUserId callerUserId userId limit mayCursor mayStatusFilter ma
           OnlyContributorContributions -> [PG.sql| source_branch.contributor_id IS NOT NULL |]
   let cursorFilter = case mayCursor of
         Nothing -> "true"
-        Just (Cursor (beforeTime, contributionId)) ->
+        Just (Cursor (beforeTime, contributionId) Next) ->
           [PG.sql|
           (contribution.updated_at, contribution.id) < (#{beforeTime}, #{contributionId})
           |]
-  addCursor
+        Just (Cursor (afterTime, contributionId) Previous) ->
+          [PG.sql|
+          (contribution.updated_at, contribution.id) > (#{afterTime}, #{contributionId})
+          |]
+  paged
     <$> PG.queryListRows @(ShareContribution UserId)
       [PG.sql|
       SELECT
@@ -318,12 +329,15 @@ listContributionsByUserId callerUserId userId limit mayCursor mayStatusFilter ma
       LIMIT #{limit}
       |]
   where
-    addCursor :: [ShareContribution UserId] -> (Maybe (Cursor ListContributionsCursor), [ShareContribution UserId])
-    addCursor xs =
-      ( lastMay xs <&> \(ShareContribution {updatedAt, contributionId}) ->
-          Cursor (updatedAt, contributionId),
-        xs
-      )
+    paged :: [ShareContribution UserId] -> (Paged ListContributionsCursor (ShareContribution UserId))
+    paged items =
+      let prevCursor = headMay items <&> \(ShareContribution {updatedAt, contributionId}) -> Cursor (updatedAt, contributionId) Previous
+          nextCursor = lastMay items <&> \(ShareContribution {updatedAt, contributionId}) -> Cursor (updatedAt, contributionId) Next
+       in Paged
+            { items,
+              prevCursor,
+              nextCursor
+            }
 
 -- | Note: Doesn't perform auth checks, the assumption is that if you already have access to
 -- the branchId you have access to all associated contributions.

--- a/src/Share/Postgres/Queries.hs
+++ b/src/Share/Postgres/Queries.hs
@@ -776,7 +776,8 @@ listBranchesByProject limit mayCursor mayBranchNamePrefix mayContributorQuery ki
         Just (Query branchNamePrefix) -> [PG.sql| AND starts_with(b.name, #{branchNamePrefix}) |]
   let cursorFilter = case mayCursor of
         Nothing -> mempty
-        Just (Cursor (beforeTime, branchId)) -> [PG.sql| AND (b.updated_at, b.id) < (#{beforeTime}, #{branchId})|]
+        Just (Cursor (beforeTime, branchId) Previous) -> [PG.sql| AND (b.updated_at, b.id) < (#{beforeTime}, #{branchId})|]
+        Just (Cursor (afterTime, branchId) Next) -> [PG.sql| AND (b.updated_at, b.id) > (#{afterTime}, #{branchId})|]
   let sql =
         intercalateMap
           "\n"
@@ -877,7 +878,8 @@ listContributorBranchesOfUserAccessibleToCaller contributorUserId mayCallerUserI
         Just (Query branchNamePrefix) -> [PG.sql| AND starts_with(b.name, #{branchNamePrefix}) |]
   let cursorFilter = case mayCursor of
         Nothing -> mempty
-        Just (Cursor (beforeTime, branchId)) -> [PG.sql| AND (b.updated_at, b.id) < (#{beforeTime}, #{branchId}) |]
+        Just (Cursor (beforeTime, branchId) Previous) -> [PG.sql| AND (b.updated_at, b.id) < (#{beforeTime}, #{branchId}) |]
+        Just (Cursor (afterTime, branchId) Next) -> [PG.sql| AND (b.updated_at, b.id) > (#{afterTime}, #{branchId}) |]
   let projectFilter = case mayProjectId of
         Nothing -> mempty
         Just projId -> [PG.sql| AND b.project_id = #{projId} |]
@@ -1149,8 +1151,10 @@ listReleasesByProject limit mayCursor mayVersionPrefix status projectId = do
              in numericalFilters
   let cursorFilter = case mayCursor of
         Nothing -> mempty
-        Just (Cursor (major, minor, patch, releaseId)) ->
+        Just (Cursor (major, minor, patch, releaseId) Previous) ->
           [PG.sql| AND (release.major_version, release.minor_version, release.patch_version, release.id) < (#{major}, #{minor}, #{patch}, #{releaseId}) |]
+        Just (Cursor (major, minor, patch, releaseId) Next) ->
+          [PG.sql| AND (release.major_version, release.minor_version, release.patch_version, release.id) >= (#{major}, #{minor}, #{patch}, #{releaseId}) |]
   let (sql) =
         intercalateMap
           "\n"

--- a/src/Share/Postgres/Tickets/Queries.hs
+++ b/src/Share/Postgres/Tickets/Queries.hs
@@ -20,7 +20,7 @@ where
 import Control.Lens
 import Data.List qualified as List
 import Data.Time (UTCTime)
-import Safe (lastMay)
+import Safe (headMay, lastMay)
 import Share.IDs
 import Share.Postgres qualified as PG
 import Share.Prelude
@@ -121,15 +121,19 @@ listTicketsByProjectId ::
   Maybe (Cursor ListTicketsCursor) ->
   Maybe UserId ->
   Maybe TicketStatus ->
-  PG.Transaction e (Maybe (Cursor ListTicketsCursor), [(ShareTicket UserId)])
+  PG.Transaction e (Paged ListTicketsCursor (ShareTicket UserId))
 listTicketsByProjectId projectId limit mayCursor mayUserFilter mayStatusFilter = do
   let cursorFilter = case mayCursor of
         Nothing -> "true"
-        Just (Cursor (beforeTime, ticketId)) ->
+        Just (Cursor (beforeTime, ticketId) Next) ->
           [PG.sql|
           (ticket.updated_at, ticket.id) < (#{beforeTime}, #{ticketId})
           |]
-  addCursor
+        Just (Cursor (afterTime, ticketId) Previous) ->
+          [PG.sql|
+          (ticket.updated_at, ticket.id) > (#{afterTime}, #{ticketId})
+          |]
+  paged
     <$> PG.queryListRows @(ShareTicket UserId)
       [PG.sql|
         SELECT
@@ -156,12 +160,11 @@ listTicketsByProjectId projectId limit mayCursor mayUserFilter mayStatusFilter =
         LIMIT #{limit}
       |]
   where
-    addCursor :: [ShareTicket UserId] -> (Maybe (Cursor ListTicketsCursor), [ShareTicket UserId])
-    addCursor xs =
-      ( lastMay xs <&> \(ShareTicket {updatedAt, ticketId}) ->
-          Cursor (updatedAt, ticketId),
-        xs
-      )
+    paged :: [ShareTicket UserId] -> (Paged ListTicketsCursor (ShareTicket UserId))
+    paged items =
+      let prevCursor = headMay items <&> \ShareTicket {updatedAt, ticketId} -> Cursor (updatedAt, ticketId) Previous
+          nextCursor = lastMay items <&> \(ShareTicket {updatedAt, ticketId}) -> Cursor (updatedAt, ticketId) Next
+       in Paged {items, prevCursor, nextCursor}
 
 ticketById :: TicketId -> PG.Transaction e (Maybe Ticket)
 ticketById ticketId = do
@@ -286,15 +289,19 @@ listTicketsByUserId ::
   Limit ->
   Maybe (Cursor (UTCTime, TicketId)) ->
   Maybe TicketStatus ->
-  PG.Transaction e (Maybe (Cursor (UTCTime, TicketId)), [ShareTicket UserId])
+  PG.Transaction e (Paged (UTCTime, TicketId) (ShareTicket UserId))
 listTicketsByUserId callerUserId userId limit mayCursor mayStatusFilter = do
   let cursorFilter = case mayCursor of
         Nothing -> "true"
-        Just (Cursor (beforeTime, ticketId)) ->
+        Just (Cursor (beforeTime, ticketId) Next) ->
           [PG.sql|
           (ticket.updated_at, ticket.id) < (#{beforeTime}, #{ticketId})
           |]
-  addCursor
+        Just (Cursor (afterTime, ticketId) Previous) ->
+          [PG.sql|
+          (ticket.updated_at, ticket.id) > (#{afterTime}, #{ticketId})
+          |]
+  paged
     <$> PG.queryListRows @(ShareTicket UserId)
       [PG.sql|
       SELECT
@@ -326,12 +333,15 @@ listTicketsByUserId callerUserId userId limit mayCursor mayStatusFilter = do
       LIMIT #{limit}
       |]
   where
-    addCursor :: [ShareTicket UserId] -> (Maybe (Cursor ListTicketsCursor), [ShareTicket UserId])
-    addCursor xs =
-      ( lastMay xs <&> \(ShareTicket {updatedAt, ticketId}) ->
-          Cursor (updatedAt, ticketId),
-        xs
-      )
+    paged :: [ShareTicket UserId] -> (Paged ListTicketsCursor (ShareTicket UserId))
+    paged items =
+      let prevCursor = headMay items <&> \ShareTicket {updatedAt, ticketId} -> Cursor (updatedAt, ticketId) Previous
+          nextCursor = lastMay items <&> \(ShareTicket {updatedAt, ticketId}) -> Cursor (updatedAt, ticketId) Next
+       in Paged
+            { items,
+              prevCursor,
+              nextCursor
+            }
 
 getPagedShareTicketTimelineByProjectIdAndNumber ::
   ProjectId ->

--- a/src/Share/Web/Share/Branches/Impl.hs
+++ b/src/Share/Web/Share/Branches/Impl.hs
@@ -415,7 +415,7 @@ listBranchesByProjectEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle 
                   let branchShortHand = BranchShortHand {branchName, contributorHandle}
                    in API.branchToShareBranch branchShortHand branch shareProject contributions
               )
-  pure $ Paged {items = shareBranches, cursor = nextCursor (toListOf (folded . _1) branches)}
+  pure $ Paged {items = shareBranches, nextCursor = nextCursor (toListOf (folded . _1) branches), prevCursor = mayCursor}
   where
     nextCursor branches = case branches of
       [] -> Nothing
@@ -499,7 +499,7 @@ listBranchesByUserEndpoint (AuthN.MaybeAuthedUserID callerUserId) contributorHan
                       shareProject = projectToAPI projectOwnerHandle project
                    in API.branchToShareBranch branchShortHand branch shareProject contributions
               )
-  pure $ Paged {items = shareBranches, cursor = nextCursor branches}
+  pure $ Paged {items = shareBranches, nextCursor = nextCursor branches, prevCursor = mayCursor}
   where
     defaultLimit = Limit 20
     limit = fromMaybe defaultLimit mayLimit

--- a/src/Share/Web/Share/Branches/Impl.hs
+++ b/src/Share/Web/Share/Branches/Impl.hs
@@ -7,7 +7,6 @@ module Share.Web.Share.Branches.Impl where
 
 import Control.Lens
 import Control.Monad.Trans.Maybe
-import Data.List.NonEmpty qualified as NonEmpty
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Time (UTCTime)
@@ -415,16 +414,11 @@ listBranchesByProjectEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle 
                   let branchShortHand = BranchShortHand {branchName, contributorHandle}
                    in API.branchToShareBranch branchShortHand branch shareProject contributions
               )
-  pure $ Paged {items = shareBranches, nextCursor = nextCursor (toListOf (folded . _1) branches), prevCursor = mayCursor}
+  branches
+    & pagedOn (\(Branch {updatedAt, branchId}, _, _) -> (updatedAt, branchId))
+    & (\p -> p {items = shareBranches})
+    & pure
   where
-    nextCursor branches = case branches of
-      [] -> Nothing
-      branches@(x : xs)
-        | length branches < fromIntegral (getLimit limit) -> Nothing
-        | otherwise ->
-            let Branch {updatedAt, branchId} = NonEmpty.last (x :| xs)
-             in Just $ Cursor (updatedAt, branchId)
-
     userIdForHandle handle = do
       fmap user_id <$> PG.runTransaction (UserQ.userByHandle handle)
     limit = fromMaybe defaultLimit mayLimit
@@ -499,18 +493,13 @@ listBranchesByUserEndpoint (AuthN.MaybeAuthedUserID callerUserId) contributorHan
                       shareProject = projectToAPI projectOwnerHandle project
                    in API.branchToShareBranch branchShortHand branch shareProject contributions
               )
-  pure $ Paged {items = shareBranches, nextCursor = nextCursor branches, prevCursor = mayCursor}
+  expandedBranches
+    & pagedOn ((\(Branch {updatedAt, branchId}, _contr, _proj, _projOwner) -> (updatedAt, branchId)))
+    & (\p -> p {items = shareBranches})
+    & pure
   where
     defaultLimit = Limit 20
     limit = fromMaybe defaultLimit mayLimit
-
-    nextCursor branches = case branches of
-      [] -> Nothing
-      branches@(x : xs)
-        | length branches < fromIntegral (getLimit limit) -> Nothing
-        | otherwise ->
-            let (Branch {updatedAt, branchId}, _proj, _projOwner) = NonEmpty.last (x :| xs)
-             in Just $ Cursor (updatedAt, branchId)
 
 -- | Given an optional root hash, and a branch head, validate that the root hash is accessible from the branch head.
 resolveRootHash :: Codebase.CodebaseEnv -> CausalId -> Maybe CausalHash -> WebApp CausalId

--- a/transcripts/share-apis/branches/branch-list-by-self-name-prefix.json
+++ b/transcripts/share-apis/branches/branch-list-by-self-name-prefix.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "branchRef": "@transcripts/contribution",
@@ -61,7 +60,9 @@
         },
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list-by-self-project-ref.json
+++ b/transcripts/share-apis/branches/branch-list-by-self-project-ref.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "branchRef": "@transcripts/contribution",
@@ -61,7 +60,9 @@
         },
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list-by-user-self.json
+++ b/transcripts/share-apis/branches/branch-list-by-user-self.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "branchRef": "@transcripts/contribution",
@@ -81,7 +80,9 @@
         },
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list-by-user.json
+++ b/transcripts/share-apis/branches/branch-list-by-user.json
@@ -1,7 +1,8 @@
 {
   "body": {
-    "cursor": null,
-    "items": []
+    "items": [],
+    "nextCursor": null,
+    "prevCursor": null
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list-contributor-filter.json
+++ b/transcripts/share-apis/branches/branch-list-contributor-filter.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "branchRef": "@transcripts/contribution",
@@ -101,7 +100,9 @@
         },
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list-contributor-prefix.json
+++ b/transcripts/share-apis/branches/branch-list-contributor-prefix.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "branchRef": "@transcripts/contribution",
@@ -101,7 +100,9 @@
         },
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list-contributors-only.json
+++ b/transcripts/share-apis/branches/branch-list-contributors-only.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "branchRef": "@transcripts/contribution",
@@ -61,7 +60,9 @@
         },
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list-core-only.json
+++ b/transcripts/share-apis/branches/branch-list-core-only.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "branchRef": "feature",
@@ -42,7 +41,9 @@
         },
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list-inaccessible.json
+++ b/transcripts/share-apis/branches/branch-list-inaccessible.json
@@ -1,7 +1,8 @@
 {
   "body": {
-    "cursor": null,
-    "items": []
+    "items": [],
+    "nextCursor": null,
+    "prevCursor": null
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list-name-filter.json
+++ b/transcripts/share-apis/branches/branch-list-name-filter.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "branchRef": "main",
@@ -22,7 +21,9 @@
         },
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list-name-prefix.json
+++ b/transcripts/share-apis/branches/branch-list-name-prefix.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "branchRef": "@transcripts/contribution",
@@ -61,7 +60,9 @@
         },
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list-private.json
+++ b/transcripts/share-apis/branches/branch-list-private.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "branchRef": "@transcripts/contribution",
@@ -81,7 +80,9 @@
         },
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/branches/branch-list.json
+++ b/transcripts/share-apis/branches/branch-list.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "branchRef": "@transcripts/contribution",
@@ -101,7 +100,9 @@
         },
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/contributions/contribution-list-author-filter.json
+++ b/transcripts/share-apis/contributions/contribution-list-author-filter.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": "<CURSOR>",
     "items": [
       {
         "author": {
@@ -78,7 +77,9 @@
         "title": "Fix issue with user authentication",
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/contributions/contribution-list-kind-filter.json
+++ b/transcripts/share-apis/contributions/contribution-list-kind-filter.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": "<CURSOR>",
     "items": [
       {
         "author": {
@@ -21,7 +20,9 @@
         "title": "My contribution",
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/contributions/contribution-list-status-filter.json
+++ b/transcripts/share-apis/contributions/contribution-list-status-filter.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": "<CURSOR>",
     "items": [
       {
         "author": {
@@ -59,7 +58,9 @@
         "title": "Fix issue with user authentication",
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/contributions/contribution-list.json
+++ b/transcripts/share-apis/contributions/contribution-list.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": "<CURSOR>",
     "items": [
       {
         "author": {
@@ -97,7 +96,9 @@
         "title": "Fix issue with user authentication",
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/contributions/contribution-timeline-get.json
+++ b/transcripts/share-apis/contributions/contribution-timeline-get.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": "<CURSOR>",
     "items": [
       {
         "actor": {
@@ -48,7 +47,9 @@
         "revision": 0,
         "timestamp": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": null
   },
   "status": [
     {

--- a/transcripts/share-apis/releases/release-prefix-search.json
+++ b/transcripts/share-apis/releases/release-prefix-search.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "causalHashSquashed": "#sg60bvjo91fsoo7pkh9gejbn0qgc95vra87ap6l5d35ri0lkaudl7bs12d71sf3fh6p23teemuor7mk1i9n567m50ibakcghjec5ajg",
@@ -16,7 +15,9 @@
         "updatedAt": "<TIMESTAMP>",
         "version": "4.5.6"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/releases/releases-list-published-only.json
+++ b/transcripts/share-apis/releases/releases-list-published-only.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "causalHashSquashed": "#sg60bvjo91fsoo7pkh9gejbn0qgc95vra87ap6l5d35ri0lkaudl7bs12d71sf3fh6p23teemuor7mk1i9n567m50ibakcghjec5ajg",
@@ -30,7 +29,9 @@
         "updatedAt": "<TIMESTAMP>",
         "version": "1.0.0"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/releases/releases-list-version-search.json
+++ b/transcripts/share-apis/releases/releases-list-version-search.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "causalHashSquashed": "#sg60bvjo91fsoo7pkh9gejbn0qgc95vra87ap6l5d35ri0lkaudl7bs12d71sf3fh6p23teemuor7mk1i9n567m50ibakcghjec5ajg",
@@ -16,7 +15,9 @@
         "updatedAt": "<TIMESTAMP>",
         "version": "1.2.3"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/releases/releases-list.json
+++ b/transcripts/share-apis/releases/releases-list.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": null,
     "items": [
       {
         "causalHashSquashed": "#sg60bvjo91fsoo7pkh9gejbn0qgc95vra87ap6l5d35ri0lkaudl7bs12d71sf3fh6p23teemuor7mk1i9n567m50ibakcghjec5ajg",
@@ -30,7 +29,9 @@
         "updatedAt": "<TIMESTAMP>",
         "version": "1.0.0"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/tickets/ticket-list-author-filter.json
+++ b/transcripts/share-apis/tickets/ticket-list-author-filter.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": "<CURSOR>",
     "items": [
       {
         "author": {
@@ -36,7 +35,9 @@
         "title": "Completed Request",
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/tickets/ticket-list-status-filter.json
+++ b/transcripts/share-apis/tickets/ticket-list-status-filter.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": "<CURSOR>",
     "items": [
       {
         "author": {
@@ -36,7 +35,9 @@
         "title": "Bug Report",
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/tickets/ticket-list.json
+++ b/transcripts/share-apis/tickets/ticket-list.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": "<CURSOR>",
     "items": [
       {
         "author": {
@@ -53,7 +52,9 @@
         "title": "Completed Request",
         "updatedAt": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": "<CURSOR>"
   },
   "status": [
     {

--- a/transcripts/share-apis/tickets/ticket-timeline-get.json
+++ b/transcripts/share-apis/tickets/ticket-timeline-get.json
@@ -1,6 +1,5 @@
 {
   "body": {
-    "cursor": "<CURSOR>",
     "items": [
       {
         "actor": {
@@ -48,7 +47,9 @@
         "revision": 0,
         "timestamp": "<TIMESTAMP>"
       }
-    ]
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": null
   },
   "status": [
     {

--- a/transcripts/transcript_helpers.sh
+++ b/transcripts/transcript_helpers.sh
@@ -115,7 +115,7 @@ clean_for_transcript() {
     # Replace all uuids in stdin with the string "<UUID>"
     sed -E 's/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/<UUID>/g' | \
     # Replace all cursors in stdin with the string "<CURSOR>"
-    sed -E 's/"cursor": ?"[^"]+"/"cursor": "<CURSOR>"/g' | \
+    sed -E 's/Cursor": ?"[^"]+"/Cursor": "<CURSOR>"/g' | \
     # Replace all JWTs in stdin with the string "<JWT>"
     sed -E 's/eyJ([[:alnum:]_.-]+)/<JWT>/g' | \
     # In docker we network things together with host names, but locally we just use localhost; so 


### PR DESCRIPTION
## Overview

The previous paging solution didn't have any mechanism for paging backwards 😓 

This adds that.

Unfortunately most of these endpoints don't currently detect when we're out of results to return a null cursor, so I should probably do another pass on that at some point; but one thing at a time.

## Implementation notes

Swaps paged endpoints to return `nextCursor` and `previousCursor`.

## Test coverage

Transcripts, but should probably test on staging at some point since it's a surprisingly tricky change to get right.