### PR TITLE
Include projects owned by a commercial org as "premium" projects

### DIFF
--- a/sql/2025-05-23_commercial-org-premium-projects.sql
+++ b/sql/2025-05-23_commercial-org-premium-projects.sql
@@ -1,0 +1,20 @@
+-- Include projects which are part of a commercial org as premium projects.
+
+-- This view contains all projects which have access to premium features.
+-- This currently means they are either:
+--
+-- * owned by a an active subscriber of cloud,
+-- * are public
+-- * are part of a commercial org
+CREATE OR REPLACE VIEW premium_projects AS
+  SELECT project.id AS project_id, project.owner_user_id as project_owner_user_id
+    FROM projects project
+    WHERE NOT project.private
+          OR EXISTS (SELECT FROM public.cloud_subscribers project_owner_subscription
+                      WHERE project_owner_subscription.user_id = project.owner_user_id
+                        AND project_owner_subscription.is_active
+                     )
+          OR EXISTS (SELECT FROM orgs org
+                      WHERE org.user_id = project.owner_user_id
+                        AND org.is_commercial
+                     );


### PR DESCRIPTION
## Overview

Currently some features require a "premium" project, 
which currently is any project that's _either_ public or owned by an active cloud subscriber.

This change also includes projects owned by a commercial org (and since all non-commercial org projects are public, those are already covered).

## Implementation notes

Add commercial org projects to the underlying `premium_projects` view.