### PR TITLE
Swap to use Slack instead of Zendesk for user support tickets

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -174,6 +174,7 @@ default-extensions:
   - QuasiQuotes
   - ImportQualifiedPost
   - OverloadedRecordDot
+  - NumericUnderscores
 
 library:
   source-dirs: src

--- a/share-api.cabal
+++ b/share-api.cabal
@@ -41,6 +41,7 @@ library
       Share.BackgroundJobs.Webhooks.Worker
       Share.BackgroundJobs.Workers
       Share.Branch
+      Share.ChatApps
       Share.Codebase
       Share.Codebase.Types
       Share.Contribution
@@ -225,6 +226,7 @@ library
       QuasiQuotes
       ImportQualifiedPost
       OverloadedRecordDot
+      NumericUnderscores
   ghc-options: -Wall -Werror -Wname-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -Wincomplete-uni-patterns -Widentities -Wredundant-constraints -Wpartial-fields -fprint-expanded-synonyms -fwrite-ide-info -O2 -funbox-strict-fields
   build-depends:
       Diff
@@ -375,6 +377,7 @@ executable share-api
       QuasiQuotes
       ImportQualifiedPost
       OverloadedRecordDot
+      NumericUnderscores
   ghc-options: -Wall -Werror -Wname-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -Wincomplete-uni-patterns -Widentities -Wredundant-constraints -Wpartial-fields -fprint-expanded-synonyms -fwrite-ide-info -O2 -funbox-strict-fields -threaded -rtsopts "-with-rtsopts=-N -A32m -qn2 -T"
   build-depends:
       Diff

--- a/src/Share/BackgroundJobs/Webhooks/Worker.hs
+++ b/src/Share/BackgroundJobs/Webhooks/Worker.hs
@@ -260,7 +260,7 @@ buildWebhookRequest webhookId uri event defaultPayload = do
                 mainLink = Just link,
                 author =
                   Author
-                    { authorName = actorAuthor,
+                    { authorName = Just actorAuthor,
                       authorLink = Just actorLink,
                       authorAvatarUrl = actorAvatarUrl
                     },
@@ -281,7 +281,7 @@ buildWebhookRequest webhookId uri event defaultPayload = do
                 mainLink = Just link,
                 author =
                   Author
-                    { authorName = actorAuthor,
+                    { authorName = Just actorAuthor,
                       authorLink = Just actorLink,
                       authorAvatarUrl = actorAvatarUrl
                     },

--- a/src/Share/ChatApps.hs
+++ b/src/Share/ChatApps.hs
@@ -8,6 +8,7 @@ module Share.ChatApps
     Author (..),
     sendMessage,
     shareAuthor,
+    authorFromUserId,
   )
 where
 

--- a/src/Share/ChatApps.hs
+++ b/src/Share/ChatApps.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+
+module Share.ChatApps
+  ( ChatProvider (..),
+    MessageContent (..),
+    ChatAppFailure (..),
+    Author (..),
+    sendMessage,
+    shareAuthor,
+  )
+where
+
+import Control.Monad.Trans.Except (except, runExceptT)
+import Data.Aeson (ToJSON (..))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Types ((.=))
+import Data.Text qualified as Text
+import Data.Time (UTCTime)
+import Data.Time qualified as Time
+import Data.Time.Clock.POSIX qualified as POSIX
+import Network.HTTP.Client qualified as HTTPClient
+import Network.HTTP.Types qualified as HTTP
+import Network.URI (URI)
+import Network.URI qualified as URI
+import Share.App (AppM)
+import Share.Env qualified as Env
+import Share.IDs
+import Share.Postgres qualified as PG
+import Share.Postgres.Users.Queries qualified as UsersQ
+import Share.Prelude
+import Share.User (User (..))
+import Share.Utils.URI (URIParam (..), uriToText)
+import Share.Web.UI.Links qualified as Links
+import UnliftIO (SomeException)
+
+data ChatProvider
+  = Slack
+  | Discord
+  deriving stock (Show, Eq)
+
+data Author = Author
+  { authorName :: Maybe Text,
+    authorLink :: Maybe URI,
+    authorAvatarUrl :: Maybe URI
+  }
+  deriving (Show, Eq, Ord)
+
+authorFromUserId :: UserId -> AppM reqCtx Author
+authorFromUserId userId = do
+  User {avatar_url = avatarUrl, user_name, handle} <- PG.runTransaction $ UsersQ.expectUser userId
+  authorLink <- Links.userProfilePage handle
+  pure $
+    Author
+      { authorName = user_name,
+        authorLink = Just authorLink,
+        authorAvatarUrl = unpackURI <$> avatarUrl
+      }
+
+-- A type to unify slack and discord message types
+data MessageContent (provider :: ChatProvider) = MessageContent
+  { -- Text of the bot message
+    preText :: Text,
+    -- Title of the attachment
+    title :: Text,
+    -- Text of the attachment
+    content :: Text,
+    -- Title link
+    mainLink :: Maybe URI,
+    author :: Author,
+    thumbnailUrl :: Maybe URI,
+    timestamp :: UTCTime
+  }
+  deriving stock (Show, Eq)
+
+instance ToJSON (MessageContent 'Slack) where
+  toJSON MessageContent {preText, content, title, mainLink, author = Author {authorName, authorLink, authorAvatarUrl}, thumbnailUrl, timestamp} =
+    Aeson.object
+      [ "text" .= preText,
+        "attachments"
+          .= [ Aeson.object
+                 ( [ "title" .= cutOffText 250 title,
+                     "text" .= content,
+                     "author_name" .= authorName,
+                     "author_icon" .= fmap uriToText authorAvatarUrl,
+                     "thumb_url" .= fmap uriToText thumbnailUrl,
+                     "ts" .= (round (POSIX.utcTimeToPOSIXSeconds timestamp) :: Int64),
+                     "color" .= ("#36a64f" :: Text)
+                   ]
+                     <> (mainLink & foldMap (\mainURI -> ["title_link" .= uriToText mainURI]))
+                     <> (authorLink & foldMap (\authorURI -> ["author_link" .= uriToText authorURI]))
+                 )
+             ]
+      ]
+
+instance ToJSON (MessageContent 'Discord) where
+  toJSON MessageContent {preText, content, title, mainLink, author = Author {authorName, authorLink, authorAvatarUrl}, thumbnailUrl, timestamp} =
+    Aeson.object
+      [ "username" .= ("Share Notifications" :: Text),
+        "avatar_url" .= Links.unisonLogoImage,
+        "content" .= cutOffText 1950 preText,
+        "embeds"
+          .= [ Aeson.object
+                 ( [ "title" .= cutOffText 250 title,
+                     "description" .= cutOffText 4000 content,
+                     "author"
+                       .= Aeson.object
+                         ( [ "name" .= (cutOffText 250 <$> authorName),
+                             "icon_url" .= fmap uriToText authorAvatarUrl
+                           ]
+                             <> (authorLink & foldMap (\authorURI -> ["url" .= uriToText authorURI]))
+                         ),
+                     "timestamp" .= (Just $ Text.pack $ Time.formatTime Time.defaultTimeLocale "%FT%T%QZ" timestamp),
+                     "thumbnail" .= fmap (\url -> Aeson.object ["url" .= uriToText url]) thumbnailUrl
+                   ]
+                     <> (mainLink & foldMap (\mainURI -> ["url" .= uriToText mainURI]))
+                 )
+             ]
+      ]
+
+-- | Nicely cut off text so that it doesn't exceed the max length
+cutOffText :: Int -> Text -> Text
+cutOffText maxLength text =
+  if Text.length text > maxLength
+    then Text.take (maxLength - 3) text <> "..."
+    else text
+
+shareAuthor :: Author
+shareAuthor =
+  let shareAuthorAvatarUrl = fromMaybe (error "Invalid shareAuthorAvatarUrl") $ URI.parseURI "https://share.unison-lang.org/static/unison-logo-circle.png"
+   in Author
+        { authorName = Just "Share",
+          authorLink = Nothing,
+          authorAvatarUrl = Just shareAuthorAvatarUrl
+        }
+
+data ChatAppFailure
+  = InvalidRequest SomeException
+  | ErrorResponse HTTP.Status
+
+chatAppTimeout :: HTTPClient.ResponseTimeout
+chatAppTimeout = HTTPClient.responseTimeoutMicro $ 10 * 1_000_000 -- 10 seconds
+
+sendMessage :: (ToJSON (MessageContent provider)) => URI -> MessageContent provider -> AppM reqCtx (Either ChatAppFailure ())
+sendMessage uri messageContent = runExceptT do
+  req <-
+    HTTPClient.requestFromURI uri
+      & mapLeft InvalidRequest
+      & except
+  let req' =
+        req
+          { HTTPClient.method = "POST",
+            HTTPClient.responseTimeout = chatAppTimeout,
+            HTTPClient.requestHeaders = [(HTTP.hContentType, "application/json")],
+            HTTPClient.requestBody = HTTPClient.RequestBodyLBS $ Aeson.encode messageContent
+          }
+  proxiedHTTPManager <- asks Env.proxiedHttpClient
+  resp <- liftIO $ HTTPClient.httpLbs req' proxiedHTTPManager
+  case HTTPClient.responseStatus resp of
+    httpStatus@(HTTP.Status status _)
+      | status >= 400 -> throwError $ ErrorResponse httpStatus
+      | otherwise -> pure ()

--- a/src/Share/Env.hs
+++ b/src/Share/Env.hs
@@ -32,6 +32,7 @@ data Env ctx = Env
     websiteOrigin :: URI, -- E.g. "https://www.unison-lang.org"
     cloudUiOrigin :: URI, -- E.g. "https://app.unison.cloud"
     cloudWebsiteOrigin :: URI, -- E.g. "https://www.unison.cloud"
+    supportTicketWebhookURI :: Maybe URI,
     vaultClientEnv :: S.ClientEnv,
     userSecretsVaultMount :: Vault.SecretMount,
     shareVaultToken :: Vault.VaultToken,

--- a/src/Share/Web/Support/Impl.hs
+++ b/src/Share/Web/Support/Impl.hs
@@ -3,40 +3,40 @@
 
 module Share.Web.Support.Impl where
 
+import Data.Time qualified as Time
 import Servant
 import Share.ChatApps
-import Share.IDs qualified as IDs
+import Share.ChatApps qualified as ChatApps
+import Share.Env qualified as Env
 import Share.OAuth.Session
-import Share.Postgres.Ops qualified as PGO
 import Share.Prelude
-import Share.User
 import Share.Web.App
+import Share.Web.Errors (Unimplemented (..), respondError)
 import Share.Web.Support.API qualified as Support
 import Share.Web.Support.Types
-import Share.Web.Support.Zendesk qualified as Zendesk
 
 createTicketEndpoint :: Session -> SupportTicketRequest -> WebApp NoContent
-createTicketEndpoint (Session {sessionUserId}) (SupportTicketRequest {subject, body, priority}) = do
-  User {user_name, user_email, handle} <- PGO.expectUserById sessionUserId
-  let message :: MessageContent 'Slack
+createTicketEndpoint (Session {sessionUserId}) (SupportTicketRequest {subject, body}) = do
+  author <- authorFromUserId sessionUserId
+  now <- liftIO $ Time.getCurrentTime
+  let message :: ChatApps.MessageContent 'ChatApps.Slack
       message =
         MessageContent
           { preText = "New Support Ticket",
             title = subject,
-            content = body
+            content = body,
+            author,
+            mainLink = authorLink author,
+            thumbnailUrl = authorAvatarUrl author,
+            timestamp = now
           }
-  let zendeskTicket =
-        Zendesk.ZendeskTicket
-          { subject = subject,
-            body = body,
-            priority = priority,
-            requesterName = fromMaybe (IDs.toText handle) user_name,
-            requesterEmail = user_email,
-            shareHandle = handle,
-            shareUserId = sessionUserId
-          }
-  _success <- Zendesk.createTicket zendeskTicket
-  pure NoContent
+  webhookURI <- asks Env.supportTicketWebhookURI
+  case webhookURI of
+    Nothing -> do
+      respondError Unimplemented
+    Just uri -> do
+      ChatApps.sendMessage uri message
+      pure NoContent
 
 server :: ServerT Support.API WebApp
 server = createTicketEndpoint


### PR DESCRIPTION
## Overview

Use Slack webhook from an env var rather than calling the zendesk API to back the support ticket endpoint.

## Test coverage

Will test on prod.
