### PR TITLE
Update all old project permissions filters

### DIFF
--- a/sql/2025-05-27_project-access.sql
+++ b/sql/2025-05-27_project-access.sql
@@ -1,0 +1,28 @@
+-- Function to check whether caller has access to a given project permission
+-- If the user_id is NULL, it returns TRUE for public projects
+CREATE FUNCTION user_has_project_permission(
+  user_id UUID,
+  project_id UUID,
+  permission permission
+) 
+RETURNS BOOLEAN
+STABLE
+PARALLEL SAFE
+AS $$
+  SELECT EXISTS (
+    SELECT
+    FROM user_resource_permissions urp
+    JOIN projects p ON urp.resource_id = p.resource_id
+    WHERE (urp.user_id IS NULL OR urp.user_id = $1)
+      AND p.id = $2
+      AND urp.permission = $3
+  );
+$$ LANGUAGE SQL;
+
+-- DEPLOY NEW APP CODE HERE
+
+-- Remove old project access management system
+-- We need to replace these with the new permissions system.
+DROP VIEW accessible_private_projects;
+DROP TABLE project_maintainers;
+

--- a/src/Share/Postgres/Contributions/Queries.hs
+++ b/src/Share/Postgres/Contributions/Queries.hs
@@ -37,6 +37,7 @@ import Share.Postgres.Comments.Queries (commentsByTicketOrContribution)
 import Share.Postgres.IDs
 import Share.Prelude
 import Share.Utils.API
+import Share.Web.Authorization.Types (RolePermission (..))
 import Share.Web.Errors
 import Share.Web.Share.Contributions.API (ContributionTimelineCursor, ListContributionsCursor)
 import Share.Web.Share.Contributions.Types
@@ -304,13 +305,7 @@ listContributionsByUserId callerUserId userId limit mayCursor mayStatusFilter ma
         JOIN projects AS project ON project.id = contribution.project_id
       WHERE
         contribution.author_id = #{userId}
-        AND NOT project.private
-          OR EXISTS (
-            SELECT FROM accessible_private_projects ap
-            WHERE
-              ap.user_id = #{callerUserId}
-              AND ap.project_id = project.id
-          )
+        AND user_has_project_permission(#{callerUserId}, project.id, #{ProjectView})
         AND (#{mayStatusFilter} IS NULL OR contribution.status = #{mayStatusFilter})
         AND ^{cursorFilter}
         AND ^{kindFilter}

--- a/transcripts/share-apis/project-maintainers/read-maintainer-project-list-after.json
+++ b/transcripts/share-apis/project-maintainers/read-maintainer-project-list-after.json
@@ -1,0 +1,39 @@
+{
+  "body": [
+    {
+      "createdAt": "<TIMESTAMP>",
+      "isFaved": false,
+      "numFavs": 1,
+      "owner": {
+        "handle": "@test",
+        "name": null,
+        "type": "user"
+      },
+      "slug": "publictestproject",
+      "summary": "test project summary",
+      "tags": [],
+      "updatedAt": "<TIMESTAMP>",
+      "visibility": "public"
+    },
+    {
+      "createdAt": "<TIMESTAMP>",
+      "isFaved": false,
+      "numFavs": 0,
+      "owner": {
+        "handle": "@test",
+        "name": null,
+        "type": "user"
+      },
+      "slug": "privatetestproject",
+      "summary": "private summary",
+      "tags": [],
+      "updatedAt": "<TIMESTAMP>",
+      "visibility": "private"
+    }
+  ],
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/project-maintainers/read-maintainer-project-list-before.json
+++ b/transcripts/share-apis/project-maintainers/read-maintainer-project-list-before.json
@@ -1,0 +1,24 @@
+{
+  "body": [
+    {
+      "createdAt": "<TIMESTAMP>",
+      "isFaved": false,
+      "numFavs": 1,
+      "owner": {
+        "handle": "@test",
+        "name": null,
+        "type": "user"
+      },
+      "slug": "publictestproject",
+      "summary": "test project summary",
+      "tags": [],
+      "updatedAt": "<TIMESTAMP>",
+      "visibility": "public"
+    }
+  ],
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/project-maintainers/read-maintainer-project-search-after.json
+++ b/transcripts/share-apis/project-maintainers/read-maintainer-project-search-after.json
@@ -1,0 +1,15 @@
+{
+  "body": [
+    {
+      "projectRef": "@test/privatetestproject",
+      "summary": "private summary",
+      "tag": "project",
+      "visibility": "private"
+    }
+  ],
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/project-maintainers/read-maintainer-project-search-before.json
+++ b/transcripts/share-apis/project-maintainers/read-maintainer-project-search-before.json
@@ -1,0 +1,8 @@
+{
+  "body": [],
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/project-maintainers/run.zsh
+++ b/transcripts/share-apis/project-maintainers/run.zsh
@@ -15,6 +15,11 @@ fetch "$unauthorized_user" PATCH non-maintainer-private-project-update '/users/t
     "summary": "update"
 }'
 
+
+# Before adding permissions Project viewer should NOT see the private project in the owner's project list and search
+fetch "$read_user" GET read-maintainer-project-list-before '/users/test/projects'
+fetch "$read_user" GET read-maintainer-project-search-before '/search?query=%40private'
+
 fetch "$test_user" POST add-roles '/users/test/projects/privatetestproject/roles' "
 {
     \"role_assignments\": 
@@ -54,6 +59,10 @@ fetch "$test_user" POST owner-ticket-create '/users/test/projects/privatetestpro
 
 # Project viewer can view the project
 fetch "$read_user" GET read-maintainer-project-view '/users/test/projects/privatetestproject'
+
+# Project viewer should see the private project in the owner's project list and search
+fetch "$read_user" GET read-maintainer-project-list-after '/users/test/projects'
+fetch "$read_user" GET read-maintainer-project-search-after '/search?query=%40private'
 
 # Contributor user should be able to create tickets
 fetch "$contributor_user" POST contributor-maintainer-ticket-create '/users/test/projects/privatetestproject/tickets' '{


### PR DESCRIPTION
## Overview


* [x] Run migration to create new function  THEN
* [ ] Deploy THEN
* [ ] drop old tables/views

A bunch of old project permissions checks only knew about whether a project was public, owned by the caller, or part of an org, they didn't respect project-maintainer roles.

This updates all the relevant queries to use the new permissions system.

Affects:

* Causal importing
* Project Search
* Projects list
* Defn Search
* Contribution listing
* Ticket listing
* Branch listing

## Implementation notes

* Adds a `user_has_project_permission` SQL function
* Wires this into all queries in-place of the old `accessible_private_projects` view

## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc. 
What could have been done differently, but wasn't? And why?

## Test coverage

* [x] Add additional transcript tests

