### PR TITLE
Add hasUnreadNotifications to /account

### DIFF
--- a/src/Share/Web/Share/Impl.hs
+++ b/src/Share/Web/Share/Impl.hs
@@ -15,6 +15,7 @@ import Share.IDs (TourId, UserHandle (..))
 import Share.IDs qualified as IDs
 import Share.JWT qualified as JWT
 import Share.Notifications.Impl qualified as Notifications
+import Share.Notifications.Queries qualified as NotifQ
 import Share.OAuth.Session
 import Share.OAuth.Types (UserId)
 import Share.Postgres qualified as PG
@@ -482,6 +483,7 @@ accountInfoEndpoint Session {sessionUserId} = do
     isSuperadmin <- AuthZQ.isSuperadmin user_id
     displayInfo <- DisplayInfoQ.unifiedDisplayInfoForUserOf id user_id
     planTier <- UserQ.userSubscriptionTier user_id
+    hasUnreadNotifications <- NotifQ.hasUnreadNotifications user_id
     pure $
       UserAccountInfo
         { primaryEmail = user_email,
@@ -489,7 +491,8 @@ accountInfoEndpoint Session {sessionUserId} = do
           organizationMemberships,
           isSuperadmin,
           displayInfo,
-          planTier
+          planTier,
+          hasUnreadNotifications
         }
 
 completeToursEndpoint :: Session -> NonEmpty TourId -> WebApp NoContent

--- a/src/Share/Web/Share/Types.hs
+++ b/src/Share/Web/Share/Types.hs
@@ -182,7 +182,8 @@ data UserAccountInfo = UserAccountInfo
     organizationMemberships :: [UserHandle],
     isSuperadmin :: Bool,
     planTier :: PlanTier,
-    displayInfo :: UnifiedDisplayInfo
+    displayInfo :: UnifiedDisplayInfo,
+    hasUnreadNotifications :: Bool
   }
   deriving (Show)
 
@@ -200,7 +201,8 @@ instance ToJSON UserAccountInfo where
             "organizationMemberships" .= organizationMemberships,
             "completedTours" .= completedTours,
             "primaryEmail" .= primaryEmail,
-            "planTier" .= planTier
+            "planTier" .= planTier,
+            "hasUnreadNotifications" .= hasUnreadNotifications
           ]
       UnifiedOrg (OrgDisplayInfo {orgId, isCommercial, user = UserDisplayInfo {handle, name, avatarUrl, userId}}) ->
         Aeson.object
@@ -215,7 +217,8 @@ instance ToJSON UserAccountInfo where
             "isCommercial" .= isCommercial,
             "organizationMemberships" .= organizationMemberships,
             "orgId" .= orgId,
-            "planTier" .= planTier
+            "planTier" .= planTier,
+            "hasUnreadNotifications" .= hasUnreadNotifications
           ]
 
 type PathSegment = Text

--- a/transcripts/share-apis/code-browse/account.json
+++ b/transcripts/share-apis/code-browse/account.json
@@ -3,6 +3,7 @@
     "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
     "completedTours": [],
     "handle": "transcripts",
+    "hasUnreadNotifications": false,
     "isSuperadmin": false,
     "kind": "user",
     "name": "Transcript User",

--- a/transcripts/share-apis/user-creation/new-user-profile.json
+++ b/transcripts/share-apis/user-creation/new-user-profile.json
@@ -3,6 +3,7 @@
     "avatarUrl": "https://avatars.githubusercontent.com/u/0?v=4",
     "completedTours": [],
     "handle": "localgithubuser",
+    "hasUnreadNotifications": false,
     "isSuperadmin": false,
     "kind": "user",
     "name": "Local Github User",


### PR DESCRIPTION
## Overview

Expose whether the user has any unread notifications on the /account endpoint so Simon can show an indicator

## Implementation notes

includes `hasUnreadNotifications` field to `/account`


See transcripts