### PR TITLE
Add Notification Topic Groups

### DIFF
--- a/sql/2025-05-30_notification-topic-groups.sql
+++ b/sql/2025-05-30_notification-topic-groups.sql
@@ -5,7 +5,7 @@ CREATE TYPE notification_topic_group AS ENUM (
 -- Mapping for which topics are in each group.
 CREATE TABLE notification_topic_group_topics (
   topic_group notification_topic_group NOT NULL,
-  topic TEXT NOT NULL,
+  topic notification_topic NOT NULL,
   PRIMARY KEY (topic_group, topic)
 );
 

--- a/sql/2025-05-30_notification-topic-groups.sql
+++ b/sql/2025-05-30_notification-topic-groups.sql
@@ -1,0 +1,83 @@
+CREATE TYPE notification_topic_group AS ENUM (
+  'watch_project'
+);
+
+-- Mapping for which topics are in each group.
+CREATE TABLE notification_topic_group_topics (
+  topic_group notification_topic_group NOT NULL,
+  topic TEXT NOT NULL,
+  PRIMARY KEY (topic_group, topic)
+);
+
+CREATE INDEX idx_notification_topic_group_topics_topic ON notification_topic_group_topics (topic) INCLUDE (topic_group);
+
+INSERT INTO notification_topic_group_topics (topic_group, topic)
+VALUES
+  ('watch_project', 'project:contribution:created')
+;
+
+-- Allow subscribing to a group of notifications, which may change over time.
+ALTER TABLE notification_subscriptions
+  ADD COLUMN topic_groups notification_topic_group[] NOT NULL DEFAULT '{}';
+
+
+-- Rework the trigger to use the new topic groups.
+CREATE OR REPLACE FUNCTION trigger_notification_event_subscriptions()
+RETURNS TRIGGER AS $$
+DECLARE
+  the_subscription_id UUID;
+  the_event_id UUID;
+  the_subscriber UUID;
+BEGIN
+  SELECT NEW.id INTO the_event_id;
+  FOR the_subscription_id, the_subscriber IN
+    (SELECT ns.id, ns.subscriber_user_id FROM notification_subscriptions ns
+      WHERE ns.scope_user_id = NEW.scope_user_id
+        -- Check whether any subscription is subscribed to the topic directly or through a topic group.
+        AND ( NEW.topic = ANY(ns.topics)
+          OR EXISTS(
+              SELECT FROM notification_topic_group_topics ntgt
+              WHERE ntgt.topic_group = ANY(ns.topic_groups)
+                AND ntgt.topic = NEW.topic
+             )
+        )
+        AND (ns.filter IS NULL OR NEW.data @> ns.filter)
+        AND 
+        -- A subscriber can be notified if the event is in their scope or if they have permission to the resource.
+        -- The latter is usually a superset of the former, but the former is trivial to compute so it can help
+        -- performance to include it.
+          (NEW.scope_user_id = ns.subscriber_user_id
+            OR user_has_permission(ns.subscriber_user_id, NEW.resource_id, topic_permission(NEW.topic))
+          )
+    )
+  LOOP
+    -- Log that this event triggered this subscription.
+    INSERT INTO notification_providence_log (event_id, subscription_id)
+      VALUES (the_event_id, the_subscription_id);
+
+    -- Add to the relevant queues.
+    -- Each delivery method _may_ be triggered by multiple subscriptions,
+    -- we need ON CONFLICT DO NOTHING.
+    INSERT INTO notification_webhook_queue (event_id, webhook_id)
+      SELECT the_event_id, nbw.webhook_id
+      FROM notification_by_webhook nbw
+      WHERE nbw.subscription_id = the_subscription_id
+      ON CONFLICT DO NOTHING;
+
+    INSERT INTO notification_email_queue (event_id, email_id)
+      SELECT the_event_id AS event_id, nbe.email_id
+      FROM notification_by_email nbe
+      WHERE nbe.subscription_id = the_subscription_id
+      ON CONFLICT DO NOTHING;
+
+    -- Also add the notification to the hub.
+    -- It's possible it was already added by another subscription for this user,
+    -- in which case we just carry on.
+    INSERT INTO notification_hub_entries (event_id, user_id)
+      VALUES (the_event_id, the_subscriber)
+      ON CONFLICT DO NOTHING;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/Share/Notifications/API.hs
+++ b/src/Share/Notifications/API.hs
@@ -39,7 +39,7 @@ import Data.Text qualified as Text
 import Data.Time (UTCTime)
 import Servant
 import Share.IDs
-import Share.Notifications.Types (DeliveryMethodId, HydratedEvent, NotificationDeliveryMethod, NotificationHubEntry, NotificationStatus, NotificationSubscription, NotificationTopic, SubscriptionFilter)
+import Share.Notifications.Types (DeliveryMethodId, HydratedEvent, NotificationDeliveryMethod, NotificationHubEntry, NotificationStatus, NotificationSubscription, NotificationTopic, NotificationTopicGroup, SubscriptionFilter)
 import Share.OAuth.Session (AuthenticatedUserId)
 import Share.Prelude
 import Share.Utils.URI (URIParam)
@@ -131,7 +131,8 @@ type CreateSubscriptionEndpoint =
 data CreateSubscriptionRequest
   = CreateSubscriptionRequest
   { subscriptionScope :: UserHandle,
-    subscriptionTopics :: NESet NotificationTopic,
+    subscriptionTopics :: Set NotificationTopic,
+    subscriptionTopicGroups :: Set NotificationTopicGroup,
     subscriptionFilter :: Maybe SubscriptionFilter
   }
 
@@ -139,8 +140,9 @@ instance FromJSON CreateSubscriptionRequest where
   parseJSON = withObject "CreateSubscriptionRequest" $ \o -> do
     subscriptionScope <- o .: "scope"
     subscriptionTopics <- o .: "topics"
+    subscriptionTopicGroups <- o .: "topicGroups"
     subscriptionFilter <- o .:? "filter"
-    pure CreateSubscriptionRequest {subscriptionScope, subscriptionTopics, subscriptionFilter}
+    pure CreateSubscriptionRequest {subscriptionScope, subscriptionTopics, subscriptionTopicGroups, subscriptionFilter}
 
 data CreateSubscriptionResponse
   = CreateSubscriptionResponse
@@ -164,15 +166,17 @@ type UpdateSubscriptionEndpoint =
 
 data UpdateSubscriptionRequest
   = UpdateSubscriptionRequest
-  { subscriptionTopics :: Maybe (NESet NotificationTopic),
+  { subscriptionTopics :: Maybe (Set NotificationTopic),
+    subscriptionTopicGroups :: Maybe (Set NotificationTopicGroup),
     subscriptionFilter :: Maybe SubscriptionFilter
   }
 
 instance FromJSON UpdateSubscriptionRequest where
   parseJSON = withObject "UpdateSubscriptionRequest" $ \o -> do
     subscriptionTopics <- o .:? "topics"
+    subscriptionTopicGroups <- o .:? "topicGroups"
     subscriptionFilter <- o .:? "filter"
-    pure UpdateSubscriptionRequest {subscriptionTopics, subscriptionFilter}
+    pure UpdateSubscriptionRequest {subscriptionTopics, subscriptionTopicGroups, subscriptionFilter}
 
 type GetDeliveryMethodsEndpoint =
   AuthenticatedUserId

--- a/src/Share/Notifications/Impl.hs
+++ b/src/Share/Notifications/Impl.hs
@@ -171,7 +171,7 @@ getSubscriptionsEndpoint userHandle callerUserId = do
   pure $ API.GetSubscriptionsResponse {subscriptions}
 
 createSubscriptionEndpoint :: UserHandle -> UserId -> API.CreateSubscriptionRequest -> WebApp API.CreateSubscriptionResponse
-createSubscriptionEndpoint subscriberHandle callerUserId API.CreateSubscriptionRequest {subscriptionScope, subscriptionTopics, subscriptionFilter} = do
+createSubscriptionEndpoint subscriberHandle callerUserId API.CreateSubscriptionRequest {subscriptionScope, subscriptionTopics, subscriptionTopicGroups, subscriptionFilter} = do
   User {user_id = subscriberUserId} <- UserQ.expectUserByHandle subscriberHandle
   User {user_id = scopeUserId} <- UserQ.expectUserByHandle subscriptionScope
   _authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkSubscriptionsManage callerUserId subscriberUserId
@@ -180,7 +180,7 @@ createSubscriptionEndpoint subscriberHandle callerUserId API.CreateSubscriptionR
   -- the resource of a given event for the permission associated to that topic via the
   -- 'topic_permission' SQL function.
   subscription <- PG.runTransaction $ do
-    subscriptionId <- NotificationQ.createNotificationSubscription subscriberUserId scopeUserId subscriptionTopics subscriptionFilter
+    subscriptionId <- NotificationQ.createNotificationSubscription subscriberUserId scopeUserId subscriptionTopics subscriptionTopicGroups subscriptionFilter
     NotificationQ.getNotificationSubscription subscriberUserId subscriptionId
   pure $ API.CreateSubscriptionResponse {subscription}
 
@@ -192,10 +192,10 @@ deleteSubscriptionEndpoint userHandle callerUserId subscriptionId = do
   pure ()
 
 updateSubscriptionEndpoint :: UserHandle -> UserId -> NotificationSubscriptionId -> API.UpdateSubscriptionRequest -> WebApp API.CreateSubscriptionResponse
-updateSubscriptionEndpoint userHandle callerUserId subscriptionId API.UpdateSubscriptionRequest {subscriptionTopics, subscriptionFilter} = do
+updateSubscriptionEndpoint userHandle callerUserId subscriptionId API.UpdateSubscriptionRequest {subscriptionTopics, subscriptionTopicGroups, subscriptionFilter} = do
   User {user_id = notificationUserId} <- UserQ.expectUserByHandle userHandle
   _authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkSubscriptionsManage callerUserId notificationUserId
   subscription <- PG.runTransaction $ do
-    NotificationQ.updateNotificationSubscription notificationUserId subscriptionId subscriptionTopics subscriptionFilter
+    NotificationQ.updateNotificationSubscription notificationUserId subscriptionId subscriptionTopics subscriptionTopicGroups subscriptionFilter
     NotificationQ.getNotificationSubscription notificationUserId subscriptionId
   pure $ API.CreateSubscriptionResponse {subscription}

--- a/transcripts/share-apis/notifications/create-subscription-for-other-user-project.json
+++ b/transcripts/share-apis/notifications/create-subscription-for-other-user-project.json
@@ -4,7 +4,8 @@
       "filter": null,
       "id": "NS-<UUID>",
       "scope": "U-<UUID>",
-      "topic": [
+      "topicGroups": [],
+      "topics": [
         "project:branch:updated",
         "project:contribution:created"
       ]

--- a/transcripts/share-apis/notifications/run.zsh
+++ b/transcripts/share-apis/notifications/run.zsh
@@ -6,11 +6,12 @@ source "../../transcript_helpers.sh"
 
 publictestproject_id=$(project_id_from_handle_and_slug 'test' 'publictestproject')
 
-# Subscribe to project:contribution:created notifications for the test user's publictestproject.
+# Subscribe to project-related notifications for the test user's publictestproject.
+# This subscription uses a topic group rather than a specific topic.
 subscription_id=$(fetch_data_jq "$test_user" POST create-subscription-for-project '/users/test/notifications/subscriptions' '.subscription.id' "{
   \"scope\": \"test\",
-  \"topics\": [
-    \"project:contribution:created\"
+  \"topicGroups\": [
+    \"watch_project\"
   ],
   \"filter\": {
     \"projectId\": \"$publictestproject_id\"

--- a/transcripts/share-apis/notifications/run.zsh
+++ b/transcripts/share-apis/notifications/run.zsh
@@ -10,6 +10,7 @@ publictestproject_id=$(project_id_from_handle_and_slug 'test' 'publictestproject
 # This subscription uses a topic group rather than a specific topic.
 subscription_id=$(fetch_data_jq "$test_user" POST create-subscription-for-project '/users/test/notifications/subscriptions' '.subscription.id' "{
   \"scope\": \"test\",
+  \"topics\": [],
   \"topicGroups\": [
     \"watch_project\"
   ],
@@ -38,7 +39,8 @@ fetch "$transcripts_user" POST create-subscription-for-other-user-project '/user
   \"scope\": \"test\",
   \"topics\": [
     \"project:contribution:created\", \"project:branch:updated\"
-  ]
+  ],
+  \"topicGroups\": []
 }"
 
 fetch "$test_user" POST create-email-delivery '/users/test/notifications/delivery-methods/emails' '{


### PR DESCRIPTION
## Overview

Adds notification topic groups so end users can subscribe to groups of topic semantically, e.g. "Watch Project" or "Subscribe to this ticket and its updates", but we can still expand these sets of topics the groups correspond to.

## Implementation notes

* Leaves the existing individual topic list so things like webhooks can still be specific about which events they want
* Adds a list of subscribed topic groups to each subscription
* Adds a topic group for watching everything in a project

## Test coverage

[x] Transcripts