### PR TITLE
Add endpoints for subscribing to a project

### DIFF
--- a/sql/2025-06-04_watch-projects.sql
+++ b/sql/2025-06-04_watch-projects.sql
@@ -1,0 +1,19 @@
+-- Migration to add watch_project subscriptions for all existing users and projects.
+
+INSERT INTO notification_subscriptions (subscriber_user_id, scope_user_id, topics, topic_groups, filter)
+  SELECT u.id, 
+         p.owner_user_id, 
+         '{}', 
+         ARRAY['watch_project'::notification_topic_group]::notification_topic_group[],
+         jsonb_build_object('projectId', p.id)
+    FROM users u
+    JOIN projects p ON u.id = p.owner_user_id
+  WHERE NOT EXISTS (
+  SELECT FROM notification_subscriptions ns
+    WHERE ns.subscriber_user_id = u.id
+      AND ns.scope_user_id = p.owner_user_id
+      AND ns.topics = '{}'
+      AND ns.topic_groups = ARRAY['watch_project'::notification_topic_group]
+      AND ns.filter = jsonb_build_object('projectId', p.id)
+    )
+;

--- a/src/Share/Web/Authorization.hs
+++ b/src/Share/Web/Authorization.hs
@@ -393,9 +393,8 @@ checkDownloadFromProjectBranchCodebase :: WebApp (Either AuthZFailure AuthZ.Auth
 checkDownloadFromProjectBranchCodebase =
   pure . Right $ AuthZ.UnsafeAuthZReceipt Nothing
 
-checkProjectCreate :: Maybe UserId -> UserId -> WebApp (Either AuthZFailure AuthZ.AuthZReceipt)
-checkProjectCreate mayReqUserId targetUserId = maybePermissionFailure (ProjectPermission (ProjectCreate targetUserId)) $ do
-  reqUserId <- guardMaybe mayReqUserId
+checkProjectCreate :: UserId -> UserId -> WebApp (Either AuthZFailure AuthZ.AuthZReceipt)
+checkProjectCreate reqUserId targetUserId = maybePermissionFailure (ProjectPermission (ProjectCreate targetUserId)) $ do
   -- Can create projects in their own user, or in any org they have permission to create projects in.
   guard (reqUserId == targetUserId) <|> checkCreateInOrg reqUserId
   pure $ AuthZ.UnsafeAuthZReceipt Nothing

--- a/src/Share/Web/Authorization/Types.hs
+++ b/src/Share/Web/Authorization/Types.hs
@@ -450,7 +450,7 @@ instance FromJSON ProjectNotificationSubscriptionRequest where
 
 data ProjectNotificationSubscriptionResponse
   = ProjectNotificationSubscriptionResponse
-  { subscriptionId :: NotificationSubscriptionId
+  { subscriptionId :: Maybe NotificationSubscriptionId
   }
   deriving (Show, Eq)
 

--- a/src/Share/Web/Authorization/Types.hs
+++ b/src/Share/Web/Authorization/Types.hs
@@ -26,6 +26,7 @@ module Share.Web.Authorization.Types
     RemoveRolesResponse (..),
     AddRolesRequest (..),
     RemoveRolesRequest (..),
+    ProjectNotificationSubscriptionRequest (..),
 
     -- * AuthZReceipt
     AuthZReceipt (..),
@@ -434,3 +435,14 @@ data AuthZReceipt = UnsafeAuthZReceipt {getCacheability :: Maybe CachingToken}
 -- | Requests should only be cached if they're for a public endpoint.
 -- Obtaining a caching token is proof that the resource was public and can be cached.
 data CachingToken = CachingToken
+
+data ProjectNotificationSubscriptionRequest
+  = ProjectNotificationSubscriptionRequest
+  { isSubscribed :: Bool
+  }
+  deriving (Show, Eq)
+
+instance FromJSON ProjectNotificationSubscriptionRequest where
+  parseJSON = Aeson.withObject "ProjectNotificationSubscriptionRequest" $ \o -> do
+    isSubscribed <- o Aeson..: "isSubscribed"
+    pure ProjectNotificationSubscriptionRequest {isSubscribed}

--- a/src/Share/Web/Authorization/Types.hs
+++ b/src/Share/Web/Authorization/Types.hs
@@ -27,6 +27,7 @@ module Share.Web.Authorization.Types
     AddRolesRequest (..),
     RemoveRolesRequest (..),
     ProjectNotificationSubscriptionRequest (..),
+    ProjectNotificationSubscriptionResponse (..),
 
     -- * AuthZReceipt
     AuthZReceipt (..),
@@ -446,3 +447,15 @@ instance FromJSON ProjectNotificationSubscriptionRequest where
   parseJSON = Aeson.withObject "ProjectNotificationSubscriptionRequest" $ \o -> do
     isSubscribed <- o Aeson..: "isSubscribed"
     pure ProjectNotificationSubscriptionRequest {isSubscribed}
+
+data ProjectNotificationSubscriptionResponse
+  = ProjectNotificationSubscriptionResponse
+  { subscriptionId :: NotificationSubscriptionId
+  }
+  deriving (Show, Eq)
+
+instance ToJSON ProjectNotificationSubscriptionResponse where
+  toJSON ProjectNotificationSubscriptionResponse {..} =
+    object
+      [ "subscriptionId" .= subscriptionId
+      ]

--- a/src/Share/Web/Share/Projects/API.hs
+++ b/src/Share/Web/Share/Projects/API.hs
@@ -115,4 +115,4 @@ type RemoveRolesEndpoint =
 
 type ProjectNotificationSubscriptionEndpoint =
   ReqBody '[JSON] ProjectNotificationSubscriptionRequest
-    :> Put '[JSON] ()
+    :> Put '[JSON] ProjectNotificationSubscriptionResponse

--- a/src/Share/Web/Share/Projects/API.hs
+++ b/src/Share/Web/Share/Projects/API.hs
@@ -41,7 +41,8 @@ type ProjectResourceAPI =
       :<|> GetProjectEndpoint
       :<|> ( "fav" :> FavProjectEndpoint
            )
-      :<|> "roles" :> MaintainersResourceAPI
+      :<|> ("roles" :> MaintainersResourceAPI)
+      :<|> ("subscription" :> ProjectNotificationSubscriptionEndpoint)
   )
 
 type ProjectDiffNamespacesEndpoint =
@@ -111,3 +112,7 @@ type RemoveRolesEndpoint =
     :>
     -- Return the updated list of maintainers
     Delete '[JSON] RemoveRolesResponse
+
+type ProjectNotificationSubscriptionEndpoint =
+  ReqBody '[JSON] ProjectNotificationSubscriptionRequest
+    :> Put '[JSON] ()

--- a/src/Share/Web/Share/Projects/Types.hs
+++ b/src/Share/Web/Share/Projects/Types.hs
@@ -25,6 +25,7 @@ module Share.Web.Share.Projects.Types
     IsPremiumProject (..),
     APIProjectBranchAndReleaseDetails (..),
     PermissionsInfo (..),
+    IsSubscribed (..),
   )
 where
 
@@ -223,6 +224,12 @@ newtype IsPremiumProject = IsPremiumProject
   deriving (Show)
   deriving (ToJSON) via (AtKey "isPremiumProject" Bool)
 
+newtype IsSubscribed = IsSubscribed
+  { isSubscribed :: Bool
+  }
+  deriving (Show)
+  deriving (ToJSON) via (AtKey "isSubscribed" Bool)
+
 type GetProjectResponse =
   APIProject
     :++ FavData
@@ -232,6 +239,7 @@ type GetProjectResponse =
     :++ TicketStats
     :++ PermissionsInfo
     :++ IsPremiumProject
+    :++ IsSubscribed
 
 data ListProjectsResponse = ListProjectsResponse
   { projects :: [APIProject :++ FavData]

--- a/transcripts/share-apis/notifications/list-subscriptions-test-after-unsubscribe.json
+++ b/transcripts/share-apis/notifications/list-subscriptions-test-after-unsubscribe.json
@@ -1,0 +1,10 @@
+{
+  "body": {
+    "subscriptions": []
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/notifications/list-subscriptions-test.json
+++ b/transcripts/share-apis/notifications/list-subscriptions-test.json
@@ -1,0 +1,22 @@
+{
+  "body": {
+    "subscriptions": [
+      {
+        "filter": {
+          "projectId": "P-<UUID>"
+        },
+        "id": "NS-<UUID>",
+        "scope": "U-<UUID>",
+        "topicGroups": [
+          "watch_project"
+        ],
+        "topics": []
+      }
+    ]
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/notifications/unsubscribe-from-project.json
+++ b/transcripts/share-apis/notifications/unsubscribe-from-project.json
@@ -1,0 +1,10 @@
+{
+  "body": {
+    "subscriptionId": null
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/project-maintainers/read-maintainer-project-view.json
+++ b/transcripts/share-apis/project-maintainers/read-maintainer-project-view.json
@@ -4,6 +4,7 @@
     "defaultBranch": "main",
     "isFaved": false,
     "isPremiumProject": true,
+    "isSubscribed": false,
     "latestRelease": null,
     "numActiveContributions": 0,
     "numClosedContributions": 0,

--- a/transcripts/share-apis/projects-flow/project-get-after-update.json
+++ b/transcripts/share-apis/projects-flow/project-get-after-update.json
@@ -4,6 +4,7 @@
     "defaultBranch": null,
     "isFaved": true,
     "isPremiumProject": true,
+    "isSubscribed": true,
     "latestRelease": null,
     "numActiveContributions": 0,
     "numClosedContributions": 0,

--- a/transcripts/share-apis/projects-flow/project-get-private-authorized.json
+++ b/transcripts/share-apis/projects-flow/project-get-private-authorized.json
@@ -4,6 +4,7 @@
     "defaultBranch": null,
     "isFaved": false,
     "isPremiumProject": false,
+    "isSubscribed": true,
     "latestRelease": null,
     "numActiveContributions": 0,
     "numClosedContributions": 0,

--- a/transcripts/share-apis/projects-flow/project-get-public-unauthenticated.json
+++ b/transcripts/share-apis/projects-flow/project-get-public-unauthenticated.json
@@ -4,6 +4,7 @@
     "defaultBranch": null,
     "isFaved": false,
     "isPremiumProject": true,
+    "isSubscribed": false,
     "latestRelease": null,
     "numActiveContributions": 0,
     "numClosedContributions": 0,

--- a/transcripts/share-apis/projects-flow/project-get-simple.json
+++ b/transcripts/share-apis/projects-flow/project-get-simple.json
@@ -4,6 +4,7 @@
     "defaultBranch": "main",
     "isFaved": false,
     "isPremiumProject": true,
+    "isSubscribed": false,
     "latestRelease": "1.2.3",
     "numActiveContributions": 2,
     "numClosedContributions": 0,

--- a/transcripts/share-apis/releases/project-latest-release.json
+++ b/transcripts/share-apis/releases/project-latest-release.json
@@ -4,6 +4,7 @@
     "defaultBranch": "main",
     "isFaved": true,
     "isPremiumProject": true,
+    "isSubscribed": false,
     "latestRelease": "4.5.6",
     "numActiveContributions": 2,
     "numClosedContributions": 0,

--- a/transcripts/share-apis/roles/maintainer-project-view.json
+++ b/transcripts/share-apis/roles/maintainer-project-view.json
@@ -4,6 +4,7 @@
     "defaultBranch": "main",
     "isFaved": false,
     "isPremiumProject": false,
+    "isSubscribed": false,
     "latestRelease": null,
     "numActiveContributions": 0,
     "numClosedContributions": 0,


### PR DESCRIPTION
## Overview

Adds endpoints to allow users to watch or unwatch a given project.
Adds `isSubscribed` to the GetProject response.
Auto-subscribe to projects that a given user creates.

TODO:
* [ ] Migration to subscribe all existing users to existing projects

## Implementation notes

Adds:

```
PUT /users/<handle>/projects/<slug>/subscription

{ "isSubscribed": <bool>
}

Response:
{ "subscriptionId": NS-<UUID> | null
}
```

Adds `isSubscribed` to the Get Project response.

## Test coverage

Transcripts