### PR TITLE
Status update notifications

### DIFF
--- a/src/Share/BackgroundJobs/Webhooks/Worker.hs
+++ b/src/Share/BackgroundJobs/Webhooks/Worker.hs
@@ -27,6 +27,7 @@ import Share.BackgroundJobs.Webhooks.Queries qualified as WQ
 import Share.BackgroundJobs.Workers (newWorker)
 import Share.ChatApps (Author (..))
 import Share.ChatApps qualified as ChatApps
+import Share.Contribution (displayContributionStatus)
 import Share.Env qualified as Env
 import Share.IDs
 import Share.IDs qualified as IDs
@@ -41,6 +42,7 @@ import Share.Notifications.Webhooks.Secrets qualified as Webhooks
 import Share.Postgres qualified as PG
 import Share.Postgres.Notifications qualified as Notif
 import Share.Prelude
+import Share.Ticket (displayTicketStatus)
 import Share.Utils.Logging qualified as Logging
 import Share.Utils.URI (URIParam (..))
 import Share.Web.Authorization qualified as AuthZ
@@ -308,8 +310,16 @@ buildWebhookRequest webhookId uri event defaultPayload = do
         HydratedProjectContributionCreatedPayload payload -> do
           let mkPretext pbShorthand = "New Contribution in " <> IDs.toText pbShorthand
           contributionChatMessage event author mainLink payload mkPretext
-        HydratedProjectContributionUpdatedPayload payload -> do
-          let mkPretext pbShorthand = "Updated Contribution in " <> IDs.toText pbShorthand
+        HydratedProjectContributionStatusUpdatedPayload payload (StatusUpdatePayload {oldStatus, newStatus}) -> do
+          let mkPretext pbShorthand =
+                Text.unwords
+                  [ "Contribution in",
+                    IDs.toText pbShorthand,
+                    "changed from",
+                    displayContributionStatus oldStatus,
+                    "to",
+                    displayContributionStatus newStatus
+                  ]
           contributionChatMessage event author mainLink payload mkPretext
         HydratedProjectContributionCommentPayload payload comment -> do
           let mkPretext pbShorthand = "New Comment on Contribution in " <> IDs.toText pbShorthand
@@ -321,8 +331,16 @@ buildWebhookRequest webhookId uri event defaultPayload = do
         HydratedProjectTicketCreatedPayload payload -> do
           let mkPretext projectShorthand = "New Ticket in " <> IDs.toText projectShorthand
           ticketChatMessage event author mainLink payload mkPretext
-        HydratedProjectTicketUpdatedPayload payload -> do
-          let mkPretext projectShorthand = "Updated Ticket in " <> IDs.toText projectShorthand
+        HydratedProjectTicketStatusUpdatedPayload payload (StatusUpdatePayload {oldStatus, newStatus}) -> do
+          let mkPretext projectShorthand =
+                Text.unwords
+                  [ "Ticket in",
+                    IDs.toText projectShorthand,
+                    "changed from",
+                    displayTicketStatus oldStatus,
+                    "to",
+                    displayTicketStatus newStatus
+                  ]
           ticketChatMessage event author mainLink payload mkPretext
         HydratedProjectTicketCommentPayload payload comment -> do
           let mkPretext projectShorthand = "New Comment on Ticket in " <> IDs.toText projectShorthand

--- a/src/Share/Contribution.hs
+++ b/src/Share/Contribution.hs
@@ -36,6 +36,13 @@ instance Aeson.FromJSON ContributionStatus where
       "merged" -> pure Merged
       _ -> fail "Invalid contribution status"
 
+displayContributionStatus :: ContributionStatus -> Text
+displayContributionStatus = \case
+  Draft -> "Draft"
+  InReview -> "In Review"
+  Closed -> "Closed"
+  Merged -> "Merged"
+
 instance Hasql.EncodeValue ContributionStatus where
   encodeValue =
     PG.encodeValue & contramap \case

--- a/src/Share/Notifications/Queries.hs
+++ b/src/Share/Notifications/Queries.hs
@@ -332,10 +332,14 @@ hydrateEventPayload = \case
     (ProjectData {projectId})
     (ContributionData {contributionId, fromBranchId, toBranchId, contributorUserId}) -> do
       HydratedProjectContributionCreatedPayload <$> hydrateContributionPayload contributionId projectId fromBranchId toBranchId contributorUserId
-  ProjectContributionUpdatedData
+  ProjectContributionStatusUpdatedData
     (ProjectData {projectId})
-    (ContributionData {contributionId, fromBranchId, toBranchId, contributorUserId}) -> do
-      HydratedProjectContributionUpdatedPayload <$> hydrateContributionPayload contributionId projectId fromBranchId toBranchId contributorUserId
+    (ContributionData {contributionId, fromBranchId, toBranchId, contributorUserId})
+    (StatusUpdateData {oldStatus, newStatus}) -> do
+      let statusPayload = StatusUpdatePayload {oldStatus, newStatus}
+      HydratedProjectContributionStatusUpdatedPayload
+        <$> hydrateContributionPayload contributionId projectId fromBranchId toBranchId contributorUserId
+        <*> pure statusPayload
   ProjectContributionCommentData
     (ProjectData {projectId})
     (ContributionData {contributionId, fromBranchId, toBranchId, contributorUserId})
@@ -347,10 +351,14 @@ hydrateEventPayload = \case
     (ProjectData {projectId})
     (TicketData {ticketId, ticketAuthorUserId}) -> do
       HydratedProjectTicketCreatedPayload <$> hydrateTicketPayload projectId ticketId ticketAuthorUserId
-  ProjectTicketUpdatedData
+  ProjectTicketStatusUpdatedData
     (ProjectData {projectId})
-    (TicketData {ticketId, ticketAuthorUserId}) -> do
-      HydratedProjectTicketUpdatedPayload <$> hydrateTicketPayload projectId ticketId ticketAuthorUserId
+    (TicketData {ticketId, ticketAuthorUserId})
+    (StatusUpdateData {oldStatus, newStatus}) -> do
+      let statusPayload = StatusUpdatePayload {oldStatus, newStatus}
+      HydratedProjectTicketStatusUpdatedPayload
+        <$> hydrateTicketPayload projectId ticketId ticketAuthorUserId
+        <*> pure statusPayload
   ProjectTicketCommentData
     (ProjectData {projectId})
     (TicketData {ticketId, ticketAuthorUserId})

--- a/src/Share/Postgres/Contributions/Ops.hs
+++ b/src/Share/Postgres/Contributions/Ops.hs
@@ -13,7 +13,7 @@ import Data.Set qualified as Set
 import Share.Contribution (Contribution (..), ContributionStatus (..))
 import Share.IDs
 import Share.Notifications.Queries qualified as NotifQ
-import Share.Notifications.Types (ContributionData (..), NotificationEvent (..), NotificationEventData (..))
+import Share.Notifications.Types (ContributionData (..), NotificationEvent (..), NotificationEventData (..), StatusUpdateData (..))
 import Share.Postgres qualified as PG
 import Share.Postgres.Contributions.Queries qualified as ContribQ
 import Share.Postgres.Projects.Queries qualified as ProjectQ
@@ -141,16 +141,17 @@ insertContributionStatusChangeEvent projectId contributionId actorUserId oldStat
   -- Only record a notification event if it's a status change, not a creation
   case oldStatus of
     Nothing -> pure ()
-    Just _ -> do
+    Just oldStatus' -> do
       (projectData, projectResourceId, projectOwnerUserId) <- ProjectsQ.projectNotificationData projectId
       -- Record the status update notification event
       contributionData <- ContribQ.contributionNotificationData contributionId
+      let statusUpdateData = StatusUpdateData {oldStatus = oldStatus', newStatus}
       let notifEvent =
             NotificationEvent
               { eventId = (),
                 eventOccurredAt = (),
                 eventResourceId = projectResourceId,
-                eventData = ProjectContributionUpdatedData projectData contributionData,
+                eventData = ProjectContributionStatusUpdatedData projectData contributionData statusUpdateData,
                 eventScope = projectOwnerUserId,
                 eventActor = actorUserId
               }

--- a/src/Share/Postgres/Contributions/Ops.hs
+++ b/src/Share/Postgres/Contributions/Ops.hs
@@ -2,16 +2,24 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Share.Postgres.Contributions.Ops (createContribution) where
+module Share.Postgres.Contributions.Ops
+  ( createContribution,
+    updateContribution,
+    performMergesAndBCAUpdatesFromBranchPush,
+  )
+where
 
-import Share.Contribution (ContributionStatus (..))
+import Data.Set qualified as Set
+import Share.Contribution (Contribution (..), ContributionStatus (..))
 import Share.IDs
 import Share.Notifications.Queries qualified as NotifQ
 import Share.Notifications.Types (ContributionData (..), NotificationEvent (..), NotificationEventData (..))
 import Share.Postgres qualified as PG
 import Share.Postgres.Contributions.Queries qualified as ContribQ
 import Share.Postgres.Projects.Queries qualified as ProjectQ
+import Share.Postgres.Projects.Queries qualified as ProjectsQ
 import Share.Prelude
+import Share.Utils.API (NullableUpdate (..), fromNullableUpdate)
 
 createContribution ::
   -- | Author
@@ -55,7 +63,7 @@ createContribution authorId projectId title description status sourceBranchId ta
           JOIN project_branches AS target_branch ON target_branch.id = #{targetBranchId}
         RETURNING contributions.id, contributions.contribution_number
       |]
-  ContribQ.insertContributionStatusChangeEvent contributionId authorId Nothing status
+  insertContributionStatusChangeEvent projectId contributionId authorId Nothing status
   (projectData, projectResourceId, projectOwnerUserId) <- ProjectQ.projectNotificationData projectId
 
   let contributionData =
@@ -76,3 +84,108 @@ createContribution authorId projectId title description status sourceBranchId ta
           }
   NotifQ.recordEvent notifEvent
   pure (contributionId, number)
+
+updateContribution :: UserId -> ContributionId -> Maybe Text -> NullableUpdate Text -> Maybe ContributionStatus -> Maybe BranchId -> Maybe BranchId -> PG.Transaction e Bool
+updateContribution callerUserId contributionId newTitle newDescription newStatus newSourceBranchId newTargetBranchId = do
+  isJust <$> runMaybeT do
+    Contribution {..} <- lift $ ContribQ.contributionById contributionId
+    let updatedTitle = fromMaybe title newTitle
+    let updatedDescription = fromNullableUpdate description newDescription
+    let updatedStatus = fromMaybe status newStatus
+    let updatedSourceBranchId = fromMaybe sourceBranchId newSourceBranchId
+    let updatedTargetBranchId = fromMaybe targetBranchId newTargetBranchId
+    -- Add a status change event
+    when (isJust newStatus && newStatus /= Just status) do
+      lift $ insertContributionStatusChangeEvent projectId contributionId callerUserId (Just status) updatedStatus
+    lift $
+      PG.execute_
+        [PG.sql|
+        UPDATE contributions
+        SET
+          title = #{updatedTitle},
+          description = #{updatedDescription},
+          status = #{updatedStatus},
+          source_branch = #{updatedSourceBranchId},
+          target_branch = #{updatedTargetBranchId}
+        WHERE id = #{contributionId}
+        |]
+    -- We don't want to change the causals for merged or closed contributions because it
+    -- messes with the diffs.
+    -- But we do want to update them if the source or target branch has changed.
+    when
+      (updatedStatus == InReview || updatedStatus == Draft)
+      do
+        lift $
+          PG.execute_
+            [PG.sql|
+          UPDATE contributions
+          SET
+            source_causal_id = (SELECT pb.causal_id FROM project_branches pb WHERE pb.id = #{updatedSourceBranchId}),
+            target_causal_id = (SELECT pb.causal_id FROM project_branches pb WHERE pb.id = #{updatedTargetBranchId}),
+            best_common_ancestor_causal_id = best_common_causal_ancestor(
+              (SELECT pb.causal_id FROM project_branches pb WHERE pb.id = #{updatedSourceBranchId}),
+              (SELECT pb.causal_id FROM project_branches pb WHERE pb.id = #{updatedTargetBranchId})
+            )
+          WHERE id = #{contributionId}
+          |]
+
+insertContributionStatusChangeEvent :: ProjectId -> ContributionId -> UserId -> Maybe ContributionStatus -> ContributionStatus -> PG.Transaction e ()
+insertContributionStatusChangeEvent projectId contributionId actorUserId oldStatus newStatus = do
+  PG.execute_
+    [PG.sql|
+        INSERT INTO contribution_status_events
+          (contribution_id, actor, old_status, new_status)
+          VALUES (#{contributionId}, #{actorUserId}, #{oldStatus}, #{newStatus})
+      |]
+
+  -- Only record a notification event if it's a status change, not a creation
+  case oldStatus of
+    Nothing -> pure ()
+    Just _ -> do
+      (projectData, projectResourceId, projectOwnerUserId) <- ProjectsQ.projectNotificationData projectId
+      -- Record the status update notification event
+      contributionData <- ContribQ.contributionNotificationData contributionId
+      let notifEvent =
+            NotificationEvent
+              { eventId = (),
+                eventOccurredAt = (),
+                eventResourceId = projectResourceId,
+                eventData = ProjectContributionUpdatedData projectData contributionData,
+                eventScope = projectOwnerUserId,
+                eventActor = actorUserId
+              }
+      NotifQ.recordEvent notifEvent
+
+-- | Recompute the best common ancestors for all contributions related to the branch, then
+-- return the set of contribution IDs which have been marked as merged.
+performMergesAndBCAUpdatesFromBranchPush :: UserId -> BranchId -> PG.Transaction e (Set ContributionId)
+performMergesAndBCAUpdatesFromBranchPush callerUserId branchId = do
+  -- Get the new BCAs for all contributions related to the branch
+  contributionsToMarkAsMerged <-
+    PG.queryListCol @(ContributionId)
+      [PG.sql|
+    WITH new_bcas(contribution_id, source_causal_id, target_causal_id, bca_id) AS (
+      SELECT contr.id, source_branch.causal_id, target_branch.causal_id, best_common_causal_ancestor(source_branch.causal_id, target_branch.causal_id) FROM contributions contr
+        JOIN project_branches AS source_branch ON source_branch.id = contr.source_branch
+        JOIN project_branches AS target_branch ON target_branch.id = contr.target_branch
+        WHERE contr.source_branch = #{branchId} OR contr.target_branch = #{branchId}
+          AND status IN (#{Draft}, #{InReview})
+    ), contributions_to_mark_as_merged(contribution_id) AS (
+      SELECT contribution_id FROM new_bcas
+        WHERE new_bcas.bca_id IS NOT NULL
+          AND new_bcas.bca_id = new_bcas.source_causal_id
+    ), non_merged_bca_updates AS MATERIALIZED (
+      UPDATE contributions contr
+        SET best_common_ancestor_causal_id = new_bcas.bca_id,
+            source_causal_id = new_bcas.source_causal_id,
+            target_causal_id = new_bcas.target_causal_id
+        FROM new_bcas
+        WHERE
+          contr.id = new_bcas.contribution_id
+          AND contr.id NOT IN (SELECT contribution_id FROM contributions_to_mark_as_merged)
+    ) SELECT contribution_id FROM contributions_to_mark_as_merged
+      |]
+  for_ contributionsToMarkAsMerged \contributionId -> do
+    _success <- updateContribution callerUserId contributionId Nothing Unchanged (Just Merged) Nothing Nothing
+    pure ()
+  pure $ Set.fromList contributionsToMarkAsMerged

--- a/src/Share/Ticket.hs
+++ b/src/Share/Ticket.hs
@@ -4,13 +4,13 @@ module Share.Ticket where
 
 import Data.Aeson qualified as Aeson
 import Data.Time (UTCTime)
-import Share.IDs
-import Share.Postgres qualified as PG
-import Share.Prelude
 import Hasql.Decoders qualified as Decoders
 import Hasql.Encoders qualified as Encoders
 import Hasql.Interpolate qualified as Hasql
 import Servant (FromHttpApiData (..))
+import Share.IDs
+import Share.Postgres qualified as PG
+import Share.Prelude
 
 data TicketStatus
   = Open
@@ -52,6 +52,11 @@ instance Hasql.DecodeValue TicketStatus where
           "closed" -> Just Closed
           _ -> Nothing
       )
+
+displayTicketStatus :: TicketStatus -> Text
+displayTicketStatus = \case
+  Open -> "Open"
+  Closed -> "Closed"
 
 data Ticket = Ticket
   { ticketId :: TicketId,

--- a/src/Share/Web/Share/Contributions/Impl.hs
+++ b/src/Share/Web/Share/Contributions/Impl.hs
@@ -30,6 +30,7 @@ import Share.IDs qualified as IDs
 import Share.OAuth.Session
 import Share.Postgres qualified as PG
 import Share.Postgres.Causal.Queries qualified as CausalQ
+import Share.Postgres.Contributions.Ops qualified as ContribOps
 import Share.Postgres.Contributions.Ops qualified as ContributionOps
 import Share.Postgres.Contributions.Queries qualified as ContributionsQ
 import Share.Postgres.NameLookups.Ops qualified as NL
@@ -209,7 +210,7 @@ updateContributionByNumberEndpoint session handle projectSlug contributionNumber
     pure (contribution, maySourceBranch, mayTargetBranch)
   _authReceipt <- AuthZ.permissionGuard $ AuthZ.checkContributionUpdate callerUserId contribution updateRequest
   PG.runTransactionOrRespondError $ do
-    _ <- ContributionsQ.updateContribution callerUserId contributionId title description status (branchId <$> maySourceBranch) (branchId <$> mayTargetBranch)
+    _ <- ContribOps.updateContribution callerUserId contributionId title description status (branchId <$> maySourceBranch) (branchId <$> mayTargetBranch)
     DiffsQ.submitContributionsToBeDiffed $ Set.singleton contributionId
     ContributionsQ.shareContributionByProjectIdAndNumber projectId contributionNumber `whenNothingM` throwError (EntityMissing (ErrorID "contribution:missing") "Contribution not found")
       >>= UsersQ.userDisplayInfoOf traversed

--- a/src/Share/Web/Share/Contributions/MergeDetection.hs
+++ b/src/Share/Web/Share/Contributions/MergeDetection.hs
@@ -7,13 +7,14 @@ import Data.Set qualified as Set
 import Share.BackgroundJobs.Diffs.Queries qualified as DiffsQ
 import Share.IDs
 import Share.Postgres qualified as PG
+import Share.Postgres.Contributions.Ops qualified as ContribOps
 import Share.Postgres.Contributions.Queries qualified as ContributionQ
 
 -- | Update contribution status to reflect any merges which may have occurred and update the
 -- best common ancestors.
 updateContributionsFromBranchUpdate :: UserId -> BranchId -> PG.Transaction e ()
 updateContributionsFromBranchUpdate callerUserId branchId = do
-  contributionsWithUpdatedBCAs <- ContributionQ.performMergesAndBCAUpdatesFromBranchPush callerUserId branchId
+  contributionsWithUpdatedBCAs <- ContribOps.performMergesAndBCAUpdatesFromBranchPush callerUserId branchId
   rebasedContributions <- ContributionQ.rebaseContributionsFromMergedBranches contributionsWithUpdatedBCAs
   affectedContributions <- ContributionQ.contributionsRelatedToBranches (Set.singleton branchId)
   DiffsQ.submitContributionsToBeDiffed (Set.fromList affectedContributions <> rebasedContributions)

--- a/src/Share/Web/Share/Tickets/Impl.hs
+++ b/src/Share/Web/Share/Tickets/Impl.hs
@@ -148,7 +148,7 @@ updateTicketByNumberEndpoint session handle projectSlug ticketNumber updateReque
     pure ticket
   _authReceipt <- AuthZ.permissionGuard $ AuthZ.checkTicketUpdate callerUserId ticket updateRequest
   PG.runTransactionOrRespondError $ do
-    _ <- TicketsQ.updateTicket callerUserId ticketId title description status
+    _ <- TicketOps.updateTicket callerUserId ticketId title description status
     TicketsQ.shareTicketByProjectIdAndNumber projectId ticketNumber `whenNothingM` throwError (EntityMissing (ErrorID "ticket:missing") "Ticket not found")
       >>= UserQ.userDisplayInfoOf traversed
   where

--- a/src/Share/Web/UI/Links.hs
+++ b/src/Share/Web/UI/Links.hs
@@ -129,13 +129,13 @@ notificationLink = \case
     projectBranchBrowseLink payload.branchInfo.projectBranchShortHand
   HydratedProjectContributionCreatedPayload payload ->
     contributionLink payload.projectInfo.projectShortHand payload.contributionInfo.contributionNumber
-  HydratedProjectContributionUpdatedPayload payload ->
+  HydratedProjectContributionStatusUpdatedPayload payload _status ->
     contributionLink payload.projectInfo.projectShortHand payload.contributionInfo.contributionNumber
   HydratedProjectContributionCommentPayload payload comment ->
     contributionCommentLink payload.projectInfo.projectShortHand payload.contributionInfo.contributionNumber comment.commentId
   HydratedProjectTicketCreatedPayload payload ->
     ticketLink payload.projectInfo.projectShortHand payload.ticketInfo.ticketNumber
-  HydratedProjectTicketUpdatedPayload payload ->
+  HydratedProjectTicketStatusUpdatedPayload payload _status ->
     ticketLink payload.projectInfo.projectShortHand payload.ticketInfo.ticketNumber
   HydratedProjectTicketCommentPayload payload comment ->
     ticketCommentLink payload.projectInfo.projectShortHand payload.ticketInfo.ticketNumber comment.commentId

--- a/transcripts/share-apis/notifications/contribution-update-status.json
+++ b/transcripts/share-apis/notifications/contribution-update-status.json
@@ -1,0 +1,26 @@
+{
+  "body": {
+    "author": {
+      "avatarUrl": null,
+      "handle": "test",
+      "name": null,
+      "userId": "U-<UUID>"
+    },
+    "createdAt": "<TIMESTAMP>",
+    "description": "This contribution addresses an issue where users were unable to log in due to a validation error in the authentication process.\n\n## Changes made:\n\n* Modified the validation logic for the Auth type to properly authenticate users.\n* Added unit tests to ensure the authentication process works as expected.\n\n## Testing:\n\nI tested this change locally on my development environment and confirmed that users can now log in without any issues. All unit tests are passing.",
+    "id": "C-<UUID>",
+    "numComments": 3,
+    "number": 1,
+    "projectRef": "@test/publictestproject",
+    "sourceBranchRef": "@transcripts/contribution",
+    "status": "closed",
+    "targetBranchRef": "main",
+    "title": "Fix issue with user authentication",
+    "updatedAt": "<TIMESTAMP>"
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/notifications/create-subscription-for-other-user-project.json
+++ b/transcripts/share-apis/notifications/create-subscription-for-other-user-project.json
@@ -4,10 +4,11 @@
       "filter": null,
       "id": "NS-<UUID>",
       "scope": "U-<UUID>",
-      "topicGroups": [],
+      "topicGroups": [
+        "watch_project"
+      ],
       "topics": [
-        "project:branch:updated",
-        "project:contribution:created"
+        "project:branch:updated"
       ]
     }
   },

--- a/transcripts/share-apis/notifications/list-notifications-test.json
+++ b/transcripts/share-apis/notifications/list-notifications-test.json
@@ -160,7 +160,7 @@
                   "branchShortHand": "main",
                   "projectBranchShortHand": "@test/publictestproject/main"
                 },
-                "status": "in_review",
+                "status": "closed",
                 "targetBranch": {
                   "branchContributorHandle": "transcripts",
                   "branchContributorUserId": "U-<UUID>",

--- a/transcripts/share-apis/notifications/list-notifications-transcripts.json
+++ b/transcripts/share-apis/notifications/list-notifications-transcripts.json
@@ -48,6 +48,75 @@
         },
         "id": "NOT-<UUID>",
         "status": "unread"
+      },
+      {
+        "createdAt": "<TIMESTAMP>",
+        "event": {
+          "actor": {
+            "info": {
+              "avatarUrl": null,
+              "handle": "test",
+              "name": null,
+              "userId": "U-<UUID>"
+            },
+            "kind": "user"
+          },
+          "data": {
+            "kind": "project:contribution:updated",
+            "link": "http://<HOST>:1234/@test/publictestproject/contributions/1",
+            "payload": {
+              "contribution": {
+                "author": {
+                  "avatarUrl": null,
+                  "handle": "test",
+                  "name": null,
+                  "userId": "U-<UUID>"
+                },
+                "contributionId": "C-<UUID>",
+                "description": "This contribution addresses an issue where users were unable to log in due to a validation error in the authentication process.\n\n## Changes made:\n\n* Modified the validation logic for the Auth type to properly authenticate users.\n* Added unit tests to ensure the authentication process works as expected.\n\n## Testing:\n\nI tested this change locally on my development environment and confirmed that users can now log in without any issues. All unit tests are passing.",
+                "number": 1,
+                "sourceBranch": {
+                  "branchContributorHandle": null,
+                  "branchContributorUserId": null,
+                  "branchId": "B-<UUID>",
+                  "branchName": "main",
+                  "branchShortHand": "main",
+                  "projectBranchShortHand": "@test/publictestproject/main"
+                },
+                "status": "closed",
+                "targetBranch": {
+                  "branchContributorHandle": "transcripts",
+                  "branchContributorUserId": "U-<UUID>",
+                  "branchId": "B-<UUID>",
+                  "branchName": "contribution",
+                  "branchShortHand": "@transcripts/contribution",
+                  "projectBranchShortHand": "@test/publictestproject/@transcripts/contribution"
+                },
+                "title": "Fix issue with user authentication"
+              },
+              "project": {
+                "projectId": "P-<UUID>",
+                "projectOwnerHandle": "test",
+                "projectOwnerUserId": "U-<UUID>",
+                "projectShortHand": "@test/publictestproject",
+                "projectSlug": "publictestproject"
+              }
+            }
+          },
+          "id": "EVENT-<UUID>",
+          "occurredAt": "<TIMESTAMP>",
+          "scope": {
+            "info": {
+              "avatarUrl": null,
+              "handle": "test",
+              "name": null,
+              "userId": "U-<UUID>"
+            },
+            "kind": "user"
+          }
+        },
+        "id": "NOT-<UUID>",
+        "status": "unread"
       }
     ],
     "nextCursor": "<CURSOR>",

--- a/transcripts/share-apis/notifications/list-notifications-transcripts.json
+++ b/transcripts/share-apis/notifications/list-notifications-transcripts.json
@@ -94,6 +94,8 @@
                 },
                 "title": "Fix issue with user authentication"
               },
+              "newStatus": "closed",
+              "oldStatus": "in_review",
               "project": {
                 "projectId": "P-<UUID>",
                 "projectOwnerHandle": "test",

--- a/transcripts/share-apis/notifications/list-notifications-unread-test.json
+++ b/transcripts/share-apis/notifications/list-notifications-unread-test.json
@@ -97,7 +97,7 @@
                   "branchShortHand": "main",
                   "projectBranchShortHand": "@test/publictestproject/main"
                 },
-                "status": "in_review",
+                "status": "closed",
                 "targetBranch": {
                   "branchContributorHandle": "transcripts",
                   "branchContributorUserId": "U-<UUID>",

--- a/transcripts/share-apis/notifications/run.zsh
+++ b/transcripts/share-apis/notifications/run.zsh
@@ -30,9 +30,9 @@ fetch "$test_user" POST add-webhook-to-subscription "/users/test/notifications/s
 fetch "$transcripts_user" POST create-subscription-for-other-user-project '/users/transcripts/notifications/subscriptions' "{
   \"scope\": \"test\",
   \"topics\": [
-    \"project:contribution:created\", \"project:branch:updated\"
+    \"project:branch:updated\"
   ],
-  \"topicGroups\": []
+  \"topicGroups\": [\"watch_project\"]
 }"
 
 fetch "$test_user" POST create-email-delivery '/users/test/notifications/delivery-methods/emails' '{
@@ -70,6 +70,12 @@ fetch "$transcripts_user" POST ticket-create '/users/test/projects/publictestpro
 fetch "$transcripts_user" POST ticket-comment-create '/users/test/projects/publictestproject/tickets/1/timeline/comments' '{
     "content": "This is a new comment on the ticket"
 }'
+
+# Update the contribution status, which should trigger a status update notification.
+fetch "$test_user" PATCH contribution-update-status '/users/test/projects/publictestproject/contributions/1' '{
+    "status": "closed"
+}'
+
 
 # Create a contribution in a private project, which shouldn't create a notification for either, because 'test' has
 # a subscription filter and 'transcripts' doesn't have access.

--- a/transcripts/share-apis/notifications/webhook_results.txt
+++ b/transcripts/share-apis/notifications/webhook_results.txt
@@ -1,3 +1,3 @@
-Successful webhooks: 4
-Unsuccessful webhooks: 4
+Successful webhooks: 5
+Unsuccessful webhooks: 5
 


### PR DESCRIPTION
## Overview

Adds triggers for contribution & ticket status update notifications

* [x] TODO: Capture the from status and to-status on the event itself, or at least join it with the status-log

## Implementation notes

* Creates notification update events when a ticket is closed or re-opened
* Creates contribution update events when a contribution is merged, closed, re-opened,  moved from draft to ready or ready to draft.

## Test coverage

* [x] Transcripts
