### PR TITLE
Null out paging cursors when appropriate

### DIFF
--- a/src/Share/Notifications/Impl.hs
+++ b/src/Share/Notifications/Impl.hs
@@ -12,7 +12,7 @@ import Share.Notifications.Types
 import Share.Postgres qualified as PG
 import Share.Postgres.Ops qualified as UserQ
 import Share.User (User (..))
-import Share.Utils.API (Cursor, Paged, pagedOn)
+import Share.Utils.API (Cursor, Paged)
 import Share.Web.App
 import Share.Web.Authorization qualified as AuthZ
 import Share.Web.Share.DisplayInfo.Types (UnifiedDisplayInfo)
@@ -93,9 +93,7 @@ getHubEntriesEndpoint userHandle callerUserId limit mayCursor mayStatusFilter = 
   notifications <- PG.runTransaction $ do
     notifs <- NotificationQ.listNotificationHubEntryPayloads notificationUserId limit mayCursor (API.getStatusFilter <$> mayStatusFilter)
     forOf (traversed . traversed) notifs NotifOps.hydrateEvent
-  notifications
-    & pagedOn (\(NotificationHubEntry {hubEntryId, hubEntryCreatedAt}) -> (hubEntryCreatedAt, hubEntryId))
-    & pure
+  pure notifications
 
 updateHubEntriesEndpoint :: UserHandle -> UserId -> API.UpdateHubEntriesRequest -> WebApp ()
 updateHubEntriesEndpoint userHandle callerUserId API.UpdateHubEntriesRequest {notificationStatus, notificationIds} = do

--- a/src/Share/Utils/API.hs
+++ b/src/Share/Utils/API.hs
@@ -13,6 +13,7 @@ module Share.Utils.API
     emptySetUpdate,
     Cursor (..),
     Paged (..),
+    guardPaged,
     Query (..),
     Limit (..),
     (:++) (..),
@@ -228,6 +229,13 @@ instance (ToJSON a, ToJSON cursor) => ToJSON (Paged cursor a) where
         "prevCursor" .= prevCursor,
         "nextCursor" .= nextCursor
       ]
+
+guardPaged :: Bool -> Bool -> Paged cursor a -> Paged cursor a
+guardPaged hasPrev hasNext paged@(Paged {prevCursor, nextCursor}) =
+  paged
+    { prevCursor = if hasPrev then prevCursor else Nothing,
+      nextCursor = if hasNext then nextCursor else Nothing
+    }
 
 -- | The maximum page size for pageable endpoints
 maxLimit :: Int64

--- a/transcripts/share-apis/notifications/list-notifications-read-transcripts.json
+++ b/transcripts/share-apis/notifications/list-notifications-read-transcripts.json
@@ -50,8 +50,8 @@
         "status": "read"
       }
     ],
-    "nextCursor": "<CURSOR>",
-    "prevCursor": "<CURSOR>"
+    "nextCursor": null,
+    "prevCursor": null
   },
   "status": [
     {

--- a/transcripts/share-apis/notifications/list-notifications-test-paging.json
+++ b/transcripts/share-apis/notifications/list-notifications-test-paging.json
@@ -1,0 +1,76 @@
+{
+  "body": {
+    "items": [
+      {
+        "createdAt": "<TIMESTAMP>",
+        "event": {
+          "actor": {
+            "info": {
+              "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+              "handle": "transcripts",
+              "name": "Transcript User",
+              "userId": "U-<UUID>"
+            },
+            "kind": "user"
+          },
+          "data": {
+            "kind": "project:ticket:comment",
+            "link": "http://<HOST>:1234/@test/publictestproject/tickets/1",
+            "payload": {
+              "author": {
+                "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+                "handle": "transcripts",
+                "name": "Transcript User",
+                "userId": "U-<UUID>"
+              },
+              "commentId": "CMT-<UUID>",
+              "content": "This is a new comment on the ticket",
+              "createdAt": "<TIMESTAMP>",
+              "project": {
+                "projectId": "P-<UUID>",
+                "projectOwnerHandle": "test",
+                "projectOwnerUserId": "U-<UUID>",
+                "projectShortHand": "@test/publictestproject",
+                "projectSlug": "publictestproject"
+              },
+              "ticket": {
+                "author": {
+                  "avatarUrl": null,
+                  "handle": "test",
+                  "name": null,
+                  "userId": "U-<UUID>"
+                },
+                "createdAt": "<TIMESTAMP>",
+                "description": "I want the code to solve all my problems but it does not. Please fix.\n\n## Things I need:\n\n* It should tie my *shoes*\n* It should make me _coffee_\n* It should do my taxes\n",
+                "number": 1,
+                "status": "open",
+                "ticketId": "T-<UUID>",
+                "title": "Bug Report"
+              }
+            }
+          },
+          "id": "EVENT-<UUID>",
+          "occurredAt": "<TIMESTAMP>",
+          "scope": {
+            "info": {
+              "avatarUrl": null,
+              "handle": "test",
+              "name": null,
+              "userId": "U-<UUID>"
+            },
+            "kind": "user"
+          }
+        },
+        "id": "NOT-<UUID>",
+        "status": "unread"
+      }
+    ],
+    "nextCursor": "<CURSOR>",
+    "prevCursor": null
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/notifications/list-notifications-test.json
+++ b/transcripts/share-apis/notifications/list-notifications-test.json
@@ -266,8 +266,8 @@
         "status": "unread"
       }
     ],
-    "nextCursor": "<CURSOR>",
-    "prevCursor": "<CURSOR>"
+    "nextCursor": null,
+    "prevCursor": null
   },
   "status": [
     {

--- a/transcripts/share-apis/notifications/list-notifications-transcripts.json
+++ b/transcripts/share-apis/notifications/list-notifications-transcripts.json
@@ -121,8 +121,8 @@
         "status": "unread"
       }
     ],
-    "nextCursor": "<CURSOR>",
-    "prevCursor": "<CURSOR>"
+    "nextCursor": null,
+    "prevCursor": null
   },
   "status": [
     {

--- a/transcripts/share-apis/notifications/list-notifications-unread-test.json
+++ b/transcripts/share-apis/notifications/list-notifications-unread-test.json
@@ -203,8 +203,8 @@
         "status": "unread"
       }
     ],
-    "nextCursor": "<CURSOR>",
-    "prevCursor": "<CURSOR>"
+    "nextCursor": null,
+    "prevCursor": null
   },
   "status": [
     {

--- a/transcripts/share-apis/notifications/run.zsh
+++ b/transcripts/share-apis/notifications/run.zsh
@@ -102,6 +102,8 @@ test_notification_id=$(fetch_data_jq "$test_user" GET list-notifications-test '/
 transcripts_notification_id=$(fetch_data_jq "$transcripts_user" GET list-notifications-transcripts '/users/transcripts/notifications/hub' '.items[0].id')
 
 fetch "$test_user" GET list-notifications-test '/users/test/notifications/hub'
+# If we pass a limit, we should get a next cursor
+fetch "$test_user" GET list-notifications-test-paging '/users/test/notifications/hub?limit=1'
 
 fetch "$transcripts_user" GET list-notifications-transcripts '/users/transcripts/notifications/hub'
 
@@ -120,7 +122,7 @@ fetch "$transcripts_user" PATCH mark-notifications-read-transcripts '/users/tran
   ]
 }"
 
-# Show only unread notifications (none should be unread):
+# Show only unread notifications:
 fetch "$test_user" GET list-notifications-unread-test '/users/test/notifications/hub?status=unread'
 
 # Show only read notifications (the one we just marked as read):


### PR DESCRIPTION
Simply nulls out the nextCursor/prevCursor when there are no further results in that direction.