### PR TITLE
Include Markdown Readmes

### DIFF
--- a/src/Share/Web/Share/Branches/Impl.hs
+++ b/src/Share/Web/Share/Branches/Impl.hs
@@ -48,6 +48,8 @@ import Unison.NameSegment.Internal (NameSegment (..))
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
+import Unison.Server.Doc.Markdown.Render qualified as MD
+import Unison.Server.Doc.Markdown.Types qualified as MD
 import Unison.Server.Share.DefinitionSummary (serveTermSummary, serveTypeSummary)
 import Unison.Server.Share.DefinitionSummary.Types (TermSummary, TypeSummary)
 import Unison.Server.Share.Definitions qualified as ShareBackend
@@ -299,7 +301,7 @@ getProjectBranchReadmeEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle
       let mayReadme = do
             NamespaceDetails {readme} <- mayNamespaceDetails
             readme
-      pure $ ReadmeResponse {readMe = mayReadme}
+      pure $ ReadmeResponse {readMe = mayReadme, markdownReadMe = MD.toText . MD.toMarkdown <$> mayReadme}
   where
     cacheParams = [IDs.toText projectBranchShortHand]
     projectBranchShortHand = ProjectBranchShortHand {userHandle, projectSlug, contributorHandle, branchName}

--- a/src/Share/Web/Share/Impl.hs
+++ b/src/Share/Web/Share/Impl.hs
@@ -18,6 +18,8 @@ import Share.Notifications.Impl qualified as Notifications
 import Share.Notifications.Queries qualified as NotifQ
 import Share.OAuth.Session
 import Share.OAuth.Types (UserId)
+import Unison.Server.Doc.Markdown.Render qualified as MD
+import Unison.Server.Doc.Markdown.Types qualified as MD
 import Share.Postgres qualified as PG
 import Share.Postgres.Authorization.Queries qualified as AuthZQ
 import Share.Postgres.IDs (CausalHash)
@@ -336,7 +338,7 @@ getUserReadmeEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandle = do
       let mayReadme = do
             NamespaceDetails {readme} <- mayNamespaceDetails
             readme
-      pure $ ReadmeResponse {readMe = mayReadme}
+      pure $ ReadmeResponse {readMe = mayReadme, markdownReadMe = MD.toText . MD.toMarkdown <$> mayReadme}
   where
     cacheParams = [IDs.toText userHandle]
 

--- a/src/Share/Web/Share/Releases/Impl.hs
+++ b/src/Share/Web/Share/Releases/Impl.hs
@@ -50,6 +50,8 @@ import Unison.NameSegment.Internal (NameSegment (..))
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
+import Unison.Server.Doc.Markdown.Render qualified as MD
+import Unison.Server.Doc.Markdown.Types qualified as MD
 import Unison.Server.Share.DefinitionSummary (serveTermSummary, serveTypeSummary)
 import Unison.Server.Share.DefinitionSummary.Types (TermSummary, TypeSummary)
 import Unison.Server.Share.Definitions qualified as ShareBackend
@@ -313,7 +315,7 @@ getProjectReleaseReadmeEndpoint (AuthN.MaybeAuthedUserID callerUserId) userHandl
       let mayReadme = do
             NamespaceDetails {readme} <- mayNamespaceDetails
             readme
-      pure $ ReadmeResponse {readMe = mayReadme}
+      pure $ ReadmeResponse {readMe = mayReadme, markdownReadMe = MD.toText . MD.toMarkdown <$> mayReadme}
   where
     cacheParams = [IDs.toText projectReleaseShortHand]
     projectReleaseShortHand = ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion}

--- a/src/Share/Web/Share/Types.hs
+++ b/src/Share/Web/Share/Types.hs
@@ -95,14 +95,16 @@ instance ToJSON DescribeUserProfile where
           ]
 
 data ReadmeResponse = ReadmeResponse
-  { readMe :: Maybe Doc
+  { readMe :: Maybe Doc,
+    markdownReadMe :: Maybe Text
   }
   deriving (Show)
 
 instance ToJSON ReadmeResponse where
   toJSON ReadmeResponse {..} =
     Aeson.object
-      [ "readMe" .= readMe
+      [ "readMe" .= readMe,
+        "markdownReadMe" .= markdownReadMe
       ]
 
 -- | A reponse for rendering docs.

--- a/transcripts/share-apis/projects-flow/prelude.md
+++ b/transcripts/share-apis/projects-flow/prelude.md
@@ -1,3 +1,7 @@
+```ucm
+scratch/main> builtins.mergeio
+```
+
 ```unison
 -- Dependencies depend on transitive dependencies
 lib.someLib.depNum = lib.dep.lib.transitiveDep.transitiveDepNum
@@ -5,6 +9,12 @@ lib.dep.lib.transitiveDep.transitiveDepNum = 1
 
 -- Definitions can depend on dependencies
 someTerm = lib.someLib.depNum
+
+README = {{
+## Title
+
+References {someTerm}
+}}
 ```
 
 ```ucm

--- a/transcripts/share-apis/projects-flow/project-readme.json
+++ b/transcripts/share-apis/projects-flow/project-readme.json
@@ -1,0 +1,50 @@
+{
+  "body": {
+    "markdownReadMe": "# Title\n\nReferences `someTerm`\n\n\n",
+    "readMe": {
+      "contents": [
+        {
+          "contents": [
+            {
+              "contents": "Title",
+              "tag": "Word"
+            }
+          ],
+          "tag": "Paragraph"
+        },
+        [
+          {
+            "contents": [
+              {
+                "contents": "References",
+                "tag": "Word"
+              },
+              {
+                "contents": {
+                  "contents": [
+                    {
+                      "annotation": {
+                        "contents": "#3r86bb0g1gn0ugqcf1hcvchic4rmlkep93agjdni44rfpf8m8pn9n3rtfq0jo4kovhv1nus01eqiivgdk2b20snsarln4n57dbk88m0",
+                        "tag": "TermReference"
+                      },
+                      "segment": "someTerm"
+                    }
+                  ],
+                  "tag": "Link"
+                },
+                "tag": "Special"
+              }
+            ],
+            "tag": "Paragraph"
+          }
+        ]
+      ],
+      "tag": "Section"
+    }
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/projects-flow/run.zsh
+++ b/transcripts/share-apis/projects-flow/run.zsh
@@ -8,6 +8,8 @@ transcript_ucm transcript prelude.md
 
 fetch "$unauthenticated_user" GET project-get-simple '/users/test/projects/publictestproject'
 
+
+fetch "$transcripts_user" GET project-readme "/users/transcripts/projects/transcriptproject/readme"
 fetch "$transcripts_user" GET project-browse-definition "/users/transcripts/projects/transcriptproject/branches/main/definitions/by-name/someTerm"
 fetch "$transcripts_user" GET project-browse-definition-in-dependency "/users/transcripts/projects/transcriptproject/branches/main/definitions/by-name/lib.someLib.depNum"
 


### PR DESCRIPTION
## Overview

Adds Markdown Readmes to the /readme endpoint in projects. this is more human readable (and AI Agent readable) than the structured readme, at very little extra cost. I'll use this in creating the Unison Share MCP tools