### PR TITLE
Slightly rework causal_diff_queue insertion logic

### DIFF
--- a/src/Share/BackgroundJobs/Diffs/CausalDiffs.hs
+++ b/src/Share/BackgroundJobs/Diffs/CausalDiffs.hs
@@ -54,6 +54,7 @@ processDiffs authZReceipt makeRuntime = do
               Just causalDiffInfo -> do
                 startTime <- PG.transactionUnsafeIO (Clock.getTime Clock.Monotonic)
                 result <- PG.catchTransaction (maybeComputeAndStoreCausalDiff authZReceipt makeRuntime causalDiffInfo)
+                DQ.deleteClaimedCausalDiff causalDiffInfo
                 pure (Just (causalDiffInfo, startTime, result))
         whenJust result \(CausalDiffInfo {fromCausalId, toCausalId, fromCodebaseOwner, toCodebaseOwner}, startTime, result) -> do
           let tags =


### PR DESCRIPTION
## Overview

@ChrisPenner and I accidentally discovered today that the real culprit behind an `INSERT ON CONFLICT DO NOTHING` into `causal_diff_queue` blocking is not due to a row lock taken by `SELECT FOR UPDATE`, but rather the eager `DELETE` of the selected row.

So, we decided to simply move the `DELETE` call to after a worker has finished computing a namespace diff, significantly reducing the time window during which a concurrent `INSERT` might block.

This also lets us implement the "on get contribution diff, if missing, insert into work queue" which is convenient to have for a number of minor reasons, including that we can wipe precomputed diffs out of `namespace_diffs` whenever we need to, since we are no longer relying on creating or updating a contribution being the only actions that trigger a diff computation.