### PR TITLE
Add notifications for new releases

### DIFF
--- a/share-api.cabal
+++ b/share-api.cabal
@@ -88,6 +88,7 @@ library
       Share.Postgres.Projects.Queries
       Share.Postgres.Queries
       Share.Postgres.Refs.Types
+      Share.Postgres.Releases.Ops
       Share.Postgres.Releases.Queries
       Share.Postgres.Search.DefinitionSearch.Queries
       Share.Postgres.Serialization

--- a/sql/2025-06-18_release-notifications.sql
+++ b/sql/2025-06-18_release-notifications.sql
@@ -1,0 +1,38 @@
+ALTER TYPE notification_topic ADD VALUE 'project:release:created';
+
+INSERT INTO notification_topic_group_topics (topic_group, topic)
+VALUES
+  ('watch_project', 'project:release:created')
+;
+
+
+-- Returns the permission a user must have for an event's resource in order to be notified.
+CREATE OR REPLACE FUNCTION topic_permission(topic notification_topic)
+RETURNS permission
+PARALLEL SAFE
+IMMUTABLE
+AS $$
+BEGIN
+  CASE topic
+    WHEN 'project:branch:updated' THEN
+      RETURN 'project:view'::permission;
+    WHEN 'project:contribution:created' THEN
+      RETURN 'project:view'::permission;
+    WHEN 'project:contribution:updated' THEN
+      RETURN 'project:view'::permission;
+    WHEN 'project:contribution:comment' THEN
+      RETURN 'project:view'::permission;
+    WHEN 'project:ticket:created' THEN
+      RETURN 'project:view'::permission;
+    WHEN 'project:ticket:updated' THEN
+      RETURN 'project:view'::permission;
+    WHEN 'project:ticket:comment' THEN
+      RETURN 'project:view'::permission;
+    WHEN 'project:release:created' THEN
+      RETURN 'project:view'::permission;
+    ELSE
+      RAISE EXCEPTION 'topic_permissions: topic % must declare its necessary permissions', topic;
+  END CASE;
+END;
+$$ LANGUAGE plpgsql;
+

--- a/src/Share/BackgroundJobs/Search/DefinitionSync.hs
+++ b/src/Share/BackgroundJobs/Search/DefinitionSync.hs
@@ -34,6 +34,7 @@ import Share.Postgres.NameLookups.Types qualified as NL
 import Share.Postgres.Notifications qualified as Notif
 import Share.Postgres.Queries qualified as PG
 import Share.Postgres.Releases.Queries qualified as RQ
+import Share.Postgres.Releases.Queries qualified as ReleasesQ
 import Share.Postgres.Search.DefinitionSearch.Queries qualified as DDQ
 import Share.Prelude
 import Share.PrettyPrintEnvDecl.Postgres qualified as PPEPostgres
@@ -109,7 +110,7 @@ syncRelease ::
   ReleaseId ->
   PG.Transaction e [DefnIndexingFailure]
 syncRelease authZReceipt releaseId = fmap (fromMaybe []) . runMaybeT $ do
-  Release {projectId, releaseId, squashedCausal, version} <- lift $ PG.expectReleaseById releaseId
+  Release {projectId, releaseId, squashedCausal, version} <- lift $ ReleasesQ.releaseById releaseId
   -- Wipe out any existing rows for this release. Normally there should be none, but this
   -- makes it easy to re-index later if we change how we tokenize things.
   latestVersion <- MaybeT $ RQ.latestReleaseVersionByProjectId projectId

--- a/src/Share/Postgres/Projects/Queries.hs
+++ b/src/Share/Postgres/Projects/Queries.hs
@@ -114,20 +114,19 @@ expectProjectShortHandsOf trav s = do
         else pure results
 
 -- | Info used when constructing a notification within a project.
-projectNotificationData :: ProjectId -> Transaction e (ProjectData, ResourceId, UserId)
+projectNotificationData :: (QueryA m) => ProjectId -> m (ProjectData, ResourceId, UserId)
 projectNotificationData projectId = do
-  (resourceId, ownerUserId, isPrivate) <-
-    PG.queryExpect1Row
-      [PG.sql|
+  PG.queryExpect1Row
+    [PG.sql|
       SELECT p.resource_id, p.owner_user_id, p.private
       FROM projects p
       WHERE p.id = #{projectId}
     |]
-  pure
-    ( ProjectData
-        { projectId,
-          public = not isPrivate
-        },
-      resourceId,
-      ownerUserId
-    )
+    <&> \(resourceId, ownerUserId, isPrivate) ->
+      ( ProjectData
+          { projectId,
+            public = not isPrivate
+          },
+        resourceId,
+        ownerUserId
+      )

--- a/src/Share/Postgres/Queries.hs
+++ b/src/Share/Postgres/Queries.hs
@@ -37,7 +37,7 @@ import Share.Web.Authorization.Types (RolePermission (..))
 import Share.Web.Errors (EntityMissing (EntityMissing), ErrorID (..))
 import Share.Web.Share.Branches.Types (BranchKindFilter (..))
 import Share.Web.Share.Projects.Types (ContributionStats (..), DownloadStats (..), FavData, ProjectOwner, TicketStats (..))
-import Share.Web.Share.Releases.Types (ReleaseStatusFilter (..), StatusUpdate (..))
+import Share.Web.Share.Releases.Types (ReleaseStatusFilter (..))
 import Unison.Util.List qualified as Utils
 import Unison.Util.Monoid (intercalateMap)
 
@@ -996,34 +996,6 @@ organizationMemberships uid = do
           WHERE member_user_id = #{uid}
       |]
 
-releaseById :: ReleaseId -> PG.Transaction e (Maybe (Release CausalId UserId))
-releaseById releaseId = do
-  PG.query1Row
-    [PG.sql|
-        SELECT
-          release.id,
-          release.project_id,
-          release.unsquashed_causal_id,
-          release.squashed_causal_id,
-          release.created_at,
-          release.updated_at,
-          release.created_at,
-          release.created_by,
-          release.deprecated_at,
-          release.deprecated_by,
-          release.created_by,
-          release.major_version,
-          release.minor_version,
-          release.patch_version
-        FROM project_releases AS release
-        WHERE release.id = #{releaseId}
-      |]
-
-expectReleaseById :: ReleaseId -> PG.Transaction e (Release CausalId UserId)
-expectReleaseById releaseId = do
-  mayRow <- releaseById releaseId
-  whenNothing mayRow $ unrecoverableError $ EntityMissing (ErrorID "release:missing") ("Release with id " <> IDs.toText releaseId <> " not found")
-
 releaseByProjectReleaseShortHand :: ProjectReleaseShortHand -> PG.Transaction e (Maybe (Release CausalId UserId))
 releaseByProjectReleaseShortHand ProjectReleaseShortHand {userHandle, projectSlug, releaseVersion = ReleaseVersion {major, minor, patch}} = do
   PG.query1Row
@@ -1184,45 +1156,6 @@ incrementBranchDownloads branchId = do
 
 likeEscape :: Text -> Text
 likeEscape = Text.replace "%" "\\%" . Text.replace "_" "\\_"
-
-data UpdateReleaseResult
-  = UpdateRelease'Success
-  | UpdateRelease'NotFound
-  | UpdateRelease'CantPublishDeprecated
-
-updateRelease :: UserId -> ReleaseId -> Maybe StatusUpdate -> PG.Transaction e UpdateReleaseResult
-updateRelease caller releaseId newStatus = do
-  fromMaybe UpdateRelease'NotFound <$> runMaybeT do
-    Release {..} <- lift $ expectReleaseById releaseId
-    -- Can go from draft -> published -> deprecated
-    -- or straight from draft -> deprecated
-    -- but can't go from published -> draft or deprecated -> draft.
-    case (status, newStatus) of
-      (_, Nothing) ->
-        -- No-op
-        pure UpdateRelease'Success
-      (DeprecatedRelease {}, Just MakePublished) -> do
-        pure UpdateRelease'CantPublishDeprecated
-      (PublishedRelease {}, Just MakePublished) ->
-        -- No-op
-        pure UpdateRelease'Success
-      (PublishedRelease {}, Just MakeDeprecated) -> do
-        lift makeDeprecated
-        pure UpdateRelease'Success
-      (DeprecatedRelease {}, Just MakeDeprecated) -> do
-        -- No-op
-        pure UpdateRelease'Success
-  where
-    makeDeprecated = do
-      PG.execute_
-        [PG.sql|
-          UPDATE project_releases
-          SET
-            deprecated_at = NOW(),
-            deprecated_by = #{caller}
-          WHERE
-            id = #{releaseId}
-        |]
 
 getOAuthConfigForClient :: OAuthClientId -> PG.Transaction e (Maybe OAuthClientConfig)
 getOAuthConfigForClient clientId = do

--- a/src/Share/Postgres/Queries.hs
+++ b/src/Share/Postgres/Queries.hs
@@ -24,7 +24,6 @@ import Share.Postgres qualified as PG
 import Share.Postgres.IDs
 import Share.Postgres.NameLookups.Types (NameLookupReceipt)
 import Share.Postgres.Projects.Queries qualified as ProjectsQ
-import Share.Postgres.Search.DefinitionSearch.Queries qualified as DDQ
 import Share.Postgres.Users.Queries qualified as UserQ
 import Share.Prelude
 import Share.Project
@@ -612,48 +611,6 @@ createBranch !_nlReceipt projectId branchName contributorId causalId mergeTarget
                 eventActor = creatorId
               }
       NotifQ.recordEvent notifEvent
-
-createRelease ::
-  (PG.QueryM m) =>
-  NameLookupReceipt ->
-  ProjectId ->
-  ReleaseVersion ->
-  CausalId ->
-  CausalId ->
-  UserId ->
-  m (Release CausalId UserId)
-createRelease !_nlReceipt projectId ReleaseVersion {major, minor, patch} squashedCausalId unsquashedCausalId creatorId = do
-  release@Release {releaseId} <-
-    PG.queryExpect1Row
-      [PG.sql|
-        INSERT INTO project_releases(
-          project_id,
-          created_by,
-          squashed_causal_id,
-          unsquashed_causal_id,
-          major_version,
-          minor_version,
-          patch_version
-        )
-        VALUES (#{projectId}, #{creatorId}, #{squashedCausalId}, #{unsquashedCausalId}, #{major}, #{minor}, #{patch})
-        RETURNING
-          id,
-          project_id,
-          unsquashed_causal_id,
-          squashed_causal_id,
-          created_at,
-          updated_at,
-          created_at,
-          created_by,
-          deprecated_at,
-          deprecated_by,
-          created_by,
-          major_version,
-          minor_version,
-          patch_version
-      |]
-  DDQ.submitReleaseToBeSynced releaseId
-  pure release
 
 setBranchCausalHash ::
   NameLookupReceipt ->

--- a/src/Share/Postgres/Releases/Ops.hs
+++ b/src/Share/Postgres/Releases/Ops.hs
@@ -1,0 +1,69 @@
+module Share.Postgres.Releases.Ops (createRelease) where
+
+import Share.IDs
+import Share.Notifications.Queries qualified as NotifQ
+import Share.Notifications.Types (NotificationEvent (..), NotificationEventData (..), ReleaseData (..))
+import Share.Postgres qualified as PG
+import Share.Postgres.IDs
+import Share.Postgres.NameLookups.Types (NameLookupReceipt)
+import Share.Postgres.Projects.Queries qualified as ProjectsQ
+import Share.Postgres.Search.DefinitionSearch.Queries qualified as DDQ
+import Share.Release
+
+createRelease ::
+  (PG.QueryM m) =>
+  NameLookupReceipt ->
+  ProjectId ->
+  ReleaseVersion ->
+  CausalId ->
+  CausalId ->
+  UserId ->
+  m (Release CausalId UserId)
+createRelease !_nlReceipt projectId (releaseVersion@ReleaseVersion {major, minor, patch}) squashedCausalId unsquashedCausalId creatorId = do
+  release@Release {releaseId} <-
+    PG.queryExpect1Row
+      [PG.sql|
+        INSERT INTO project_releases(
+          project_id,
+          created_by,
+          squashed_causal_id,
+          unsquashed_causal_id,
+          major_version,
+          minor_version,
+          patch_version
+        )
+        VALUES (#{projectId}, #{creatorId}, #{squashedCausalId}, #{unsquashedCausalId}, #{major}, #{minor}, #{patch})
+        RETURNING
+          id,
+          project_id,
+          unsquashed_causal_id,
+          squashed_causal_id,
+          created_at,
+          updated_at,
+          created_at,
+          created_by,
+          deprecated_at,
+          deprecated_by,
+          created_by,
+          major_version,
+          minor_version,
+          patch_version
+      |]
+  DDQ.submitReleaseToBeSynced releaseId
+  (projectData, projectResourceId, projectOwnerUserId) <- ProjectsQ.projectNotificationData projectId
+  let releaseData =
+        ReleaseData
+          { releaseId,
+            releaseVersion
+          }
+  let notifEvent =
+        NotificationEvent
+          { eventId = (),
+            eventOccurredAt = (),
+            eventResourceId = projectResourceId,
+            eventData = ProjectReleaseCreatedData projectData releaseData,
+            eventScope = projectOwnerUserId,
+            eventActor = creatorId
+          }
+  NotifQ.recordEvent notifEvent
+  pure release

--- a/src/Share/Utils/API.hs
+++ b/src/Share/Utils/API.hs
@@ -304,6 +304,7 @@ instance (Typeable a, Typeable b, FromJSON a, FromJSON b) => FromJSON (a :++ b) 
 
 -- | Wrapper useful in combination with `:++` to include the given payload at a specific key.
 newtype AtKey (key :: Symbol) a = AtKey a
+  deriving stock (Eq, Ord, Show)
 
 instance (ToJSON a, TypeLits.KnownSymbol key) => ToJSON (AtKey key a) where
   toJSON (AtKey a) = object [String.fromString (TypeLits.symbolVal (Proxy @key)) .= a]

--- a/src/Share/Web/Share/Releases/Impl.hs
+++ b/src/Share/Web/Share/Releases/Impl.hs
@@ -24,6 +24,7 @@ import Share.Postgres.Hashes.Queries qualified as HashQ
 import Share.Postgres.IDs
 import Share.Postgres.NameLookups.Ops qualified as NLOps
 import Share.Postgres.Queries qualified as Q
+import Share.Postgres.Releases.Queries qualified as ReleasesQ
 import Share.Postgres.Users.Queries qualified as UserQ
 import Share.Prelude
 import Share.Project (Project (..))
@@ -403,10 +404,10 @@ updateReleaseEndpoint session userHandle projectSlug releaseVersion UpdateReleas
   callerUserId <- AuthN.requireAuthenticatedUser session
   _authZReceipt <- AuthZ.permissionGuard $ AuthZ.checkReleaseUpdate (Just callerUserId) projectId
   PG.runTransactionOrRespondError do
-    Q.updateRelease callerUserId releaseId newStatus >>= \case
-      Q.UpdateRelease'Success -> pure ()
-      Q.UpdateRelease'NotFound -> throwSomeServerError releaseNotFound
-      Q.UpdateRelease'CantPublishDeprecated -> throwSomeServerError cantPublishDeprecated
+    ReleasesQ.updateRelease callerUserId releaseId newStatus >>= \case
+      ReleasesQ.UpdateRelease'Success -> pure ()
+      ReleasesQ.UpdateRelease'NotFound -> throwSomeServerError releaseNotFound
+      ReleasesQ.UpdateRelease'CantPublishDeprecated -> throwSomeServerError cantPublishDeprecated
   where
     releaseNotFound = EntityMissing (ErrorID "missing-release") "Release could not be found"
     cantPublishDeprecated = BadRequest "Cannot publish a release which has already been deprecated"

--- a/src/Share/Web/Share/Releases/Impl.hs
+++ b/src/Share/Web/Share/Releases/Impl.hs
@@ -24,6 +24,7 @@ import Share.Postgres.Hashes.Queries qualified as HashQ
 import Share.Postgres.IDs
 import Share.Postgres.NameLookups.Ops qualified as NLOps
 import Share.Postgres.Queries qualified as Q
+import Share.Postgres.Releases.Ops qualified as ReleaseOps
 import Share.Postgres.Releases.Queries qualified as ReleasesQ
 import Share.Postgres.Users.Queries qualified as UserQ
 import Share.Prelude
@@ -437,7 +438,7 @@ createRelease session userHandle projectSlug CreateReleaseRequest {releaseVersio
     pure (nlReceipt, squashedCausalId, unsquashedCausalId)
   -- Separate transaction to ensure squashing and name lookups make progress even on failure.
   Codebase.runCodebaseTransactionOrRespondError codebase $ do
-    release <- Q.createRelease nlReceipt projectId releaseVersion squashedCausalId unsquashedCausalId callerUserId
+    release <- ReleaseOps.createRelease nlReceipt projectId releaseVersion squashedCausalId unsquashedCausalId callerUserId
     releaseWithHandles <- forOf releaseUsers_ release \userId -> (fmap User.handle <$> UserQ.userByUserId userId) `whenNothingM` throwError (EntityMissing (ErrorID "user:missing") "Project owner not found")
     releaseWithCausalHashes <- CausalQ.expectCausalHashesByIdsOf releaseCausals_ releaseWithHandles
     User {handle = projectOwnerHandle} <- (UserQ.userByUserId ownerUserId) `whenNothingM` throwError (EntityMissing (ErrorID "user:missing") "Project owner not found")

--- a/src/Share/Web/UCM/Projects/Impl.hs
+++ b/src/Share/Web/UCM/Projects/Impl.hs
@@ -24,6 +24,7 @@ import Share.Postgres.NameLookups.Ops qualified as NLOps
 import Share.Postgres.NameLookups.Types (NameLookupReceipt)
 import Share.Postgres.Ops qualified as PGO
 import Share.Postgres.Queries qualified as Q
+import Share.Postgres.Releases.Ops qualified as ReleaseOps
 import Share.Postgres.Users.Queries qualified as UserQ
 import Share.Prelude
 import Share.Project
@@ -306,7 +307,7 @@ createProjectRelease callerUserId projectId unsquashedCausalHash releaseName = t
   (nlReceipt, squashedCausalId, squashedCausalHash) <- either (lift . respondError) pure squashResult
   signedSquashedCausalHash <- lift $ HashJWT.signHashForUser (Just callerUserId) (causalHashToHash32 squashedCausalHash)
   apiRelease <- pgT $ do
-    Release {releaseId} <- Q.createRelease nlReceipt projectId releaseName squashedCausalId unsquashedCausalId callerUserId
+    Release {releaseId} <- ReleaseOps.createRelease nlReceipt projectId releaseName squashedCausalId unsquashedCausalId callerUserId
     User {handle = projectOwnerHandle} <- UserQ.userByUserId ownerUserId `orThrow` UCMProjects.CreateProjectBranchResponseNotFound (UCMProjects.NotFound "Project owner not found")
     let projectShortHand =
           ProjectShortHand

--- a/src/Share/Web/UI/Links.hs
+++ b/src/Share/Web/UI/Links.hs
@@ -122,23 +122,30 @@ ticketCommentLink (ProjectShortHand {userHandle, projectSlug}) ticketNumber _com
   let path = [IDs.toText (PrefixedID @"@" userHandle), IDs.toText projectSlug, "tickets", IDs.toText ticketNumber]
   shareUIPath path
 
+releaseLink :: (MonadReader (Env.Env ctx) m) => ProjectShortHand -> ReleaseVersion -> m URI
+releaseLink (ProjectShortHand {userHandle, projectSlug}) releaseVersion = do
+  let path = [IDs.toText (PrefixedID @"@" userHandle), IDs.toText projectSlug, "releases", IDs.toText releaseVersion]
+  shareUIPath path
+
 -- | Where the user should go when clicking on a notification
 notificationLink :: (MonadReader (Env.Env ctx) m) => HydratedEventPayload -> m URI
 notificationLink = \case
-  HydratedProjectBranchUpdatedPayload payload ->
-    projectBranchBrowseLink payload.branchInfo.projectBranchShortHand
-  HydratedProjectContributionCreatedPayload payload ->
-    contributionLink payload.projectInfo.projectShortHand payload.contributionInfo.contributionNumber
-  HydratedProjectContributionStatusUpdatedPayload payload _status ->
-    contributionLink payload.projectInfo.projectShortHand payload.contributionInfo.contributionNumber
-  HydratedProjectContributionCommentPayload payload comment ->
-    contributionCommentLink payload.projectInfo.projectShortHand payload.contributionInfo.contributionNumber comment.commentId
-  HydratedProjectTicketCreatedPayload payload ->
-    ticketLink payload.projectInfo.projectShortHand payload.ticketInfo.ticketNumber
-  HydratedProjectTicketStatusUpdatedPayload payload _status ->
-    ticketLink payload.projectInfo.projectShortHand payload.ticketInfo.ticketNumber
-  HydratedProjectTicketCommentPayload payload comment ->
-    ticketCommentLink payload.projectInfo.projectShortHand payload.ticketInfo.ticketNumber comment.commentId
+  HydratedProjectBranchUpdatedPayload _project branch ->
+    projectBranchBrowseLink branch.projectBranchShortHand
+  HydratedProjectContributionCreatedPayload project contribution ->
+    contributionLink project.projectShortHand contribution.contributionNumber
+  HydratedProjectContributionStatusUpdatedPayload project contribution _status ->
+    contributionLink project.projectShortHand contribution.contributionNumber
+  HydratedProjectContributionCommentPayload project contribution comment ->
+    contributionCommentLink project.projectShortHand contribution.contributionNumber comment.commentId
+  HydratedProjectTicketCreatedPayload project ticket ->
+    ticketLink project.projectShortHand ticket.ticketNumber
+  HydratedProjectTicketStatusUpdatedPayload project ticket _status ->
+    ticketLink project.projectShortHand ticket.ticketNumber
+  HydratedProjectTicketCommentPayload project ticket comment ->
+    ticketCommentLink project.projectShortHand ticket.ticketNumber comment.commentId
+  HydratedProjectReleaseCreatedPayload project release ->
+    releaseLink project.projectShortHand release.releaseVersion
 
 unisonLogoImage :: URI
 unisonLogoImage =

--- a/transcripts/share-apis/notifications/create-subscription-for-other-user-project.json
+++ b/transcripts/share-apis/notifications/create-subscription-for-other-user-project.json
@@ -8,7 +8,8 @@
         "watch_project"
       ],
       "topics": [
-        "project:branch:updated"
+        "project:branch:updated",
+        "project:release:created"
       ]
     }
   },

--- a/transcripts/share-apis/notifications/list-notifications-test-paging.json
+++ b/transcripts/share-apis/notifications/list-notifications-test-paging.json
@@ -17,15 +17,17 @@
             "kind": "project:ticket:comment",
             "link": "http://<HOST>:1234/@test/publictestproject/tickets/1",
             "payload": {
-              "author": {
-                "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
-                "handle": "transcripts",
-                "name": "Transcript User",
-                "userId": "U-<UUID>"
+              "comment": {
+                "author": {
+                  "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+                  "handle": "transcripts",
+                  "name": "Transcript User",
+                  "userId": "U-<UUID>"
+                },
+                "commentId": "CMT-<UUID>",
+                "content": "This is a new comment on the ticket",
+                "createdAt": "<TIMESTAMP>"
               },
-              "commentId": "CMT-<UUID>",
-              "content": "This is a new comment on the ticket",
-              "createdAt": "<TIMESTAMP>",
               "project": {
                 "projectId": "P-<UUID>",
                 "projectOwnerHandle": "test",

--- a/transcripts/share-apis/notifications/list-notifications-test.json
+++ b/transcripts/share-apis/notifications/list-notifications-test.json
@@ -17,15 +17,17 @@
             "kind": "project:ticket:comment",
             "link": "http://<HOST>:1234/@test/publictestproject/tickets/1",
             "payload": {
-              "author": {
-                "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
-                "handle": "transcripts",
-                "name": "Transcript User",
-                "userId": "U-<UUID>"
+              "comment": {
+                "author": {
+                  "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+                  "handle": "transcripts",
+                  "name": "Transcript User",
+                  "userId": "U-<UUID>"
+                },
+                "commentId": "CMT-<UUID>",
+                "content": "This is a new comment on the ticket",
+                "createdAt": "<TIMESTAMP>"
               },
-              "commentId": "CMT-<UUID>",
-              "content": "This is a new comment on the ticket",
-              "createdAt": "<TIMESTAMP>",
               "project": {
                 "projectId": "P-<UUID>",
                 "projectOwnerHandle": "test",
@@ -134,14 +136,17 @@
             "kind": "project:contribution:comment",
             "link": "http://<HOST>:1234/@test/publictestproject/contributions/1",
             "payload": {
-              "author": {
-                "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
-                "handle": "transcripts",
-                "name": "Transcript User",
-                "userId": "U-<UUID>"
+              "comment": {
+                "author": {
+                  "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+                  "handle": "transcripts",
+                  "name": "Transcript User",
+                  "userId": "U-<UUID>"
+                },
+                "commentId": "CMT-<UUID>",
+                "content": "This is a new comment",
+                "createdAt": "<TIMESTAMP>"
               },
-              "commentId": "CMT-<UUID>",
-              "content": "This is a new comment",
               "contribution": {
                 "author": {
                   "avatarUrl": null,
@@ -171,7 +176,6 @@
                 },
                 "title": "Fix issue with user authentication"
               },
-              "createdAt": "<TIMESTAMP>",
               "project": {
                 "projectId": "P-<UUID>",
                 "projectOwnerHandle": "test",

--- a/transcripts/share-apis/notifications/list-notifications-transcripts.json
+++ b/transcripts/share-apis/notifications/list-notifications-transcripts.json
@@ -94,14 +94,61 @@
                 },
                 "title": "Fix issue with user authentication"
               },
-              "newStatus": "closed",
-              "oldStatus": "in_review",
               "project": {
                 "projectId": "P-<UUID>",
                 "projectOwnerHandle": "test",
                 "projectOwnerUserId": "U-<UUID>",
                 "projectShortHand": "@test/publictestproject",
                 "projectSlug": "publictestproject"
+              },
+              "status_update": {
+                "newStatus": "closed",
+                "oldStatus": "in_review"
+              }
+            }
+          },
+          "id": "EVENT-<UUID>",
+          "occurredAt": "<TIMESTAMP>",
+          "scope": {
+            "info": {
+              "avatarUrl": null,
+              "handle": "test",
+              "name": null,
+              "userId": "U-<UUID>"
+            },
+            "kind": "user"
+          }
+        },
+        "id": "NOT-<UUID>",
+        "status": "unread"
+      },
+      {
+        "createdAt": "<TIMESTAMP>",
+        "event": {
+          "actor": {
+            "info": {
+              "avatarUrl": null,
+              "handle": "test",
+              "name": null,
+              "userId": "U-<UUID>"
+            },
+            "kind": "user"
+          },
+          "data": {
+            "kind": "project:release:created",
+            "link": "http://<HOST>:1234/@test/publictestproject/releases/2.3.4",
+            "payload": {
+              "project": {
+                "projectId": "P-<UUID>",
+                "projectOwnerHandle": "test",
+                "projectOwnerUserId": "U-<UUID>",
+                "projectShortHand": "@test/publictestproject",
+                "projectSlug": "publictestproject"
+              },
+              "release": {
+                "createdAt": "<TIMESTAMP>",
+                "releaseId": "R-<UUID>",
+                "version": "2.3.4"
               }
             }
           },

--- a/transcripts/share-apis/notifications/list-notifications-unread-test.json
+++ b/transcripts/share-apis/notifications/list-notifications-unread-test.json
@@ -71,14 +71,17 @@
             "kind": "project:contribution:comment",
             "link": "http://<HOST>:1234/@test/publictestproject/contributions/1",
             "payload": {
-              "author": {
-                "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
-                "handle": "transcripts",
-                "name": "Transcript User",
-                "userId": "U-<UUID>"
+              "comment": {
+                "author": {
+                  "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+                  "handle": "transcripts",
+                  "name": "Transcript User",
+                  "userId": "U-<UUID>"
+                },
+                "commentId": "CMT-<UUID>",
+                "content": "This is a new comment",
+                "createdAt": "<TIMESTAMP>"
               },
-              "commentId": "CMT-<UUID>",
-              "content": "This is a new comment",
               "contribution": {
                 "author": {
                   "avatarUrl": null,
@@ -108,7 +111,6 @@
                 },
                 "title": "Fix issue with user authentication"
               },
-              "createdAt": "<TIMESTAMP>",
               "project": {
                 "projectId": "P-<UUID>",
                 "projectOwnerHandle": "test",

--- a/transcripts/share-apis/notifications/release-create.json
+++ b/transcripts/share-apis/notifications/release-create.json
@@ -1,0 +1,21 @@
+{
+  "body": {
+    "causalHashSquashed": "#sg60bvjo91fsoo7pkh9gejbn0qgc95vra87ap6l5d35ri0lkaudl7bs12d71sf3fh6p23teemuor7mk1i9n567m50ibakcghjec5ajg",
+    "causalHashUnsquashed": "#sg60bvjo91fsoo7pkh9gejbn0qgc95vra87ap6l5d35ri0lkaudl7bs12d71sf3fh6p23teemuor7mk1i9n567m50ibakcghjec5ajg",
+    "createdAt": "<TIMESTAMP>",
+    "createdBy": "@test",
+    "projectRef": "@test/publictestproject",
+    "status": {
+      "publishedAt": "<TIMESTAMP>",
+      "publishedBy": "@test",
+      "status": "published"
+    },
+    "updatedAt": "<TIMESTAMP>",
+    "version": "2.3.4"
+  },
+  "status": [
+    {
+      "status_code": 201
+    }
+  ]
+}

--- a/transcripts/share-apis/notifications/run.zsh
+++ b/transcripts/share-apis/notifications/run.zsh
@@ -25,12 +25,13 @@ fetch "$test_user" POST add-webhook-to-subscription "/users/test/notifications/s
   \"deliveryMethods\": [{\"kind\": \"webhook\",  \"id\": \"${webhook_id}\"}, {\"kind\": \"webhook\",  \"id\": \"${failing_webhook_id}\"}]
 }"
 
-# Add a subscription within the transcripts user to notifications for contributions created in any project belonging to the test user.
+# Add a subscription within the transcripts user to notifications for some select topics in any project owned by the test
+# user.
 # No filter is applied.
 fetch "$transcripts_user" POST create-subscription-for-other-user-project '/users/transcripts/notifications/subscriptions' "{
   \"scope\": \"test\",
   \"topics\": [
-    \"project:branch:updated\"
+    \"project:branch:updated\", \"project:release:created\"
   ],
   \"topicGroups\": [\"watch_project\"]
 }"
@@ -49,6 +50,15 @@ fetch "$transcripts_user" POST public-contribution-create '/users/test/projects/
     "status": "draft",
     "sourceBranchRef": "feature",
     "targetBranchRef": "main"
+}'
+
+# Create a release in a public project, which should trigger a notification for both users, but will be omitted
+# from 'test' notification list since it's a self-notification.
+fetch "$test_user" POST release-create '/users/test/projects/publictestproject/releases' '{
+    "causalHash": "#sg60bvjo91fsoo7pkh9gejbn0qgc95vra87ap6l5d35ri0lkaudl7bs12d71sf3fh6p23teemuor7mk1i9n567m50ibakcghjec5ajg",
+    "major": 2,
+    "minor": 3,
+    "patch": 4
 }'
 
 # Add a comment to a contribution, which should trigger a notification for the test user, which

--- a/transcripts/share-apis/notifications/webhook_results.txt
+++ b/transcripts/share-apis/notifications/webhook_results.txt
@@ -1,3 +1,3 @@
-Successful webhooks: 5
-Unsuccessful webhooks: 5
+Successful webhooks: 6
+Unsuccessful webhooks: 6
 


### PR DESCRIPTION
## Overview

Adds new notification topic for Project Releases

NOTE for @hojberg  this rearranges the data payloads for comments and status updates, which weren't nested under a key, but probably should have been.

AFAIK you weren't using these yet, but if you were we'll need to coordinate to deploy :) 

