### PR TITLE
Add logging within Transactions

### DIFF
--- a/src/Share/BackgroundJobs/Monad.hs
+++ b/src/Share/BackgroundJobs/Monad.hs
@@ -21,6 +21,9 @@ data BackgroundCtx = BackgroundCtx
 
 instance HasTags BackgroundCtx where
   getTags BackgroundCtx {loggingTags, workerName} = pure $ Map.singleton "workerName" workerName <> loggingTags
+  updateTags f BackgroundCtx {loggingTags, workerName} = do
+    let newTags = f loggingTags
+    pure $ BackgroundCtx {workerName, loggingTags = newTags}
 
 type Background = AppM BackgroundCtx
 

--- a/src/Share/BackgroundJobs/Monad.hs
+++ b/src/Share/BackgroundJobs/Monad.hs
@@ -12,14 +12,15 @@ where
 import Data.Map qualified as Map
 import Share.App
 import Share.Env
-import Share.Env qualified as Env
 import Share.Prelude
-import Share.Utils.Logging qualified as Logging
 
 data BackgroundCtx = BackgroundCtx
   { workerName :: Text,
     loggingTags :: Map Text Text
   }
+
+instance HasTags BackgroundCtx where
+  getTags BackgroundCtx {loggingTags, workerName} = pure $ Map.singleton "workerName" workerName <> loggingTags
 
 type Background = AppM BackgroundCtx
 
@@ -34,17 +35,6 @@ withTag key value = withTags [(key, value)]
 
 withTags :: [(Text, Text)] -> Background a -> Background a
 withTags tags = localBackgroundCtx \ctx -> ctx {loggingTags = Map.union (Map.fromList tags) (loggingTags ctx)}
-
-instance Logging.MonadLogger Background where
-  logMsg msg = do
-    log <- asks Env.logger
-    BackgroundCtx {workerName, loggingTags} <- asks ctx
-    let currentTags = Map.singleton "workerName" workerName <> loggingTags
-    msg <- pure $ msg {Logging.tags = Logging.tags msg `Map.union` currentTags}
-    minSeverity <- asks Env.minLogSeverity
-    when (Logging.severity msg >= minSeverity) $ do
-      timestamp <- asks timeCache >>= liftIO
-      liftIO . log . Logging.logFmtFormatter timestamp $ msg
 
 runBackground :: Env () -> Text -> Background a -> IO a
 runBackground env workerName bg =

--- a/src/Share/ChatApps.hs
+++ b/src/Share/ChatApps.hs
@@ -47,7 +47,7 @@ data Author = Author
   }
   deriving (Show, Eq, Ord)
 
-authorFromUserId :: UserId -> AppM reqCtx Author
+authorFromUserId :: (Env.HasTags reqCtx) => UserId -> AppM reqCtx Author
 authorFromUserId userId = do
   User {avatar_url = avatarUrl, user_name, handle} <- PG.runTransaction $ UsersQ.expectUser userId
   authorLink <- Links.userProfilePage handle

--- a/src/Share/Env.hs
+++ b/src/Share/Env.hs
@@ -64,10 +64,15 @@ data Env ctx = Env
 
 -- | A Class for different request contexts to expose their tags.
 class HasTags ctx where
-  getTags :: ctx -> IO (Map Text Text)
+  getTags :: (MonadIO m) => ctx -> m (Map Text Text)
+  updateTags :: (MonadIO m) => (Map Text Text -> Map Text Text) -> ctx -> m ctx
 
 instance (HasTags ctx) => HasTags (Env ctx) where
   getTags env = getTags (ctx env)
+  updateTags f env = do
+    ctx' <- updateTags f (ctx env)
+    pure $ env {ctx = ctx'}
 
 instance HasTags () where
   getTags _ = pure mempty
+  updateTags _ _ = pure ()

--- a/src/Share/Env.hs
+++ b/src/Share/Env.hs
@@ -1,5 +1,6 @@
 module Share.Env
   ( Env (..),
+    HasTags (..),
   )
 where
 
@@ -60,3 +61,13 @@ data Env ctx = Env
     maxParallelismPerUploadRequest :: Int
   }
   deriving (Functor)
+
+-- | A Class for different request contexts to expose their tags.
+class HasTags ctx where
+  getTags :: ctx -> IO (Map Text Text)
+
+instance (HasTags ctx) => HasTags (Env ctx) where
+  getTags env = getTags (ctx env)
+
+instance HasTags () where
+  getTags _ = pure mempty

--- a/src/Share/Metrics.hs
+++ b/src/Share/Metrics.hs
@@ -68,7 +68,7 @@ data SlowChangingMetrics = SlowChangingMetrics
   }
 
 -- | Serves the app's prometheus metrics at `/metrics`
-serveMetricsMiddleware :: Env.Env x -> IO Wai.Middleware
+serveMetricsMiddleware :: (Env.HasTags x) => Env.Env x -> IO Wai.Middleware
 serveMetricsMiddleware env = do
   Prom.register Prom.ghcMetrics
   getMetrics <- atMostOnceEveryInterval metricUpdateInterval $ do

--- a/src/Share/Postgres.hs
+++ b/src/Share/Postgres.hs
@@ -114,9 +114,14 @@ data TransactionError e
   = Unrecoverable SomeServerError
   | Err !e
 
+newtype Tags = Tags (Map Text Text)
+
+instance Env.HasTags Tags where
+  getTags (Tags tags) = pure tags
+
 -- | A transaction that may fail with an error 'e' (or throw an unrecoverable error)
-newtype Transaction e a = Transaction {unTransaction :: ReaderT (Env.Env ()) Hasql.Session (Either (TransactionError e) a)}
-  deriving (Functor, Applicative, Monad, MonadReader (Env.Env ())) via (ReaderT (Env.Env ()) (ExceptT (TransactionError e) Hasql.Session))
+newtype Transaction e a = Transaction {unTransaction :: Logging.LoggerT (ReaderT (Env.Env Tags) Hasql.Session) (Either (TransactionError e) a)}
+  deriving (Functor, Applicative, Monad, MonadReader (Env.Env Tags), Logging.MonadLogger) via (Logging.LoggerT (ReaderT (Env.Env Tags) (ExceptT (TransactionError e) Hasql.Session)))
 
 instance MonadError e (Transaction e) where
   throwError = Transaction . pure . Left . Err
@@ -132,7 +137,7 @@ newtype Pipeline e a = Pipeline {unPipeline :: Hasql.Pipeline.Pipeline (Either (
 
 -- | Run a pipeline in a transaction
 pipelined :: Pipeline e a -> Transaction e a
-pipelined p = Transaction (lift $ Hasql.pipeline (unPipeline p))
+pipelined p = Transaction (lift . lift $ Hasql.pipeline (unPipeline p))
 
 -- | Like fmap, but the provided function can throw a recoverable error by returning 'Left'.
 pEitherMap :: (a -> Either e b) -> Pipeline e a -> Pipeline e b
@@ -154,8 +159,8 @@ pFor_ f p = pipelined $ for_ f p
 type T = Transaction Void
 
 -- | A session that may fail with an error 'e'
-newtype Session e a = Session {_unSession :: ReaderT (Env.Env ()) (ExceptT (TransactionError e) Hasql.Session) a}
-  deriving newtype (Functor, Applicative, Monad, MonadReader (Env.Env ()), MonadIO, MonadError (TransactionError e))
+newtype Session e a = Session {_unSession :: Logging.LoggerT (ReaderT (Env.Env Tags) (ExceptT (TransactionError e) Hasql.Session)) a}
+  deriving newtype (Functor, Applicative, Monad, MonadReader (Env.Env Tags), MonadIO, Logging.MonadLogger, MonadError (TransactionError e))
 
 data PostgresError
   = PostgresError (Pool.UsageError)
@@ -190,9 +195,9 @@ data IsolationLevel
 -- | Run a transaction in a session
 transaction :: forall e a. IsolationLevel -> Mode -> Transaction e a -> Session e a
 transaction isoLevel mode (Transaction t) = Session do
-  let loop :: ReaderT (Env.Env ()) Session.Session (Either (TransactionError e) a)
+  let loop :: Logging.LoggerT (ReaderT (Env.Env Tags) Session.Session) (Either (TransactionError e) a)
       loop = do
-        lift $ beginTransaction isoLevel mode
+        lift . lift $ beginTransaction isoLevel mode
         res <- catchError (Just <$> mayCommit t) \case
           Session.QueryError
             _
@@ -206,25 +211,25 @@ transaction isoLevel mode (Transaction t) = Session do
           err -> do
             -- Try rolling back, but this will most likely fail since the connection has
             -- already failed. If this fails we just rethrow the original exception.
-            lift $ catchError rollbackSession (const $ throwError err)
+            lift . lift $ catchError rollbackSession (const $ throwError err)
             -- It's very important to rethrow all QueryErrors so Hasql can remove the
             -- connection from the pool.
             throwError err
         case res of
           Nothing -> do
-            lift $ rollbackSession
+            lift . lift $ rollbackSession
             loop
           Just res -> pure res
-  mapReaderT ExceptT loop
+  coerce loop
   where
-    mayCommit :: ReaderT (Env.Env ()) Hasql.Session (Either (TransactionError e) a) -> ReaderT (Env.Env ()) Hasql.Session (Either (TransactionError e) a)
+    mayCommit :: Logging.LoggerT (ReaderT (Env.Env Tags) Hasql.Session) (Either (TransactionError e) a) -> Logging.LoggerT (ReaderT (Env.Env Tags) Hasql.Session) (Either (TransactionError e) a)
     mayCommit m =
       m >>= \case
         Left err -> do
-          lift rollbackSession
+          lift . lift $ rollbackSession
           pure (Left err)
         Right a -> do
-          lift commit
+          lift . lift $ commit
           pure (Right a)
 
 beginTransaction :: IsolationLevel -> Mode -> Hasql.Session ()
@@ -254,7 +259,7 @@ rollback e = Transaction do
 
 transactionStatement :: a -> Hasql.Statement a b -> Transaction e b
 transactionStatement v stmt = Transaction do
-  Right <$> lift (Session.statement v stmt)
+  Right <$> (lift . lift $ (Session.statement v stmt))
 
 -- | Run a read-only transaction within a session
 readTransaction :: Transaction e a -> Session e a
@@ -272,20 +277,20 @@ writeTransaction t = transaction defaultIsolationLevel ReadWrite t
 --
 -- Uses a Write transaction for simplicity since there's not much
 -- benefit in distinguishing transaction types.
-runTransaction :: (MonadReader (Env.Env x) m, MonadIO m, HasCallStack) => Transaction Void a -> m a
+runTransaction :: (MonadReader (Env.Env ctx) m, MonadIO m, HasCallStack, Env.HasTags ctx) => Transaction Void a -> m a
 runTransaction t = runSession (writeTransaction t)
 
-runTransactionMode :: (MonadReader (Env.Env x) m, MonadIO m, HasCallStack) => IsolationLevel -> Mode -> Transaction Void a -> m a
+runTransactionMode :: (MonadReader (Env.Env ctx) m, MonadIO m, HasCallStack, Env.HasTags ctx) => IsolationLevel -> Mode -> Transaction Void a -> m a
 runTransactionMode isoLevel mode t = runSession (transaction isoLevel mode t)
 
 -- | Run a transaction in the App monad, returning an Either error.
 --
 -- Uses a Write transaction for simplicity since there's not much
 -- benefit in distinguishing transaction types.
-tryRunTransaction :: (MonadReader (Env.Env x) m, MonadIO m, HasCallStack) => Transaction e a -> m (Either e a)
+tryRunTransaction :: (MonadReader (Env.Env ctx) m, MonadIO m, HasCallStack, Env.HasTags ctx) => Transaction e a -> m (Either e a)
 tryRunTransaction t = tryRunSession (writeTransaction t)
 
-tryRunTransactionMode :: (MonadReader (Env.Env x) m, MonadIO m, HasCallStack) => IsolationLevel -> Mode -> Transaction e a -> m (Either e a)
+tryRunTransactionMode :: (MonadReader (Env.Env ctx) m, MonadIO m, HasCallStack, Env.HasTags ctx) => IsolationLevel -> Mode -> Transaction e a -> m (Either e a)
 tryRunTransactionMode isoLevel mode t = tryRunSession (transaction isoLevel mode t)
 
 -- | Run a transaction in the App monad, responding to the request with an error if it fails.
@@ -299,33 +304,39 @@ runTransactionOrRespondError t = runSessionOrRespondError (writeTransaction t)
 --
 -- Uses a Write transaction for simplicity since there's not much
 -- benefit in distinguishing transaction types.
-unliftTransaction :: Transaction e a -> AppM x (IO (Either e a))
+unliftTransaction :: (Env.HasTags ctx) => Transaction e a -> AppM ctx (IO (Either e a))
 unliftTransaction t = unliftSession (writeTransaction t)
 
 -- | Run a session in the App monad without any errors.
-runSession :: (MonadReader (Env.Env x) m, MonadIO m, HasCallStack) => Session Void a -> m a
+runSession :: (MonadReader (Env.Env ctx) m, MonadIO m, HasCallStack, Env.HasTags ctx) => Session Void a -> m a
 runSession t = either absurd id <$> tryRunSession t
 
 -- | Run a session in the App monad, returning an Either error.
-tryRunSession :: (MonadReader (Env.Env x) m, MonadIO m, HasCallStack) => Session e a -> m (Either e a)
+tryRunSession :: (MonadReader (Env.Env ctx) m, MonadIO m, HasCallStack, Env.HasTags ctx) => Session e a -> m (Either e a)
 tryRunSession s = do
   env <- ask
   liftIO $ tryRunSessionWithEnv env s
 
 -- | Unlift a session to run in IO.
-unliftSession :: Session e a -> AppM x (IO (Either e a))
+unliftSession :: (Env.HasTags ctx) => Session e a -> AppM ctx (IO (Either e a))
 unliftSession s = do
   env <- ask
   pure $ tryRunSessionWithEnv env s
 
 -- | Manually run an unfailing session using the connection pool from the provided env.
-runSessionWithEnv :: (HasCallStack) => Env.Env any -> Session Void a -> IO a
+runSessionWithEnv :: (HasCallStack, Env.HasTags ctx) => Env.Env ctx -> Session Void a -> IO a
 runSessionWithEnv env s = either absurd id <$> tryRunSessionWithEnv env s
 
 -- | Manually run a session, using the connection pool from the provided env, returning an Either error.
-tryRunSessionWithEnv :: (HasCallStack) => Env.Env any -> Session e a -> IO (Either e a)
-tryRunSessionWithEnv env@(Env.Env {pgConnectionPool = pool}) (Session s) = do
-  liftIO (Pool.use pool (runExceptT $ runReaderT s (void env))) >>= \case
+tryRunSessionWithEnv :: (HasCallStack, Env.HasTags ctx) => Env.Env ctx -> Session e a -> IO (Either e a)
+tryRunSessionWithEnv env@(Env.Env {pgConnectionPool = pool, minLogSeverity, logger, timeCache}) (Session s) = do
+  tags <- Env.getTags env
+  let ioSession =
+        s
+          & Logging.runLoggerT minLogSeverity logger tags timeCache
+          & flip runReaderT (env $> Tags tags)
+          & runExceptT
+  liftIO (Pool.use pool ioSession) >>= \case
     Left err -> throwIO . someServerError $ PostgresError err
     Right (Left (Unrecoverable e)) -> throwIO e
     Right (Left (Err e)) -> pure (Left e)
@@ -353,7 +364,7 @@ class (Applicative m) => QueryA m where
       Right y -> pure y
       Left e -> unrecoverableError e
 
-class (Monad m, QueryA m) => QueryM m where
+class (Logging.MonadLogger m, QueryA m) => QueryM m where
   -- | Allow running IO actions in a transaction. These actions may be run multiple times if
   -- the transaction is retried.
   transactionUnsafeIO :: IO a -> m a
@@ -375,7 +386,7 @@ instance QueryM (Transaction e) where
 
 instance QueryA (Session e) where
   statement q s =
-    Session . lift . lift $ Session.statement q s
+    Session . lift . lift . lift $ Session.statement q s
 
   unrecoverableError e = do
     throwError (Unrecoverable (someServerError e))

--- a/src/Share/Postgres/Notifications.hs
+++ b/src/Share/Postgres/Notifications.hs
@@ -48,7 +48,7 @@ initialize scope = Ki.fork_ scope $ forever do
         PG.statement () $ Hasql.listen (Hasql.Identifier . Text.encodeUtf8 $ toChannelText kind)
       -- Wait for notifications
       let loop = do
-            Hasql.Notification {channel} <- PG.Session . lift . lift $ Hasql.await
+            Hasql.Notification {channel} <- PG.Session . lift . lift . lift $ Hasql.await
             fromChannelText channel & \case
               Just kind -> do
                 liftIO . STM.atomically $ STM.modifyTVar' notifs $ Set.insert kind

--- a/src/Share/Web/App.hs
+++ b/src/Share/Web/App.hs
@@ -70,6 +70,10 @@ instance HasTags RequestCtx where
     reqTags <- liftIO $ readTVarIO reqTagsVar
     -- local tags take precedence over request tags
     pure $ localTags <> reqTags
+  updateTags f reqCtx = do
+    tags <- getTags reqCtx
+    let newTags = f tags
+    pure $ reqCtx {localTags = newTags <> localTags reqCtx}
 
 -- | Add a tag to the current request. This tag will be used in logging and error reports
 addRequestTag :: (MonadReader (Env RequestCtx) m, MonadIO m) => Text -> Text -> m ()

--- a/src/Share/Web/App.hs
+++ b/src/Share/Web/App.hs
@@ -22,10 +22,8 @@ import Servant
 import Servant.Server.Generic (AsServerT)
 import Share.App
 import Share.Env
-import Share.Env qualified as Env
 import Share.IDs (RequestId, UserId)
 import Share.Prelude
-import Share.Utils.Logging
 import UnliftIO.STM
 
 type WebApp = AppM RequestCtx
@@ -50,16 +48,6 @@ data RequestCtx = RequestCtx
     rawURI :: Maybe URI
   }
 
-instance MonadLogger WebApp where
-  logMsg msg = do
-    log <- asks Env.logger
-    currentTags <- getTags
-    msg <- pure $ msg {tags = tags msg `Map.union` currentTags}
-    minSeverity <- asks Env.minLogSeverity
-    when (severity msg >= minSeverity) $ do
-      timestamp <- asks timeCache >>= liftIO
-      liftIO . log . logFmtFormatter timestamp $ msg
-
 -- | Generate an empty request context
 freshRequestCtx :: (MonadIO m) => m RequestCtx
 freshRequestCtx = do
@@ -76,13 +64,12 @@ freshRequestCtx = do
         }
     )
 
--- | Get the tags associated with the current request.
-getTags :: (MonadReader (Env RequestCtx) m, MonadIO m) => m (Map Text Text)
-getTags = do
-  RequestCtx {reqTagsVar, localTags} <- asks ctx
-  reqTags <- liftIO $ readTVarIO reqTagsVar
-  -- local tags take precedence over request tags
-  pure $ localTags <> reqTags
+instance HasTags RequestCtx where
+  -- Get the tags associated with the current request.
+  getTags RequestCtx {reqTagsVar, localTags} = do
+    reqTags <- liftIO $ readTVarIO reqTagsVar
+    -- local tags take precedence over request tags
+    pure $ localTags <> reqTags
 
 -- | Add a tag to the current request. This tag will be used in logging and error reports
 addRequestTag :: (MonadReader (Env RequestCtx) m, MonadIO m) => Text -> Text -> m ()

--- a/src/Share/Web/Errors.hs
+++ b/src/Share/Web/Errors.hs
@@ -90,9 +90,9 @@ instance (Show a, TL.KnownNat errStatus, TL.KnownSymbol errorMsg) => Loggable (S
   toLog (SimpleServerError err) =
     let severity =
           if
-              | status < 400 -> Info
-              | status < 500 -> UserFault
-              | otherwise -> Error
+            | status < 400 -> Info
+            | status < 500 -> UserFault
+            | otherwise -> Error
      in Logging.textLog (errMsg <> ": " <> tShow err)
           & withSeverity severity
     where
@@ -182,7 +182,7 @@ reportError e = do
   let (ErrorID errID, serverErr) = toServerError e
   env <- ask
   RequestCtx {pathInfo, rawURI} <- asks Env.ctx
-  reqTags <- getTags
+  reqTags <- liftIO $ getTags env
   let errLog@LogMsg {msg} = withTag ("error-id", errID) $ toLog e
   -- We emit a separate log message for each error, but it's also
   -- handy to have that data on the main log for the request.

--- a/src/Share/Web/UCM/Sync/Impl.hs
+++ b/src/Share/Web/UCM/Sync/Impl.hs
@@ -42,7 +42,6 @@ import Share.Postgres.Users.Queries qualified as UserQ
 import Share.Prelude
 import Share.Project (Project (..))
 import Share.User (User (..))
-import Share.Utils.Logging
 import Share.Utils.Logging qualified as Logging
 import Share.Utils.Servant (parseParam)
 import Share.Web.App
@@ -228,7 +227,7 @@ uploadEntitiesEndpoint callingUserId (UploadEntitiesRequest {repoInfo, entities}
 -- | Insert entities to the user's codebase (either temp storage or main), returning the hashes of any missing dependencies
 -- we still need from the client.
 insertEntitiesToCodebase ::
-  (MonadLogger (AppM r), Env.HasTags r) =>
+  (Env.HasTags r) =>
   CodebaseEnv ->
   NEMap Hash32 (Sync.Entity Text Hash32 Hash32) ->
   AppM r (Either Sync.EntityValidationError (Maybe (NESet Hash32)))


### PR DESCRIPTION
## Overview

Rewrites logging instances to allow us to log within transactions.
If a transaction is retried, it will re-log, but the duplicate logs will be tagged indicating as such.
