### PR TITLE
Don't always auto-insert component hashes on lookup

### DIFF
--- a/src/Share/Names/Postgres.hs
+++ b/src/Share/Names/Postgres.hs
@@ -22,6 +22,7 @@ namesForReferences namesPerspective refs = do
   withPGRefs <-
     Set.toList refs
       & CV.labeledDependencies1ToValidPGRefs
+      & PG.pipelined
   (termNames, typeNames) <- foldMapM namesForReference withPGRefs
   pure $ Names.fromTermsAndTypes termNames typeNames
   where

--- a/src/Share/Names/Postgres.hs
+++ b/src/Share/Names/Postgres.hs
@@ -21,7 +21,7 @@ namesForReferences :: forall m. (PG.QueryM m) => NamesPerspective -> Set Labeled
 namesForReferences namesPerspective refs = do
   withPGRefs <-
     Set.toList refs
-      & CV.labeledDependencies1ToPG
+      & CV.labeledDependencies1ToValidPGRefs
   (termNames, typeNames) <- foldMapM namesForReference withPGRefs
   pure $ Names.fromTermsAndTypes termNames typeNames
   where

--- a/src/Share/Names/Postgres.hs
+++ b/src/Share/Names/Postgres.hs
@@ -21,7 +21,8 @@ namesForReferences :: forall m. (PG.QueryM m) => NamesPerspective -> Set Labeled
 namesForReferences namesPerspective refs = do
   withPGRefs <-
     Set.toList refs
-      & CV.labeledDependencies1ToValidPGRefs
+      & CV.labeledDependencies1ToPG
+      & fmap catMaybes -- Filter out any missing components
       & PG.pipelined
   (termNames, typeNames) <- foldMapM namesForReference withPGRefs
   pure $ Names.fromTermsAndTypes termNames typeNames

--- a/src/Share/Postgres/NameLookups/Conversions.hs
+++ b/src/Share/Postgres/NameLookups/Conversions.hs
@@ -10,9 +10,6 @@ module Share.Postgres.NameLookups.Conversions
     referencesPGTo2Of,
     referentsPGTo1UsingCTOf,
     referentsPGTo2Of,
-    namedReferentsWithCT2ToPG,
-    namedReferents2ToPG,
-    namedReferences2ToPG,
     labeledDependencies1ToPG,
   )
 where
@@ -21,7 +18,6 @@ import Control.Lens
 import Share.Postgres qualified as PG
 import Share.Postgres.Hashes.Queries qualified as Hashes
 import Share.Postgres.IDs (ComponentHash (..))
-import Share.Postgres.NameLookups.Types
 import Share.Postgres.Refs.Types
 import Share.Prelude
 import U.Codebase.Reference qualified as V2
@@ -89,33 +85,6 @@ referentsPGTo2Of trav s =
   s
     -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
     & unsafePartsOf (trav . V2.refs_ . V2.h_) %%~ (fmap coerce . Hashes.expectComponentHashesOf traversed)
-
--- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferentsWithCT2ToPG :: (PG.QueryA m) => [NamedRef (V2.Referent, Maybe V2.ConstructorType)] -> m [NamedRef (PGReferent, Maybe V2.ConstructorType)]
-namedReferentsWithCT2ToPG refs =
-  refs
-    &
-    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
-    unsafePartsOf (traversed . ref_ . _1 . V2.refs_ . V2.h_)
-      %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
-
--- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferents2ToPG :: (PG.QueryA m) => [NamedRef V2.Referent] -> m [NamedRef PGReferent]
-namedReferents2ToPG refs =
-  refs
-    &
-    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
-    unsafePartsOf (traversed . ref_ . V2.refs_ . V2.h_)
-      %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
-
--- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferences2ToPG :: (PG.QueryA m) => [NamedRef V2.Reference] -> m [NamedRef PGReference]
-namedReferences2ToPG refs =
-  refs
-    &
-    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
-    unsafePartsOf (traversed . ref_ . V2.h_)
-      %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
 -- | This is similar to `labeledDependencies1ToPG`, but it filters out refs for components
 -- which don't exist on Share, e.g. generated accessors.

--- a/src/Share/Postgres/NameLookups/Conversions.hs
+++ b/src/Share/Postgres/NameLookups/Conversions.hs
@@ -143,7 +143,7 @@ namedReferences2ToPG refs =
     unsafePartsOf (traversed . ref_ . V2.h_)
       %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-labeledDependencies1ToPG :: (PG.QueryM m) => [LD.LabeledDependency] -> m [Either (V1.Referent, PGReferent) (V1.Reference, PGReference)]
+labeledDependencies1ToPG :: (PG.QueryA m) => [LD.LabeledDependency] -> m [Either (V1.Referent, PGReferent) (V1.Reference, PGReference)]
 labeledDependencies1ToPG refs =
   refs
     & map \case
@@ -156,7 +156,7 @@ labeledDependencies1ToPG refs =
 
 -- | This is similar to `labeledDependencies1ToPG`, but it filters out refs for components
 -- which don't exist on Share, e.g. generated accessors.
-labeledDependencies1ToValidPGRefs :: (PG.QueryM m) => [LD.LabeledDependency] -> m [Either (V1.Referent, PGReferent) (V1.Reference, PGReference)]
+labeledDependencies1ToValidPGRefs :: (PG.QueryA m) => [LD.LabeledDependency] -> m [Either (V1.Referent, PGReferent) (V1.Reference, PGReference)]
 labeledDependencies1ToValidPGRefs refs =
   refs
     & map \case

--- a/src/Share/Postgres/NameLookups/Conversions.hs
+++ b/src/Share/Postgres/NameLookups/Conversions.hs
@@ -2,9 +2,9 @@
 -- Strongly prefer converting in batches using the plural combinators, they're much more
 -- efficient than converting in a loop.
 module Share.Postgres.NameLookups.Conversions
-  ( references1ToPG,
+  ( references1ToPGOf,
     references2ToPG,
-    referents1ToPG,
+    referents1ToPGOf,
     referents2ToPG,
     referencesPGTo1Of,
     referencesPGTo2Of,
@@ -33,27 +33,31 @@ import Unison.LabeledDependency qualified as LD
 import Unison.Reference qualified as V1
 import Unison.Referent qualified as V1
 
-references1ToPG :: (Traversable t, PG.QueryM m) => t V1.Reference -> m (t PGReference)
-references1ToPG refs =
-  refs
-    & fmap Cv.reference1to2
+references1ToPGOf :: (PG.QueryA m) => Traversal s t V1.Reference PGReference -> s -> m t
+references1ToPGOf trav s =
+  s
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
-    & unsafePartsOf (traversed . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
+    & unsafePartsOf trav %%~ \ref1s -> do
+      let ref2s = map Cv.reference1to2 ref1s
+      Hashes.ensureComponentHashIdsOf (traversed . V2.h_ . componentHashAsUHash_) ref2s
 
-references2ToPG :: (Traversable t, PG.QueryM m) => t V2.Reference -> m (t PGReference)
+references2ToPG :: (Traversable t, PG.QueryA m) => t V2.Reference -> m (t PGReference)
 references2ToPG refs =
   refs
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
     & unsafePartsOf (traversed . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-referents1ToPG :: (Traversable t, PG.QueryM m) => t V1.Referent -> m (t PGReferent)
-referents1ToPG refs =
-  refs
-    & fmap Cv.referent1to2
+referents1ToPGOf :: (PG.QueryA m) => Traversal s t V1.Referent PGReferent -> s -> m t
+referents1ToPGOf trav s =
+  s
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
-    & unsafePartsOf (traversed . V2.refs_ . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
+    & unsafePartsOf trav %%~ \ref1s -> do
+      let ref2s = map Cv.referent1to2 ref1s
+      -- We traverse the hashes on both the referents and references at once, then convert them
+      -- all to ComponentHashIDs in a single batch.
+      Hashes.ensureComponentHashIdsOf (traversed . V2.refs_ . V2.h_ . componentHashAsUHash_) ref2s
 
-referents2ToPG :: (Traversable t, PG.QueryM m) => t V2.Referent -> m (t PGReferent)
+referents2ToPG :: (Traversable t, PG.QueryA m) => t V2.Referent -> m (t PGReferent)
 referents2ToPG refs =
   refs
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
@@ -65,16 +69,13 @@ referencesPGTo1Of trav s =
     -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
     & Hashes.expectComponentHashesOf (trav . V2.h_ . uHashAsComponentHash_)
 
-uHashAsComponentHash_ :: Traversal ComponentHashId UHash.Hash ComponentHashId ComponentHash
-uHashAsComponentHash_ = coerced
-
 referencesPGTo2Of :: (PG.QueryA m) => Traversal s t PGReference V2.Reference -> s -> m t
 referencesPGTo2Of trav s =
   s
     -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
     & unsafePartsOf (trav . V2.h_) %%~ fmap coerce . Hashes.expectComponentHashesOf traversed
 
-referentsPGTo1UsingCTOf :: (PG.QueryM m, HasCallStack) => Traversal s t (PGReferent, Maybe V2.ConstructorType) V1.Referent -> s -> m t
+referentsPGTo1UsingCTOf :: (PG.QueryA m, HasCallStack) => Traversal s t (PGReferent, Maybe V2.ConstructorType) V1.Referent -> s -> m t
 referentsPGTo1UsingCTOf trav s =
   s
     -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
@@ -89,7 +90,7 @@ referentsPGTo2Of trav s =
     & unsafePartsOf (trav . V2.refs_ . V2.h_) %%~ (fmap coerce . Hashes.expectComponentHashesOf traversed)
 
 -- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferentsWithCT2ToPG :: (PG.QueryM m) => [NamedRef (V2.Referent, Maybe V2.ConstructorType)] -> m [NamedRef (PGReferent, Maybe V2.ConstructorType)]
+namedReferentsWithCT2ToPG :: (PG.QueryA m) => [NamedRef (V2.Referent, Maybe V2.ConstructorType)] -> m [NamedRef (PGReferent, Maybe V2.ConstructorType)]
 namedReferentsWithCT2ToPG refs =
   refs
     &
@@ -98,7 +99,7 @@ namedReferentsWithCT2ToPG refs =
       %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
 -- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferents2ToPG :: (PG.QueryM m) => [NamedRef V2.Referent] -> m [NamedRef PGReferent]
+namedReferents2ToPG :: (PG.QueryA m) => [NamedRef V2.Referent] -> m [NamedRef PGReferent]
 namedReferents2ToPG refs =
   refs
     &
@@ -107,7 +108,7 @@ namedReferents2ToPG refs =
       %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
 -- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferences2ToPG :: (PG.QueryM m) => [NamedRef V2.Reference] -> m [NamedRef PGReference]
+namedReferences2ToPG :: (PG.QueryA m) => [NamedRef V2.Reference] -> m [NamedRef PGReference]
 namedReferences2ToPG refs =
   refs
     &
@@ -140,3 +141,11 @@ labeledDependencies1ToValidPGRefs refs =
     & unsafePartsOf (traversed . beside (_2 . V2.refs_) (_2) . V2.h_) %%~ (Hashes.componentHashIdsOf traversed . fmap ComponentHash)
     <&> fmap (sequenceOf (beside (_2 . V2.refs_) _2 . V2.h_))
     <&> catMaybes
+
+-- | Helper iso for coercing between ComponentHash and UHash.Hash
+uHashAsComponentHash_ :: Iso ComponentHashId UHash.Hash ComponentHashId ComponentHash
+uHashAsComponentHash_ = coerced
+
+-- | Helper iso for coercing between UHash.Hash ComponentHash
+componentHashAsUHash_ :: Iso UHash.Hash ComponentHashId ComponentHash ComponentHashId
+componentHashAsUHash_ = coerced

--- a/src/Share/Postgres/NameLookups/Conversions.hs
+++ b/src/Share/Postgres/NameLookups/Conversions.hs
@@ -31,7 +31,7 @@ import Unison.Referent qualified as V1
 references1ToPGOf :: (PG.QueryA m) => Traversal s t V1.Reference (Maybe PGReference) -> s -> m t
 references1ToPGOf trav s =
   s
-    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
+    -- This is safe here because we always return the same number of elements as we're given
     & unsafePartsOf trav %%~ \ref1s -> do
       let ref2s = map Cv.reference1to2 ref1s
       references2ToPGOf traversed ref2s
@@ -39,14 +39,14 @@ references1ToPGOf trav s =
 references2ToPGOf :: (PG.QueryA m) => Traversal s t V2.Reference (Maybe PGReference) -> s -> m t
 references2ToPGOf trav s =
   s
-    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
+    -- This is safe here because we always return the same number of elements as we're given
     & unsafePartsOf trav %%~ \ref2s -> do
       fmap (sequenceAOf (V2.h_)) <$> Hashes.componentHashIdsOf (traversed . V2.h_ . componentHashAsUHash_) ref2s
 
 referents1ToPGOf :: (PG.QueryA m) => Traversal s t V1.Referent (Maybe PGReferent) -> s -> m t
 referents1ToPGOf trav s =
   s
-    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
+    -- This is safe here because we always return the same number of elements as we're given
     & unsafePartsOf trav %%~ \ref1s -> do
       let ref2s = map Cv.referent1to2 ref1s
       referents2ToPGOf traversed ref2s
@@ -54,7 +54,7 @@ referents1ToPGOf trav s =
 referents2ToPGOf :: (PG.QueryA m) => Traversal s t V2.Referent (Maybe PGReferent) -> s -> m t
 referents2ToPGOf trav s =
   s
-    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
+    -- This is safe here because we always return the same number of elements as we're given
     & unsafePartsOf trav %%~ \ref2s -> do
       -- We traverse the hashes on both the referents and references at once, then convert them
       -- all to ComponentHashIDs in a single batch.
@@ -63,19 +63,19 @@ referents2ToPGOf trav s =
 referencesPGTo1Of :: (PG.QueryA m) => Traversal s t PGReference V1.Reference -> s -> m t
 referencesPGTo1Of trav s =
   s
-    -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
+    -- This is safe here because we always return the same number of elements as we're given
     & Hashes.expectComponentHashesOf (trav . V2.h_ . uHashAsComponentHash_)
 
 referencesPGTo2Of :: (PG.QueryA m) => Traversal s t PGReference V2.Reference -> s -> m t
 referencesPGTo2Of trav s =
   s
-    -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
+    -- This is safe here because we always return the same number of elements as we are given
     & unsafePartsOf (trav . V2.h_) %%~ fmap coerce . Hashes.expectComponentHashesOf traversed
 
 referentsPGTo1UsingCTOf :: (PG.QueryA m, HasCallStack) => Traversal s t (PGReferent, Maybe V2.ConstructorType) V1.Referent -> s -> m t
 referentsPGTo1UsingCTOf trav s =
   s
-    -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
+    -- This is safe here because we always return the same number of elements as we are given
     & unsafePartsOf trav %%~ \refs -> do
       (Hashes.expectComponentHashesOf (traversed . _1 . V2.refs_ . V2.h_ . uHashAsComponentHash_) refs)
         <&> fmap \(ref', mayCT) -> (Cv.referent2to1UsingCT (fromMaybe (error "referentsPGTo1UsingCT: missing Constructor Type") mayCT) ref')
@@ -83,7 +83,7 @@ referentsPGTo1UsingCTOf trav s =
 referentsPGTo2Of :: (PG.QueryA m) => Traversal s t PGReferent V2.Referent -> s -> m t
 referentsPGTo2Of trav s =
   s
-    -- This is safe here because ensureComponentHashes always returns the same number of elements as it is given
+    -- This is safe here because we always return the same number of elements as we are given
     & unsafePartsOf (trav . V2.refs_ . V2.h_) %%~ (fmap coerce . Hashes.expectComponentHashesOf traversed)
 
 -- | This is similar to `labeledDependencies1ToPG`, but it filters out refs for components
@@ -94,7 +94,7 @@ labeledDependencies1ToPG refs =
     & map \case
       LD.TermReferent r -> Left (r, Cv.referent1to2 r)
       LD.TypeReference r -> Right (r, Cv.reference1to2 r)
-    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
+    -- This is safe here because we always return the same number of elements as we're given
     -- We traverse the hashes on both the referents and references at once, then convert them
     -- all to ComponentHashIDs in a single batch.
     & unsafePartsOf (traversed . beside (_2 . V2.refs_) (_2) . V2.h_) %%~ (Hashes.componentHashIdsOf traversed . fmap ComponentHash)

--- a/src/Share/Postgres/NameLookups/Conversions.hs
+++ b/src/Share/Postgres/NameLookups/Conversions.hs
@@ -22,6 +22,7 @@ module Share.Postgres.NameLookups.Conversions
     namedReferents2ToPG,
     namedReferences2ToPG,
     labeledDependencies1ToPG,
+    labeledDependencies1ToValidPGRefs,
   )
 where
 
@@ -39,7 +40,7 @@ import Unison.LabeledDependency qualified as LD
 import Unison.Reference qualified as V1
 import Unison.Referent qualified as V1
 
-reference1ToPG :: PG.QueryM m => V1.Reference -> m PGReference
+reference1ToPG :: (PG.QueryM m) => V1.Reference -> m PGReference
 reference1ToPG = fmap runIdentity . references1ToPG . Identity
 
 references1ToPG :: (Traversable t, PG.QueryM m) => t V1.Reference -> m (t PGReference)
@@ -49,7 +50,7 @@ references1ToPG refs =
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
     & unsafePartsOf (traversed . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-reference2ToPG :: PG.QueryM m => V2.Reference -> m PGReference
+reference2ToPG :: (PG.QueryM m) => V2.Reference -> m PGReference
 reference2ToPG = fmap runIdentity . references2ToPG . Identity
 
 references2ToPG :: (Traversable t, PG.QueryM m) => t V2.Reference -> m (t PGReference)
@@ -58,7 +59,7 @@ references2ToPG refs =
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
     & unsafePartsOf (traversed . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-referent1ToPG :: PG.QueryM m => V1.Referent -> m PGReferent
+referent1ToPG :: (PG.QueryM m) => V1.Referent -> m PGReferent
 referent1ToPG = fmap runIdentity . referents1ToPG . Identity
 
 referents1ToPG :: (Traversable t, PG.QueryM m) => t V1.Referent -> m (t PGReferent)
@@ -68,7 +69,7 @@ referents1ToPG refs =
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
     & unsafePartsOf (traversed . V2.refs_ . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-referent2ToPG :: PG.QueryM m => V2.Referent -> m PGReferent
+referent2ToPG :: (PG.QueryM m) => V2.Referent -> m PGReferent
 referent2ToPG = fmap runIdentity . referents2ToPG . Identity
 
 referents2ToPG :: (Traversable t, PG.QueryM m) => t V2.Referent -> m (t PGReferent)
@@ -77,7 +78,7 @@ referents2ToPG refs =
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
     & unsafePartsOf (traversed . V2.refs_ . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-referencePGTo1 :: PG.QueryM m => PGReference -> m V1.Reference
+referencePGTo1 :: (PG.QueryM m) => PGReference -> m V1.Reference
 referencePGTo1 = fmap runIdentity . referencesPGTo1 . Identity
 
 referencesPGTo1 :: (PG.QueryM m, Traversable t) => t PGReference -> m (t V1.Reference)
@@ -87,7 +88,7 @@ referencesPGTo1 refs =
     & unsafePartsOf (traversed . V2.h_) %%~ fmap coerce . Hashes.expectComponentHashesOf traversed
     <&> fmap Cv.reference2to1
 
-referencePGTo2 :: PG.QueryM m => PGReference -> m V2.Reference
+referencePGTo2 :: (PG.QueryM m) => PGReference -> m V2.Reference
 referencePGTo2 = referencesPGTo2Of id
 
 referencesPGTo2Of :: (PG.QueryM m) => Traversal s t PGReference V2.Reference -> s -> m t
@@ -106,7 +107,7 @@ referentsPGTo1UsingCT refs =
     & unsafePartsOf (traversed . _1 . V2.refs_ . V2.h_) %%~ (fmap coerce . Hashes.expectComponentHashesOf traversed)
     <&> fmap (\(ref, mayCT) -> Cv.referent2to1UsingCT (fromMaybe (error "referentsPGTo1UsingCT: missing Constructor Type") mayCT) ref)
 
-referentPGTo2 :: PG.QueryM m => PGReferent -> m V2.Referent
+referentPGTo2 :: (PG.QueryM m) => PGReferent -> m V2.Referent
 referentPGTo2 = referentsPGTo2Of id
 
 referentsPGTo2Of :: (PG.QueryM m) => Traversal s t PGReferent V2.Referent -> s -> m t
@@ -116,7 +117,7 @@ referentsPGTo2Of trav s =
     & unsafePartsOf (trav . V2.refs_ . V2.h_) %%~ (fmap coerce . Hashes.expectComponentHashesOf traversed)
 
 -- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferentsWithCT2ToPG :: PG.QueryM m => [NamedRef (V2.Referent, Maybe V2.ConstructorType)] -> m [NamedRef (PGReferent, Maybe V2.ConstructorType)]
+namedReferentsWithCT2ToPG :: (PG.QueryM m) => [NamedRef (V2.Referent, Maybe V2.ConstructorType)] -> m [NamedRef (PGReferent, Maybe V2.ConstructorType)]
 namedReferentsWithCT2ToPG refs =
   refs
     &
@@ -125,7 +126,7 @@ namedReferentsWithCT2ToPG refs =
       %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
 -- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferents2ToPG :: PG.QueryM m => [NamedRef V2.Referent] -> m [NamedRef PGReferent]
+namedReferents2ToPG :: (PG.QueryM m) => [NamedRef V2.Referent] -> m [NamedRef PGReferent]
 namedReferents2ToPG refs =
   refs
     &
@@ -134,7 +135,7 @@ namedReferents2ToPG refs =
       %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
 -- | Batch convert named refs, ensuring we also have a hash saved for each ref.
-namedReferences2ToPG :: PG.QueryM m => [NamedRef V2.Reference] -> m [NamedRef PGReference]
+namedReferences2ToPG :: (PG.QueryM m) => [NamedRef V2.Reference] -> m [NamedRef PGReference]
 namedReferences2ToPG refs =
   refs
     &
@@ -142,7 +143,7 @@ namedReferences2ToPG refs =
     unsafePartsOf (traversed . ref_ . V2.h_)
       %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-labeledDependencies1ToPG :: PG.QueryM m => [LD.LabeledDependency] -> m [Either (V1.Referent, PGReferent) (V1.Reference, PGReference)]
+labeledDependencies1ToPG :: (PG.QueryM m) => [LD.LabeledDependency] -> m [Either (V1.Referent, PGReferent) (V1.Reference, PGReference)]
 labeledDependencies1ToPG refs =
   refs
     & map \case
@@ -152,3 +153,18 @@ labeledDependencies1ToPG refs =
     -- We traverse the hashes on both the referents and references at once, then convert them
     -- all to ComponentHashIDs in a single batch.
     & unsafePartsOf (traversed . beside (_2 . V2.refs_) (_2) . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
+
+-- | This is similar to `labeledDependencies1ToPG`, but it filters out refs for components
+-- which don't exist on Share, e.g. generated accessors.
+labeledDependencies1ToValidPGRefs :: (PG.QueryM m) => [LD.LabeledDependency] -> m [Either (V1.Referent, PGReferent) (V1.Reference, PGReference)]
+labeledDependencies1ToValidPGRefs refs =
+  refs
+    & map \case
+      LD.TermReferent r -> Left (r, Cv.referent1to2 r)
+      LD.TypeReference r -> Right (r, Cv.reference1to2 r)
+    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
+    -- We traverse the hashes on both the referents and references at once, then convert them
+    -- all to ComponentHashIDs in a single batch.
+    & unsafePartsOf (traversed . beside (_2 . V2.refs_) (_2) . V2.h_) %%~ (Hashes.componentHashIdsOf traversed . fmap ComponentHash)
+    <&> fmap (sequenceOf (beside (_2 . V2.refs_) _2 . V2.h_))
+    <&> catMaybes

--- a/src/Share/Postgres/NameLookups/Conversions.hs
+++ b/src/Share/Postgres/NameLookups/Conversions.hs
@@ -3,9 +3,9 @@
 -- efficient than converting in a loop.
 module Share.Postgres.NameLookups.Conversions
   ( references1ToPGOf,
-    references2ToPG,
+    references2ToPGOf,
     referents1ToPGOf,
-    referents2ToPG,
+    referents2ToPGOf,
     referencesPGTo1Of,
     referencesPGTo2Of,
     referentsPGTo1UsingCTOf,
@@ -14,14 +14,13 @@ module Share.Postgres.NameLookups.Conversions
     namedReferents2ToPG,
     namedReferences2ToPG,
     labeledDependencies1ToPG,
-    labeledDependencies1ToValidPGRefs,
   )
 where
 
 import Control.Lens
 import Share.Postgres qualified as PG
 import Share.Postgres.Hashes.Queries qualified as Hashes
-import Share.Postgres.IDs (ComponentHash (..), ComponentHashId)
+import Share.Postgres.IDs (ComponentHash (..))
 import Share.Postgres.NameLookups.Types
 import Share.Postgres.Refs.Types
 import Share.Prelude
@@ -33,35 +32,37 @@ import Unison.LabeledDependency qualified as LD
 import Unison.Reference qualified as V1
 import Unison.Referent qualified as V1
 
-references1ToPGOf :: (PG.QueryA m) => Traversal s t V1.Reference PGReference -> s -> m t
+references1ToPGOf :: (PG.QueryA m) => Traversal s t V1.Reference (Maybe PGReference) -> s -> m t
 references1ToPGOf trav s =
   s
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
     & unsafePartsOf trav %%~ \ref1s -> do
       let ref2s = map Cv.reference1to2 ref1s
-      Hashes.ensureComponentHashIdsOf (traversed . V2.h_ . componentHashAsUHash_) ref2s
+      references2ToPGOf traversed ref2s
 
-references2ToPG :: (Traversable t, PG.QueryA m) => t V2.Reference -> m (t PGReference)
-references2ToPG refs =
-  refs
+references2ToPGOf :: (PG.QueryA m) => Traversal s t V2.Reference (Maybe PGReference) -> s -> m t
+references2ToPGOf trav s =
+  s
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
-    & unsafePartsOf (traversed . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
+    & unsafePartsOf trav %%~ \ref2s -> do
+      fmap (sequenceAOf (V2.h_)) <$> Hashes.componentHashIdsOf (traversed . V2.h_ . componentHashAsUHash_) ref2s
 
-referents1ToPGOf :: (PG.QueryA m) => Traversal s t V1.Referent PGReferent -> s -> m t
+referents1ToPGOf :: (PG.QueryA m) => Traversal s t V1.Referent (Maybe PGReferent) -> s -> m t
 referents1ToPGOf trav s =
   s
     -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
     & unsafePartsOf trav %%~ \ref1s -> do
       let ref2s = map Cv.referent1to2 ref1s
+      referents2ToPGOf traversed ref2s
+
+referents2ToPGOf :: (PG.QueryA m) => Traversal s t V2.Referent (Maybe PGReferent) -> s -> m t
+referents2ToPGOf trav s =
+  s
+    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
+    & unsafePartsOf trav %%~ \ref2s -> do
       -- We traverse the hashes on both the referents and references at once, then convert them
       -- all to ComponentHashIDs in a single batch.
-      Hashes.ensureComponentHashIdsOf (traversed . V2.refs_ . V2.h_ . componentHashAsUHash_) ref2s
-
-referents2ToPG :: (Traversable t, PG.QueryA m) => t V2.Referent -> m (t PGReferent)
-referents2ToPG refs =
-  refs
-    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
-    & unsafePartsOf (traversed . V2.refs_ . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
+      fmap (sequenceAOf (V2.refs_ . V2.h_)) <$> Hashes.componentHashIdsOf (traversed . V2.refs_ . V2.h_ . componentHashAsUHash_) ref2s
 
 referencesPGTo1Of :: (PG.QueryA m) => Traversal s t PGReference V1.Reference -> s -> m t
 referencesPGTo1Of trav s =
@@ -116,21 +117,10 @@ namedReferences2ToPG refs =
     unsafePartsOf (traversed . ref_ . V2.h_)
       %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
 
-labeledDependencies1ToPG :: (PG.QueryA m) => [LD.LabeledDependency] -> m [Either (V1.Referent, PGReferent) (V1.Reference, PGReference)]
-labeledDependencies1ToPG refs =
-  refs
-    & map \case
-      LD.TermReferent r -> Left (r, Cv.referent1to2 r)
-      LD.TypeReference r -> Right (r, Cv.reference1to2 r)
-    -- This is safe here because ensureComponentHashIdsOf always returns the same number of elements as it is given
-    -- We traverse the hashes on both the referents and references at once, then convert them
-    -- all to ComponentHashIDs in a single batch.
-    & unsafePartsOf (traversed . beside (_2 . V2.refs_) (_2) . V2.h_) %%~ (Hashes.ensureComponentHashIdsOf traversed . fmap ComponentHash)
-
 -- | This is similar to `labeledDependencies1ToPG`, but it filters out refs for components
 -- which don't exist on Share, e.g. generated accessors.
-labeledDependencies1ToValidPGRefs :: (PG.QueryA m) => [LD.LabeledDependency] -> m [Either (V1.Referent, PGReferent) (V1.Reference, PGReference)]
-labeledDependencies1ToValidPGRefs refs =
+labeledDependencies1ToPG :: (PG.QueryA m) => [LD.LabeledDependency] -> m [Maybe (Either (V1.Referent, PGReferent) (V1.Reference, PGReference))]
+labeledDependencies1ToPG refs =
   refs
     & map \case
       LD.TermReferent r -> Left (r, Cv.referent1to2 r)
@@ -140,12 +130,11 @@ labeledDependencies1ToValidPGRefs refs =
     -- all to ComponentHashIDs in a single batch.
     & unsafePartsOf (traversed . beside (_2 . V2.refs_) (_2) . V2.h_) %%~ (Hashes.componentHashIdsOf traversed . fmap ComponentHash)
     <&> fmap (sequenceOf (beside (_2 . V2.refs_) _2 . V2.h_))
-    <&> catMaybes
 
 -- | Helper iso for coercing between ComponentHash and UHash.Hash
-uHashAsComponentHash_ :: Iso ComponentHashId UHash.Hash ComponentHashId ComponentHash
+uHashAsComponentHash_ :: Iso r UHash.Hash r ComponentHash
 uHashAsComponentHash_ = coerced
 
 -- | Helper iso for coercing between UHash.Hash ComponentHash
-componentHashAsUHash_ :: Iso UHash.Hash ComponentHashId ComponentHash ComponentHashId
+componentHashAsUHash_ :: Iso UHash.Hash r ComponentHash r
 componentHashAsUHash_ = coerced

--- a/src/Share/Postgres/NameLookups/Queries.hs
+++ b/src/Share/Postgres/NameLookups/Queries.hs
@@ -333,7 +333,7 @@ instance DecodeRow FuzzySearchScore where
 -- | Searches for all names within the given name lookup which contain the provided list of segments
 -- in order.
 -- Search is case insensitive.
-fuzzySearchTerms :: (PG.QueryM m) => NameLookupReceipt -> Bool -> BranchHashId -> Int64 -> PathSegments -> NonEmpty Text -> Text -> m [(FuzzySearchScore, NamedRef (PGReferent, Maybe ConstructorType))]
+fuzzySearchTerms :: (PG.QueryA m) => NameLookupReceipt -> Bool -> BranchHashId -> Int64 -> PathSegments -> NonEmpty Text -> Text -> m [(FuzzySearchScore, NamedRef (PGReferent, Maybe ConstructorType))]
 fuzzySearchTerms !_nameLookupReceipt includeDependencies bhId limit namespace querySegments lastSearchTerm = do
   fmap unRow
     <$> PG.queryListRows
@@ -392,7 +392,7 @@ fuzzySearchTerms !_nameLookupReceipt includeDependencies bhId limit namespace qu
 -- in order.
 --
 -- Search is case insensitive.
-fuzzySearchTypes :: (PG.QueryM m) => NameLookupReceipt -> Bool -> BranchHashId -> Int64 -> PathSegments -> NonEmpty Text -> Text -> m [(FuzzySearchScore, NamedRef PGReference)]
+fuzzySearchTypes :: (PG.QueryA m) => NameLookupReceipt -> Bool -> BranchHashId -> Int64 -> PathSegments -> NonEmpty Text -> Text -> m [(FuzzySearchScore, NamedRef PGReference)]
 fuzzySearchTypes !_nameLookupReceipt includeDependencies bhId limit namespace querySegments lastSearchTerm = do
   fmap unRow
     <$> PG.queryListRows

--- a/src/Share/PrettyPrintEnvDecl/Postgres.hs
+++ b/src/Share/PrettyPrintEnvDecl/Postgres.hs
@@ -22,7 +22,8 @@ ppedForReferences :: forall m. (PG.QueryM m) => NamesPerspective -> Set LabeledD
 ppedForReferences namesPerspective refs = do
   withPGRefs <-
     Set.toList refs
-      & CV.labeledDependencies1ToValidPGRefs
+      & CV.labeledDependencies1ToPG
+      & fmap catMaybes -- Filter out any missing components
   (termNames, typeNames) <- foldMapM namesForReference withPGRefs
   pure $ ppedFromNamesWithSuffixes termNames typeNames
   where

--- a/src/Share/PrettyPrintEnvDecl/Postgres.hs
+++ b/src/Share/PrettyPrintEnvDecl/Postgres.hs
@@ -22,7 +22,7 @@ ppedForReferences :: forall m. (PG.QueryM m) => NamesPerspective -> Set LabeledD
 ppedForReferences namesPerspective refs = do
   withPGRefs <-
     Set.toList refs
-      & CV.labeledDependencies1ToPG
+      & CV.labeledDependencies1ToValidPGRefs
   (termNames, typeNames) <- foldMapM namesForReference withPGRefs
   pure $ ppedFromNamesWithSuffixes termNames typeNames
   where

--- a/src/Unison/Server/NameSearch/Postgres.hs
+++ b/src/Unison/Server/NameSearch/Postgres.hs
@@ -58,7 +58,7 @@ nameSearchForPerspective namesPerspective =
 
     lookupNamesForTypes :: V1.Reference -> PG.Transaction e (Set (HQ'.HashQualified Name))
     lookupNamesForTypes ref = do
-      pgRef <- CV.reference1ToPG ref
+      pgRef <- CV.references1ToPGOf id ref
       names <- NLOps.typeNamesForRefWithinNamespace namesPerspective pgRef Nothing
       names
         & fmap (\(fqnSegments, _suffixSegments) -> HQ'.HashQualified (reversedSegmentsToName fqnSegments) (V1Reference.toShortHash ref))
@@ -66,7 +66,7 @@ nameSearchForPerspective namesPerspective =
         & pure
     lookupNamesForTerms :: V1Referent.Referent -> PG.Transaction e (Set (HQ'.HashQualified Name))
     lookupNamesForTerms ref = do
-      pgRef <- CV.referent1ToPG ref
+      pgRef <- CV.referents1ToPGOf id ref
       names <- NLOps.termNamesForRefWithinNamespace namesPerspective pgRef Nothing
       names
         & fmap (\(fqnSegments, _suffixSegments) -> HQ'.HashQualified (reversedSegmentsToName fqnSegments) (V1Referent.toShortHash ref))
@@ -86,7 +86,7 @@ nameSearchForPerspective namesPerspective =
           let fqn = fullyQualifyName name
           termRefsV1 <-
             Set.toList <$> Codebase.termReferentsByShortHash sh
-          termRefsPG <- CV.referents1ToPG termRefsV1
+          termRefsPG <- CV.referents1ToPGOf traversed termRefsV1
           fmap Set.fromList . forMaybe (zip termRefsV1 termRefsPG) $ \(termRef, pgTermRef) -> do
             matches <-
               NLOps.termNamesForRefWithinNamespace namesPerspective pgTermRef (Just . coerce $ Name.reverseSegments name)
@@ -109,7 +109,7 @@ nameSearchForPerspective namesPerspective =
         HQ'.HashQualified name sh -> do
           let fqn = fullyQualifyName name
           typeRefs <- Set.toList <$> Codebase.typeReferencesByShortHash sh
-          pgTypeRefs <- CV.references1ToPG typeRefs
+          pgTypeRefs <- CV.references1ToPGOf traversed typeRefs
           fmap Set.fromList . forMaybe (zip typeRefs pgTypeRefs) $ \(typeRef, pgTypeRef) -> do
             matches <-
               NLOps.typeNamesForRefWithinNamespace namesPerspective pgTypeRef (Just . coerce $ Name.reverseSegments name)

--- a/src/Unison/Server/NameSearch/Postgres.hs
+++ b/src/Unison/Server/NameSearch/Postgres.hs
@@ -57,16 +57,16 @@ nameSearchForPerspective namesPerspective =
         }
 
     lookupNamesForTypes :: V1.Reference -> PG.Transaction e (Set (HQ'.HashQualified Name))
-    lookupNamesForTypes ref = do
-      pgRef <- CV.references1ToPGOf id ref
+    lookupNamesForTypes ref = fromMaybeT (pure mempty) $ do
+      pgRef <- MaybeT $ CV.references1ToPGOf id ref
       names <- NLOps.typeNamesForRefWithinNamespace namesPerspective pgRef Nothing
       names
         & fmap (\(fqnSegments, _suffixSegments) -> HQ'.HashQualified (reversedSegmentsToName fqnSegments) (V1Reference.toShortHash ref))
         & Set.fromList
         & pure
     lookupNamesForTerms :: V1Referent.Referent -> PG.Transaction e (Set (HQ'.HashQualified Name))
-    lookupNamesForTerms ref = do
-      pgRef <- CV.referents1ToPGOf id ref
+    lookupNamesForTerms ref = fromMaybeT (pure mempty) $ do
+      pgRef <- MaybeT $ CV.referents1ToPGOf id ref
       names <- NLOps.termNamesForRefWithinNamespace namesPerspective pgRef Nothing
       names
         & fmap (\(fqnSegments, _suffixSegments) -> HQ'.HashQualified (reversedSegmentsToName fqnSegments) (V1Referent.toShortHash ref))
@@ -86,7 +86,7 @@ nameSearchForPerspective namesPerspective =
           let fqn = fullyQualifyName name
           termRefsV1 <-
             Set.toList <$> Codebase.termReferentsByShortHash sh
-          termRefsPG <- CV.referents1ToPGOf traversed termRefsV1
+          termRefsPG <- catMaybes <$> CV.referents1ToPGOf traversed termRefsV1
           fmap Set.fromList . forMaybe (zip termRefsV1 termRefsPG) $ \(termRef, pgTermRef) -> do
             matches <-
               NLOps.termNamesForRefWithinNamespace namesPerspective pgTermRef (Just . coerce $ Name.reverseSegments name)
@@ -109,7 +109,7 @@ nameSearchForPerspective namesPerspective =
         HQ'.HashQualified name sh -> do
           let fqn = fullyQualifyName name
           typeRefs <- Set.toList <$> Codebase.typeReferencesByShortHash sh
-          pgTypeRefs <- CV.references1ToPGOf traversed typeRefs
+          pgTypeRefs <- catMaybes <$> CV.references1ToPGOf traversed typeRefs
           fmap Set.fromList . forMaybe (zip typeRefs pgTypeRefs) $ \(typeRef, pgTypeRef) -> do
             matches <-
               NLOps.typeNamesForRefWithinNamespace namesPerspective pgTypeRef (Just . coerce $ Name.reverseSegments name)


### PR DESCRIPTION
## Overview

Previously we'd auto-insert component hash Ids for any unknown component references.

This meant that if we were ever passed references we didn't know about, we'd still store an ID for it. It's helpful during sync, but we shouldn't be doing it everywhere. It also meant we had INSERTs on read-only GET endpoints, which means a bunch of unnecessary locking on PG's part.

This changes things so we don't have these inserts on read transactions, but also makes it so we need to explicitly handle missing component hashes if/when they come up, which is much safer.

This change also makes it so that pretty-printing of decls will omit references to any record field accessors that aren't named, which was causing hiccups on prod.

## Implementation notes

* Change the `ensureComponentHashIdsOf` usages into `componentHashIdsOf` which returns Maybes if missing, then handle those maybes.
* Also converts a bunch of these utilities to use the transaciton applicative, and pipelines a few of them for speeeeeeed 🏃🏼 

## Test coverage

Existing transcripts
