### PR TITLE
Remove CodebaseM

### DIFF
--- a/src/Share/Codebase/Types.hs
+++ b/src/Share/Codebase/Types.hs
@@ -1,6 +1,5 @@
 module Share.Codebase.Types
-  ( CodebaseM,
-    CodebaseEnv (..),
+  ( CodebaseEnv (..),
     CodebaseRuntime (..),
     CodebaseLocation (..),
     hoistCodebaseRuntime,
@@ -13,8 +12,6 @@ where
 
 import Control.Monad.Morph (MFunctor (..))
 import Share.IDs
-import Share.Postgres qualified as PG
-import Share.Prelude
 import Unison.Codebase.CodeLookup qualified as CL
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.Runtime qualified as Rt
@@ -48,9 +45,6 @@ hoistCodebaseRuntime f (CodebaseRuntime lookup eval runtime) =
       cachedEvalResult = \id -> f (eval id),
       unisonRuntime = runtime
     }
-
--- | A PG Transaction scoped to a specific user codebase.
-type CodebaseM e = ReaderT CodebaseEnv (PG.Transaction e)
 
 newtype CodebaseLocation = CodebaseLocation {codebaseOwnerUserId :: UserId}
   deriving stock (Eq, Ord, Show)

--- a/src/Share/Postgres/Search/DefinitionSearch/Queries.hs
+++ b/src/Share/Postgres/Search/DefinitionSearch/Queries.hs
@@ -138,7 +138,7 @@ markRootAsIndexed rootBranchHashId = do
 
 -- | Save definition documents to be indexed for search.
 -- Returns errors related to invalid names for logging.
-insertDefinitionDocuments :: [DefinitionDocument Name (Name, ShortHash)] -> Transaction e ([Text])
+insertDefinitionDocuments :: (QueryM m) => [DefinitionDocument Name (Name, ShortHash)] -> m ([Text])
 insertDefinitionDocuments docs = pipelined $ do
   let (badNames, validNames) =
         docs

--- a/src/Share/Postgres/Users/Queries.hs
+++ b/src/Share/Postgres/Users/Queries.hs
@@ -219,7 +219,7 @@ createFromGithubUser !authzReceipt (GithubUser _githubHandle githubUserId avatar
             VALUES (#{githubUserId}, #{userId})
         |]
   let codebase = Codebase.codebaseEnv authzReceipt (Codebase.codebaseLocationForUserCodebase userId)
-  Codebase.codebaseMToTransaction codebase LCQ.initialize
+  LCQ.initialize codebase
   let visibility = UserPublic
   pure $
     User

--- a/src/Share/Web/Share/Diffs/Impl.hs
+++ b/src/Share/Web/Share/Diffs/Impl.hs
@@ -213,8 +213,7 @@ getTermDefinition (codebase, rt, bhId, name) = do
   (namesPerspective, Identity relocatedName) <- NameLookupOps.relocateToNameRoot perspective (Identity name) bhId
   let ppedBuilder deps = PPED.biasTo [name] <$> PPEPostgres.ppedForReferences namesPerspective deps
   let nameSearch = PGNameSearch.nameSearchForPerspective namesPerspective
-  Codebase.codebaseMToTransaction codebase do
-    Definitions.termDefinitionByName ppedBuilder nameSearch renderWidth rt relocatedName
+  Definitions.termDefinitionByName codebase ppedBuilder nameSearch renderWidth rt relocatedName
   where
     renderWidth :: Width
     renderWidth = 80
@@ -238,10 +237,9 @@ getTypeDefinition :: (Codebase.CodebaseEnv, Codebase.CodebaseRuntime s IO, Branc
 getTypeDefinition (codebase, rt, bhId, name) = do
   let perspective = mempty
   (namesPerspective, Identity relocatedName) <- NameLookupOps.relocateToNameRoot perspective (Identity name) bhId
-  let ppedBuilder deps = (PPED.biasTo [name]) <$> lift (PPEPostgres.ppedForReferences namesPerspective deps)
+  let ppedBuilder deps = (PPED.biasTo [name]) <$> (PPEPostgres.ppedForReferences namesPerspective deps)
   let nameSearch = PGNameSearch.nameSearchForPerspective namesPerspective
-  Codebase.codebaseMToTransaction codebase do
-    Definitions.typeDefinitionByName ppedBuilder nameSearch renderWidth rt relocatedName
+  Definitions.typeDefinitionByName codebase ppedBuilder nameSearch renderWidth rt relocatedName
   where
     renderWidth :: Width
     renderWidth = 80

--- a/src/Share/Web/Share/Projects/Impl.hs
+++ b/src/Share/Web/Share/Projects/Impl.hs
@@ -295,18 +295,16 @@ namespaceHashForBranchOrRelease authZReceipt Project {projectId, ownerUserId = p
       let causalId = Branch.causal branch
       let codebaseLoc = Codebase.codebaseLocationForProjectBranchCodebase projectOwnerUserId (Branch.contributorId branch)
       let codebase = Codebase.codebaseEnv authZReceipt codebaseLoc
-      Codebase.codebaseMToTransaction codebase do
-        branchHashId <- CausalQ.expectNamespaceIdsByCausalIdsOf id causalId
-        pure (codebase, causalId, branchHashId)
+      branchHashId <- CausalQ.expectNamespaceIdsByCausalIdsOf id causalId
+      pure (codebase, causalId, branchHashId)
   IDs.IsReleaseShortHand releaseShortHand -> do
     PG.runTransactionOrRespondError $ do
       release <- Q.releaseByProjectIdAndReleaseShortHand projectId releaseShortHand `whenNothingM` throwError (EntityMissing (ErrorID "release-not-found") ("Release not found: " <> IDs.toText @IDs.ReleaseShortHand releaseShortHand))
       let causalId = Release.squashedCausal release
       let codebaseLoc = Codebase.codebaseLocationForProjectRelease projectOwnerUserId
       let codebase = Codebase.codebaseEnv authZReceipt codebaseLoc
-      Codebase.codebaseMToTransaction codebase do
-        branchHashId <- CausalQ.expectNamespaceIdsByCausalIdsOf id causalId
-        pure (codebase, causalId, branchHashId)
+      branchHashId <- CausalQ.expectNamespaceIdsByCausalIdsOf id causalId
+      pure (codebase, causalId, branchHashId)
 
 createProjectEndpoint :: Maybe Session -> UserHandle -> ProjectSlug -> CreateProjectRequest -> WebApp CreateProjectResponse
 createProjectEndpoint mayCaller userHandle projectSlug req = do

--- a/src/Unison/Server/Share/NamespaceDetails.hs
+++ b/src/Unison/Server/Share/NamespaceDetails.hs
@@ -2,7 +2,8 @@ module Unison.Server.Share.NamespaceDetails (namespaceDetails) where
 
 import Data.Set qualified as Set
 import Share.Codebase qualified as Codebase
-import Share.Codebase.Types (CodebaseM, CodebaseRuntime)
+import Share.Codebase.Types (CodebaseEnv, CodebaseRuntime)
+import Share.Postgres (QueryM)
 import Share.Postgres.IDs (CausalId)
 import Share.Prelude
 import U.Codebase.Causal qualified as Causal
@@ -17,14 +18,16 @@ import Unison.Server.Types
 import Unison.Util.Pretty (Width)
 
 namespaceDetails ::
+  (QueryM m) =>
+  CodebaseEnv ->
   CodebaseRuntime s IO ->
   Path.Path ->
   CausalId ->
   Maybe Width ->
-  CodebaseM e (Maybe NamespaceDetails)
-namespaceDetails runtime namespacePath rootCausalId mayWidth = runMaybeT $ do
-  causalHashAtPath <- Causal.causalHash <$> MaybeT (Codebase.loadCausalNamespaceAtPath rootCausalId namespacePath)
-  mayReadme <- lift $ RenderDoc.findAndRenderDoc readmeNames runtime namespacePath rootCausalId mayWidth
+  m (Maybe NamespaceDetails)
+namespaceDetails codebase runtime namespacePath rootCausalId mayWidth = runMaybeT $ do
+  causalHashAtPath <- Causal.causalHash <$> MaybeT (Codebase.loadCausalNamespaceAtPath codebase rootCausalId namespacePath)
+  mayReadme <- lift $ RenderDoc.findAndRenderDoc codebase readmeNames runtime namespacePath rootCausalId mayWidth
   pure $ NamespaceDetails namespacePath ("#" <> from @CausalHash @UnisonHash causalHashAtPath) mayReadme
   where
     readmeNames = Set.fromList . fmap NameSegment $ ["README", "Readme", "ReadMe", "readme"]


### PR DESCRIPTION
## Overview

Removes the CodebaseM abstraction in favour of just manually passing around Codebases.

Abstracting over the transactions types was getting weird and annoying, especially in spite of pipelining.
It also leads to confusion when operating in more than one codebase at a time, e.g. when diffing contributor branches.

## Implementation notes

Removes all CodebaseM abstractions.
