### PR TITLE
Add Open Telemetry

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ../sql:/docker-entrypoint-initdb.d
       # Optionally persist the data between container invocations
-      - postgresVolume:/var/lib/postgresql/data
+      # - postgresVolume:/var/lib/postgresql/data
       - ./postgresql.conf:/etc/postgresql/postgresql.conf
     command: postgres -c config_file=/etc/postgresql/postgresql.conf # -c log_statement=all
 
@@ -135,5 +135,5 @@ services:
 
       environment:
         - COLLECTOR_OTLP_ENABLED=true
-volumes:
-  postgresVolume:
+# volumes:
+#   postgresVolume:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -95,12 +95,13 @@ services:
       - USER_SECRETS_VAULT_MOUNT=secret # A default mount in dev vault
       - SHARE_GITHUB_CLIENTID=invalid
       - SHARE_GITHUB_CLIENT_SECRET=invalid
-
-    links:
-      - redis
-      - postgres
-      - vault
-      - http-echo
+      - OTEL_SERVICE_NAME=share-api
+      - OTEL_SERVICE_VERSION=local
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=share-api,service.version=local,deployment.environment=local
+      - OTEL_TRACES_SAMPLER=traceidratio
+      - OTEL_TRACES_SAMPLER_ARG=1.0
 
   http-echo:
     image: 'mendhak/http-https-echo:36'
@@ -111,5 +112,28 @@ services:
     ports:
       - "9999:9999"
 
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
+    ports:
+      - 1888:1888 # pprof extension
+      - 8888:8888 # Prometheus metrics exposed by the Collector
+      - 8889:8889 # Prometheus exporter metrics
+      - 13133:13133 # health_check extension
+      - 4317:4317 # OTLP gRPC receiver
+      - 4318:4318 # OTLP http receiver
+      - 55679:55679 # zpages extension
+
+    depends_on:
+      - jaeger
+
+  jaeger:
+      image: cr.jaegertracing.io/jaegertracing/jaeger:2.8.0
+      ports:
+        - 16686:16686  # Jaeger UI
+
+      environment:
+        - COLLECTOR_OTLP_ENABLED=true
 # volumes:
 #   postgresVolume:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ../sql:/docker-entrypoint-initdb.d
       # Optionally persist the data between container invocations
-      # - postgresVolume:/var/lib/postgresql/data
+      - postgresVolume:/var/lib/postgresql/data
       - ./postgresql.conf:/etc/postgresql/postgresql.conf
     command: postgres -c config_file=/etc/postgresql/postgresql.conf # -c log_statement=all
 
@@ -135,5 +135,5 @@ services:
 
       environment:
         - COLLECTOR_OTLP_ENABLED=true
-# volumes:
-#   postgresVolume:
+volumes:
+  postgresVolume:

--- a/docker/otel-collector-config.yaml
+++ b/docker/otel-collector-config.yaml
@@ -1,0 +1,42 @@
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+  pprof:
+    endpoint: 0.0.0.0:1888
+  zpages:
+    endpoint: 0.0.0.0:55679
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  debug:
+    verbosity: detailed
+  otlp:
+    endpoint: jaeger:4317  # Use internal Docker network
+    tls:
+      insecure: true
+
+service:
+  extensions: [health_check, pprof, zpages]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug, otlp]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/local.env
+++ b/local.env
@@ -22,6 +22,23 @@ export SHARE_MAX_PARALLELISM_PER_UPLOAD_REQUEST="5"
 export VAULT_HOST="http://localhost:8200/v1"
 export VAULT_TOKEN="sekrit"
 export USER_SECRETS_VAULT_MOUNT="secret" # A default mount in dev vault
+
+
+# Open telemetry setup
+export OTEL_SERVICE_NAME=share-api
+export OTEL_SERVICE_VERSION=local
+
+# OTLP configuration
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+
+# Additional resource attributes
+export OTEL_RESOURCE_ATTRIBUTES=service.name=share-api,service.version=local,deployment.environment=local
+
+# Optional: sampling (1.0 = 100%, 0.1 = 10%)
+export OTEL_TRACES_SAMPLER=traceidratio
+export OTEL_TRACES_SAMPLER_ARG=1.0
+
 # Proxies aren't used locally, but are required in staging and production
 # export SHARE_PROXY_HOST="http://localhost" 
 # export SHARE_PROXY_PORT="9999"
@@ -31,3 +48,4 @@ export SHARE_ZENDESK_API_USER="invaliduser@example.com"
 export SHARE_ZENDESK_API_TOKEN="bad-password"
 export SHARE_GITHUB_CLIENTID="invalid"
 export SHARE_GITHUB_CLIENT_SECRET="invalid"
+

--- a/package.yaml
+++ b/package.yaml
@@ -67,6 +67,8 @@ dependencies:
 - http-client-tls
 - http-media
 - http-types
+- hs-opentelemetry-sdk
+- hs-opentelemetry-instrumentation-wai
 - jose
 - ki-unlifted
 - lens

--- a/package.yaml
+++ b/package.yaml
@@ -68,6 +68,7 @@ dependencies:
 - http-media
 - http-types
 - hs-opentelemetry-sdk
+- hs-opentelemetry-api
 - hs-opentelemetry-instrumentation-wai
 - jose
 - ki-unlifted

--- a/share-api.cabal
+++ b/share-api.cabal
@@ -120,6 +120,7 @@ library
       Share.Utils.Servant.Client
       Share.Utils.Servant.PathInfo
       Share.Utils.Servant.RawRequest
+      Share.Utils.Tags
       Share.Utils.Unison
       Share.Web.Admin.API
       Share.Web.Admin.Impl

--- a/share-api.cabal
+++ b/share-api.cabal
@@ -266,6 +266,7 @@ library
     , hasql-pool
     , hedis
     , here
+    , hs-opentelemetry-api
     , hs-opentelemetry-instrumentation-wai
     , hs-opentelemetry-sdk
     , http-api-data
@@ -419,6 +420,7 @@ executable share-api
     , hasql-pool
     , hedis
     , here
+    , hs-opentelemetry-api
     , hs-opentelemetry-instrumentation-wai
     , hs-opentelemetry-sdk
     , http-api-data

--- a/share-api.cabal
+++ b/share-api.cabal
@@ -104,6 +104,8 @@ library
       Share.Project
       Share.Redis
       Share.Release
+      Share.Telemetry
+      Share.Telemetry.Setup
       Share.Ticket
       Share.User
       Share.UserProfile
@@ -263,6 +265,8 @@ library
     , hasql-pool
     , hedis
     , here
+    , hs-opentelemetry-instrumentation-wai
+    , hs-opentelemetry-sdk
     , http-api-data
     , http-client
     , http-client-tls
@@ -414,6 +418,8 @@ executable share-api
     , hasql-pool
     , hedis
     , here
+    , hs-opentelemetry-instrumentation-wai
+    , hs-opentelemetry-sdk
     , http-api-data
     , http-client
     , http-client-tls

--- a/src/Share.hs
+++ b/src/Share.hs
@@ -7,7 +7,6 @@ module Share
   )
 where
 
-import OpenTelemetry.Instrumentation.Wai (newOpenTelemetryWaiMiddleware)
 import Control.Monad.Except
 import Control.Monad.Random (randomIO)
 import Control.Monad.Reader
@@ -33,6 +32,7 @@ import Network.Wai.Internal qualified as Wai
 import Network.Wai.Middleware.Cors
 import Network.Wai.Middleware.Gzip qualified as Gzip
 import Network.Wai.Middleware.RequestLogger (logStdoutDev)
+import OpenTelemetry.Instrumentation.Wai (newOpenTelemetryWaiMiddleware)
 import Servant
 import Share.App
 import Share.BackgroundJobs qualified as BackgroundJobs
@@ -129,10 +129,10 @@ mkShareServer env = do
           & requestIDMiddleware
           & requestMetricsMiddleware Web.api
           & metricsMiddleware
-          & openTelemetryMiddleware
           & skipOnLocal corsMiddleware
           & Gzip.gzip gzipSettings
           & reqLoggerMiddleware
+          & openTelemetryMiddleware
   pure waiApp
   where
     gzipSettings =

--- a/src/Share/App.hs
+++ b/src/Share/App.hs
@@ -14,6 +14,7 @@ import Crypto.Random.Types qualified as Cryptonite
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Database.Redis qualified as R
+import OpenTelemetry.Trace.Monad (MonadTracer (..))
 import Servant
 import Share.Env (Env (..))
 import Share.Env qualified as Env
@@ -38,6 +39,9 @@ instance (Env.HasTags ctx) => Logging.MonadLogger (AppM ctx) where
     env <- ask
     env' <- Env.updateTags (Map.union newTags) env
     AppM $ local (const env') m
+
+instance MonadTracer (AppM reqCtx) where
+  getTracer = asks Env.tracer
 
 runAppM :: Env reqCtx -> AppM reqCtx a -> IO a
 runAppM env (AppM m) = runReaderT m env

--- a/src/Share/BackgroundJobs/Diffs/CausalDiffs.hs
+++ b/src/Share/BackgroundJobs/Diffs/CausalDiffs.hs
@@ -92,7 +92,7 @@ maybeComputeAndStoreCausalDiff ::
   Runtime Symbol ->
   CausalDiffInfo ->
   PG.Transaction EntityMissing Bool
-maybeComputeAndStoreCausalDiff authZReceipt unisonRuntime (CausalDiffInfo {fromCausalId, toCausalId, fromCodebaseOwner, toCodebaseOwner}) = do
+maybeComputeAndStoreCausalDiff authZReceipt unisonRuntime (CausalDiffInfo {fromCausalId, toCausalId, fromCodebaseOwner, toCodebaseOwner}) = PG.transactionSpan "maybeComputeAndStoreCausalDiff" mempty $ do
   bestCommonAncestorCausalId <- CausalQ.bestCommonAncestor fromCausalId toCausalId
   let fromCodebase = Codebase.codebaseEnv authZReceipt $ Codebase.codebaseLocationForUserCodebase fromCodebaseOwner
   let toCodebase = Codebase.codebaseEnv authZReceipt $ Codebase.codebaseLocationForUserCodebase toCodebaseOwner

--- a/src/Share/BackgroundJobs/Monad.hs
+++ b/src/Share/BackgroundJobs/Monad.hs
@@ -1,43 +1,36 @@
+{-# LANGUAGE DataKinds #-}
+
 -- | Background worker monad
 module Share.BackgroundJobs.Monad
   ( Background,
     BackgroundCtx (..),
     withWorkerName,
     runBackground,
-    withTag,
-    withTags,
   )
 where
 
-import Data.Map qualified as Map
 import Share.App
 import Share.Env
 import Share.Prelude
+import Share.Utils.Tags (HasTags (..))
 
 data BackgroundCtx = BackgroundCtx
   { workerName :: Text,
     loggingTags :: Map Text Text
   }
-
-instance HasTags BackgroundCtx where
-  getTags BackgroundCtx {loggingTags, workerName} = pure $ Map.singleton "workerName" workerName <> loggingTags
-  updateTags f BackgroundCtx {loggingTags, workerName} = do
-    let newTags = f loggingTags
-    pure $ BackgroundCtx {workerName, loggingTags = newTags}
+  deriving (Generic)
 
 type Background = AppM BackgroundCtx
+
+instance HasTags BackgroundCtx where
+  getTags ctx = pure $ loggingTags ctx
+  addTags tags ctx = ctx {loggingTags = loggingTags ctx <> tags}
 
 localBackgroundCtx :: (MonadReader (Env BackgroundCtx) m) => (BackgroundCtx -> BackgroundCtx) -> m a -> m a
 localBackgroundCtx f = local \env -> env {ctx = f (ctx env)}
 
 withWorkerName :: Text -> Background a -> Background a
 withWorkerName name = localBackgroundCtx \ctx -> ctx {workerName = name}
-
-withTag :: Text -> Text -> Background a -> Background a
-withTag key value = withTags [(key, value)]
-
-withTags :: [(Text, Text)] -> Background a -> Background a
-withTags tags = localBackgroundCtx \ctx -> ctx {loggingTags = Map.union (Map.fromList tags) (loggingTags ctx)}
 
 runBackground :: Env () -> Text -> Background a -> IO a
 runBackground env workerName bg =

--- a/src/Share/ChatApps.hs
+++ b/src/Share/ChatApps.hs
@@ -31,6 +31,7 @@ import Share.Postgres qualified as PG
 import Share.Postgres.Users.Queries qualified as UsersQ
 import Share.Prelude
 import Share.User (User (..))
+import Share.Utils.Tags (HasTags)
 import Share.Utils.URI (URIParam (..), uriToText)
 import Share.Web.UI.Links qualified as Links
 import UnliftIO (SomeException)
@@ -47,7 +48,7 @@ data Author = Author
   }
   deriving (Show, Eq, Ord)
 
-authorFromUserId :: (Env.HasTags reqCtx) => UserId -> AppM reqCtx Author
+authorFromUserId :: (HasTags reqCtx) => UserId -> AppM reqCtx Author
 authorFromUserId userId = do
   User {avatar_url = avatarUrl, user_name, handle} <- PG.runTransaction $ UsersQ.expectUser userId
   authorLink <- Links.userProfilePage handle

--- a/src/Share/Env.hs
+++ b/src/Share/Env.hs
@@ -9,6 +9,7 @@ import Database.Redis qualified as R
 import Hasql.Pool qualified as Hasql
 import Network.HTTP.Client qualified as HTTPClient
 import Network.URI (URI)
+import OpenTelemetry.Trace qualified as Trace
 import Servant.Client qualified as S
 import Share.JWT qualified as JWT
 import Share.Prelude
@@ -58,7 +59,9 @@ data Env ctx = Env
     -- E.g. sync can parallelize signing/verifying JWTs or run multiple transactions against
     -- PG. If this goes too high we can end up tanking Share.
     maxParallelismPerDownloadRequest :: Int,
-    maxParallelismPerUploadRequest :: Int
+    maxParallelismPerUploadRequest :: Int,
+    -- OpenTelemetry tracing
+    tracer :: Trace.Tracer
   }
   deriving (Functor)
 

--- a/src/Share/Env.hs
+++ b/src/Share/Env.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-
 module Share.Env
   ( Env (..),
   )

--- a/src/Share/Metrics.hs
+++ b/src/Share/Metrics.hs
@@ -29,6 +29,7 @@ import Share.Env qualified as Env
 import Share.Postgres qualified as PG
 import Share.Postgres.Metrics.Queries qualified as Q
 import Share.Prelude
+import Share.Telemetry qualified as Trace
 import Share.Utils.Deployment qualified as Deployment
 import Share.Utils.Servant.PathInfo (HasPathInfo, normalizePath)
 import System.Clock (Clock (..), diffTimeSpec, toNanoSecs)
@@ -78,7 +79,7 @@ serveMetricsMiddleware env = do
     refreshGauges getMetrics
     Prom.prometheus prometheusSettings app req handleResponse
   where
-    runPG = PG.runSessionWithEnv env . PG.transaction PG.ReadCommitted PG.Read
+    runPG = Trace.runTracerT (Env.tracer env) . PG.runSessionWithEnv env . PG.transaction PG.ReadCommitted PG.Read
     prometheusSettings =
       Prom.def
         { Prom.prometheusEndPoint = ["metrics"],

--- a/src/Share/Postgres.hs
+++ b/src/Share/Postgres.hs
@@ -316,7 +316,7 @@ rollback :: e -> Transaction e x
 rollback e = Transaction do
   pure (Left (Err e))
 
-transactionStatement :: a -> Hasql.Statement a b -> Transaction e b
+transactionStatement :: (HasCallStack) => a -> Hasql.Statement a b -> Transaction e b
 transactionStatement v stmt = Transaction do
   env <- ask
   let nqVar = numQueriesVar . Env.ctx $ env

--- a/src/Share/Postgres.hs
+++ b/src/Share/Postgres.hs
@@ -73,7 +73,7 @@ module Share.Postgres
 
     -- * Debugging and observability
     timeTransaction,
-    withSpanTransaction,
+    transactionSpan,
   )
 where
 
@@ -116,7 +116,6 @@ import Share.Utils.Logging (Loggable (..))
 import Share.Utils.Logging qualified as Logging
 import Share.Utils.Postgres (likeEscape)
 import Share.Utils.Tags (HasTags (..), MonadTags (..))
-import Share.Utils.Tags qualified as Tags
 import Share.Web.App
 import Share.Web.Errors (ErrorID (..), SomeServerError (SomeServerError), ToServerError (..), internalServerError, respondError, someServerError)
 import System.CPUTime (getCPUTime)
@@ -685,8 +684,8 @@ catchAllTransaction (Transaction t) = Transaction do
     Right a -> pure (Right $ Right a)
 
 -- | Allows tracking a span in a transaction.
-withSpanTransaction :: (HasCallStack, MonadTracer m, MonadTags m, QueryM m) => Text -> HM.HashMap Text Trace.Attribute -> m a -> m a
-withSpanTransaction name spanTags action = do
+transactionSpan :: (HasCallStack, MonadTracer m, MonadTags m, QueryM m) => Text -> HM.HashMap Text Trace.Attribute -> m a -> m a
+transactionSpan name spanTags action = do
   tags <- askTags
   let (_mayFuncName, callSiteInfo) = spanInfo
   let spanAttributes = spanTags <> callSiteInfo <> HM.fromList (Map.toList (Trace.toAttribute <$> tags))

--- a/src/Share/Telemetry.hs
+++ b/src/Share/Telemetry.hs
@@ -1,0 +1,18 @@
+module Share.Telemetry (withSpan) where
+
+import Data.Text (Text)
+import OpenTelemetry.Trace qualified as Trace
+import OpenTelemetry.Trace.Monad qualified as TraceM
+import UnliftIO
+
+withSpan :: (MonadUnliftIO m, TraceM.MonadTracer m) => Text -> m a -> m a
+withSpan name action = do
+  let spanAttributes = mempty
+  let spanArguments =
+        Trace.SpanArguments
+          { kind = Trace.Server,
+            attributes = spanAttributes,
+            links = [],
+            startTime = Nothing -- This will be set automatically
+          }
+  TraceM.inSpan name spanArguments $ action

--- a/src/Share/Telemetry.hs
+++ b/src/Share/Telemetry.hs
@@ -1,13 +1,29 @@
-module Share.Telemetry (withSpan) where
+module Share.Telemetry
+  ( withSpan,
+    TracerT (..),
+    runTracerT,
+    AttributeMap,
+    Trace.toAttribute,
+  )
+where
 
+import Control.Monad.Reader (MonadReader (..), MonadTrans, ReaderT (..))
+import Data.HashMap.Lazy qualified as HM
+import Data.Map qualified as Map
 import Data.Text (Text)
 import OpenTelemetry.Trace qualified as Trace
+import OpenTelemetry.Trace.Monad (MonadTracer)
 import OpenTelemetry.Trace.Monad qualified as TraceM
+import Share.Env (HasTags)
+import Share.Env qualified as Env
 import UnliftIO
 
-withSpan :: (MonadUnliftIO m, TraceM.MonadTracer m) => Text -> m a -> m a
-withSpan name action = do
-  let spanAttributes = mempty
+type AttributeMap = HM.HashMap Text Trace.Attribute
+
+withSpan :: (MonadUnliftIO m, TraceM.MonadTracer m, HasTags ctx, MonadReader ctx m) => Text -> AttributeMap -> m a -> m a
+withSpan name spanTags action = do
+  tags <- ask >>= Env.getTags
+  let spanAttributes = spanTags <> HM.fromList (Map.toList (Trace.toAttribute <$> tags))
   let spanArguments =
         Trace.SpanArguments
           { kind = Trace.Server,
@@ -16,3 +32,15 @@ withSpan name action = do
             startTime = Nothing -- This will be set automatically
           }
   TraceM.inSpan name spanArguments $ action
+
+-- | Helper for adding MonadTracer.
+newtype TracerT m a = TracerT
+  { unTracerT :: ReaderT Trace.Tracer m a
+  }
+  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, MonadTrans)
+
+runTracerT :: Trace.Tracer -> TracerT m a -> m a
+runTracerT tracer (TracerT action) = runReaderT action tracer
+
+instance (Monad m) => MonadTracer (TracerT m) where
+  getTracer = TracerT $ ask

--- a/src/Share/Telemetry/Setup.hs
+++ b/src/Share/Telemetry/Setup.hs
@@ -1,0 +1,26 @@
+-- | Initial Telemetry setup.
+module Share.Telemetry.Setup (withTracer) where
+
+import Data.Text (Text)
+import OpenTelemetry.Attributes qualified as Trace
+import OpenTelemetry.Trace qualified as Trace
+import UnliftIO
+
+withTracer :: Text -> (Trace.Tracer -> IO c) -> IO c
+withTracer commitHash f =
+  bracket
+    -- Install the SDK, pulling configuration from the environment
+    Trace.initializeGlobalTracerProvider
+    -- Ensure that any spans that haven't been exported yet are flushed
+    Trace.shutdownTracerProvider
+    -- Get a tracer so you can create spans
+    (\tracerProvider -> f $ Trace.makeTracer tracerProvider instrumentationLibrary tracerOptions)
+  where
+    tracerOptions = Trace.TracerOptions {Trace.tracerSchema = Nothing}
+    instrumentationLibrary =
+      Trace.InstrumentationLibrary
+        { Trace.libraryName = "share-api",
+          Trace.libraryVersion = commitHash,
+          Trace.librarySchemaUrl = "",
+          Trace.libraryAttributes = Trace.emptyAttributes
+        }

--- a/src/Share/Utils/Tags.hs
+++ b/src/Share/Utils/Tags.hs
@@ -1,0 +1,47 @@
+module Share.Utils.Tags
+  ( MonadTags (..),
+    Tags,
+    TagT (..),
+    runTagT,
+    HasTags (..),
+  )
+where
+
+import Share.Prelude
+
+type Tags = Map Text Text
+
+newtype TagT m a = TagT
+  { unTagT :: ReaderT Tags m a
+  }
+  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, MonadTrans)
+
+runTagT :: (HasTags t, MonadIO m) => t -> TagT m a -> m a
+runTagT t (TagT action) = do
+  tags <- getTags t
+  runReaderT action tags
+
+-- | A class for monads which contain tags, e.g. for logging, spans, etc.
+class (Monad m) => MonadTags m where
+  askTags :: m (Map Text Text)
+  withTags :: Map Text Text -> m a -> m a
+
+instance (Monad m) => MonadTags (TagT m) where
+  askTags = TagT ask
+  withTags newTags (TagT m) = TagT $ local (newTags <>) m
+
+instance (MonadTags m) => MonadTags (ReaderT e m) where
+  askTags = lift askTags
+  withTags newTags = mapReaderT (withTags newTags)
+
+class HasTags ctx where
+  getTags :: (MonadIO m) => ctx -> m Tags
+  addTags :: Tags -> ctx -> ctx
+
+instance HasTags () where
+  getTags _ = pure mempty
+  addTags _ ctx = ctx
+
+instance HasTags Tags where
+  getTags = pure
+  addTags newTags ctx = ctx <> newTags

--- a/src/Share/Web/App.hs
+++ b/src/Share/Web/App.hs
@@ -75,17 +75,6 @@ freshRequestCtx = do
         }
     )
 
--- instance HasTags RequestCtx where
---   -- Get the tags associated with the current request.
---   getTags RequestCtx {reqTagsVar, localTags} = do
---     reqTags <- liftIO $ readTVarIO reqTagsVar
---     -- local tags take precedence over request tags
---     pure $ localTags <> reqTags
---   updateTags f reqCtx = do
---     tags <- getTags reqCtx
---     let newTags = f tags
---     pure $ reqCtx {localTags = newTags <> localTags reqCtx}
-
 -- | Add a tag to the current request. This tag will be used in logging and error reports
 addRequestTag :: (MonadReader (Env RequestCtx) m, MonadIO m) => Text -> Text -> m ()
 addRequestTag k v = do

--- a/src/Share/Web/App.hs
+++ b/src/Share/Web/App.hs
@@ -10,7 +10,6 @@ module Share.Web.App
     freshRequestCtx,
     addRequestTag,
     addServerTag,
-    getTags,
     shouldUseCaching,
   )
 where
@@ -24,6 +23,7 @@ import Share.App
 import Share.Env
 import Share.IDs (RequestId, UserId)
 import Share.Prelude
+import Share.Utils.Tags
 import UnliftIO.STM
 
 type WebApp = AppM RequestCtx
@@ -48,6 +48,17 @@ data RequestCtx = RequestCtx
     rawURI :: Maybe URI
   }
 
+instance HasTags RequestCtx where
+  getTags RequestCtx {reqTagsVar, localTags} = do
+    reqTags <- liftIO $ readTVarIO reqTagsVar
+    -- local tags take precedence over request tags
+    pure $ localTags <> reqTags
+
+  addTags newTags reqCtx =
+    reqCtx
+      { localTags = newTags <> localTags reqCtx
+      }
+
 -- | Generate an empty request context
 freshRequestCtx :: (MonadIO m) => m RequestCtx
 freshRequestCtx = do
@@ -64,16 +75,16 @@ freshRequestCtx = do
         }
     )
 
-instance HasTags RequestCtx where
-  -- Get the tags associated with the current request.
-  getTags RequestCtx {reqTagsVar, localTags} = do
-    reqTags <- liftIO $ readTVarIO reqTagsVar
-    -- local tags take precedence over request tags
-    pure $ localTags <> reqTags
-  updateTags f reqCtx = do
-    tags <- getTags reqCtx
-    let newTags = f tags
-    pure $ reqCtx {localTags = newTags <> localTags reqCtx}
+-- instance HasTags RequestCtx where
+--   -- Get the tags associated with the current request.
+--   getTags RequestCtx {reqTagsVar, localTags} = do
+--     reqTags <- liftIO $ readTVarIO reqTagsVar
+--     -- local tags take precedence over request tags
+--     pure $ localTags <> reqTags
+--   updateTags f reqCtx = do
+--     tags <- getTags reqCtx
+--     let newTags = f tags
+--     pure $ reqCtx {localTags = newTags <> localTags reqCtx}
 
 -- | Add a tag to the current request. This tag will be used in logging and error reports
 addRequestTag :: (MonadReader (Env RequestCtx) m, MonadIO m) => Text -> Text -> m ()

--- a/src/Share/Web/Errors.hs
+++ b/src/Share/Web/Errors.hs
@@ -62,6 +62,7 @@ import Share.OAuth.Types (AuthenticationRequest (..), RedirectReceiverErr (..))
 import Share.Prelude
 import Share.Utils.Logging
 import Share.Utils.Logging qualified as Logging
+import Share.Utils.Tags (askTags)
 import Share.Utils.URI (URIParam (..), addQueryParam)
 import Share.Web.App
 import Unison.Server.Backend qualified as Backend
@@ -183,7 +184,7 @@ reportError e = do
   let (ErrorID errID, serverErr) = toServerError e
   env <- ask
   RequestCtx {pathInfo, rawURI} <- asks Env.ctx
-  reqTags <- liftIO $ getTags env
+  reqTags <- askTags
   let errLog@LogMsg {msg} = withTag ("error-id", errID) $ toLog e
   -- We emit a separate log message for each error, but it's also
   -- handy to have that data on the main log for the request.

--- a/src/Share/Web/UCM/Sync/Impl.hs
+++ b/src/Share/Web/UCM/Sync/Impl.hs
@@ -43,6 +43,7 @@ import Share.Project (Project (..))
 import Share.User (User (..))
 import Share.Utils.Logging qualified as Logging
 import Share.Utils.Servant (parseParam)
+import Share.Utils.Tags (HasTags)
 import Share.Web.App
 import Share.Web.Authentication qualified as AuthN
 import Share.Web.Authorization qualified as AuthZ
@@ -226,7 +227,7 @@ uploadEntitiesEndpoint callingUserId (UploadEntitiesRequest {repoInfo, entities}
 -- | Insert entities to the user's codebase (either temp storage or main), returning the hashes of any missing dependencies
 -- we still need from the client.
 insertEntitiesToCodebase ::
-  (Env.HasTags r) =>
+  (HasTags r) =>
   CodebaseEnv ->
   NEMap Hash32 (Sync.Entity Text Hash32 Hash32) ->
   AppM r (Either Sync.EntityValidationError (Maybe (NESet Hash32)))
@@ -310,7 +311,7 @@ insertEntitiesToCodebase codebase entities = do
 -- There's a bug somewhere in sync where sometimes entities that are ready to flush get stuck
 -- in temp, and this can also happen if certain requests get interrupted.
 -- Ideally we wouldn't need this, but it's easy enough to add and addresses this problem.
-ensureCausalIsFlushed :: (Env.HasTags r) => CodebaseEnv -> CausalHash -> AppM r (Maybe CausalId)
+ensureCausalIsFlushed :: (HasTags r) => CodebaseEnv -> CausalHash -> AppM r (Maybe CausalId)
 ensureCausalIsFlushed codebase causalHash = do
   PG.runTransaction (CausalQ.loadCausalIdByHash codebase causalHash) >>= \case
     Just cid -> pure (Just cid)
@@ -359,7 +360,7 @@ groupEntities = foldMap
 --
 -- Keep flushing to a fixed point (i.e. until we have no remaining entities that lack
 -- missing dependencies)
-flushTempEntities :: (Env.HasTags r) => CodebaseEnv -> NESet Hash32 -> AppM r ()
+flushTempEntities :: (HasTags r) => CodebaseEnv -> NESet Hash32 -> AppM r ()
 flushTempEntities codebase hashesToCheck = do
   -- This is designed so that if multiple requests are working at once, they can
   -- all make progress using short transactions without accidentally working on the same

--- a/stack.yaml
+++ b/stack.yaml
@@ -51,6 +51,18 @@ extra-deps:
 - network-udp-0.0.0@sha256:408d2d4fa1a25e49e95752ee124cca641993404bb133ae10fb81daef22d876ae,1075
 - recover-rtti-0.5.0@sha256:7d598b0c89dac9e170b488a7a50b322fcae06342fbd2da18cb8a7f93a0b44e68,4913
 
+# Open telemetry stuff
+- hs-opentelemetry-sdk-0.1.0.0@sha256:2642851866f11a494c99f15202d4bd9e75d4a5e1a7f3f172742a0676a33c664f,4059
+- hs-opentelemetry-api-0.2.0.0@sha256:bbdbe7e212e99f17a7e68d09b94c1a6613e50ce88b3cb1b68979bbb0221291ae,4051
+- hs-opentelemetry-exporter-otlp-0.1.0.0@sha256:4c908a7e2e5053879687b7a7ee6e40a8eb22868e1a0808cd0cfd6ac9905057b8,1526
+- hs-opentelemetry-propagator-b3-0.0.1.2@sha256:8815dd74f27a908b5be0729cc09a3bf9f3049481c982252bbd6c3f6b908ecfcd,1340
+- hs-opentelemetry-propagator-datadog-0.0.1.0@sha256:c85de95e3c33b3ffcf980f560166e960cab0888e0741315f487288b3653c007c,2950
+- hs-opentelemetry-propagator-w3c-0.0.1.4@sha256:251428754454fbaf71d9b6acbbea473014b1ab50bdcda8bc8fe1532e63193374,1382
+- hs-opentelemetry-otlp-0.1.0.0@sha256:5cd096b15f26f51ffae4c18f6a26794daef801acc9e13033db8b21a7606336d4,2533
+- hs-opentelemetry-instrumentation-wai-0.1.1.0@sha256:d97b4cb3870217e64e95da3f51db814eca62eb57484ee0a6f747366da5940bc2,1371
+- thread-utils-context-0.3.0.4@sha256:e763da1c6cab3b6d378fb670ca74aa9bf03c9b61b6fcf7628c56363fb0e3e71e,1671
+- thread-utils-finalizers-0.1.1.0@sha256:24944b71d9f1d01695a5908b4a3b44838fab870883114a323336d537995e0a5b,1381
+
 # Bumping hasql up to get Pipelining mode
 - hasql-1.8.1.1
 - hasql-pool-1.2.0.2

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -68,6 +68,76 @@ packages:
   original:
     hackage: recover-rtti-0.5.0@sha256:7d598b0c89dac9e170b488a7a50b322fcae06342fbd2da18cb8a7f93a0b44e68,4913
 - completed:
+    hackage: hs-opentelemetry-sdk-0.1.0.0@sha256:2642851866f11a494c99f15202d4bd9e75d4a5e1a7f3f172742a0676a33c664f,4059
+    pantry-tree:
+      sha256: c0868a6eb3d6add84df1ad32cdb0ebdbebe41205897e16ae8b30e96f205a8fe0
+      size: 1934
+  original:
+    hackage: hs-opentelemetry-sdk-0.1.0.0@sha256:2642851866f11a494c99f15202d4bd9e75d4a5e1a7f3f172742a0676a33c664f,4059
+- completed:
+    hackage: hs-opentelemetry-api-0.2.0.0@sha256:bbdbe7e212e99f17a7e68d09b94c1a6613e50ce88b3cb1b68979bbb0221291ae,4051
+    pantry-tree:
+      sha256: fcb11b19fa633afb8c34e002e6b8e8927d20fc2332d4234cc10a0b6e3dbe6022
+      size: 4396
+  original:
+    hackage: hs-opentelemetry-api-0.2.0.0@sha256:bbdbe7e212e99f17a7e68d09b94c1a6613e50ce88b3cb1b68979bbb0221291ae,4051
+- completed:
+    hackage: hs-opentelemetry-exporter-otlp-0.1.0.0@sha256:4c908a7e2e5053879687b7a7ee6e40a8eb22868e1a0808cd0cfd6ac9905057b8,1526
+    pantry-tree:
+      sha256: dd22c915f65b1ca76c6130cfb39ce666376d4813c267e12dd59be61a914bb264
+      size: 511
+  original:
+    hackage: hs-opentelemetry-exporter-otlp-0.1.0.0@sha256:4c908a7e2e5053879687b7a7ee6e40a8eb22868e1a0808cd0cfd6ac9905057b8,1526
+- completed:
+    hackage: hs-opentelemetry-propagator-b3-0.0.1.2@sha256:8815dd74f27a908b5be0729cc09a3bf9f3049481c982252bbd6c3f6b908ecfcd,1340
+    pantry-tree:
+      sha256: fc71f8b7dc25625af6b81c1b3c1c5d808b682e2a7c1daf8e23f2af45ab9dc123
+      size: 431
+  original:
+    hackage: hs-opentelemetry-propagator-b3-0.0.1.2@sha256:8815dd74f27a908b5be0729cc09a3bf9f3049481c982252bbd6c3f6b908ecfcd,1340
+- completed:
+    hackage: hs-opentelemetry-propagator-datadog-0.0.1.0@sha256:c85de95e3c33b3ffcf980f560166e960cab0888e0741315f487288b3653c007c,2950
+    pantry-tree:
+      sha256: 04c10d8901e506c8c7662c8ce549a152118303fd2d0354a887bede4e73f0a8ee
+      size: 730
+  original:
+    hackage: hs-opentelemetry-propagator-datadog-0.0.1.0@sha256:c85de95e3c33b3ffcf980f560166e960cab0888e0741315f487288b3653c007c,2950
+- completed:
+    hackage: hs-opentelemetry-propagator-w3c-0.0.1.4@sha256:251428754454fbaf71d9b6acbbea473014b1ab50bdcda8bc8fe1532e63193374,1382
+    pantry-tree:
+      sha256: 5f7ff3fd37b7f720064193f02c84e8af6b554f8a7a2b7702a4bcd34fe576f721
+      size: 445
+  original:
+    hackage: hs-opentelemetry-propagator-w3c-0.0.1.4@sha256:251428754454fbaf71d9b6acbbea473014b1ab50bdcda8bc8fe1532e63193374,1382
+- completed:
+    hackage: hs-opentelemetry-otlp-0.1.0.0@sha256:5cd096b15f26f51ffae4c18f6a26794daef801acc9e13033db8b21a7606336d4,2533
+    pantry-tree:
+      sha256: 618a513764a7ae9995fc4f8b8ee5cec731a8759ac8c5df8e9553171abd3ff97d
+      size: 2585
+  original:
+    hackage: hs-opentelemetry-otlp-0.1.0.0@sha256:5cd096b15f26f51ffae4c18f6a26794daef801acc9e13033db8b21a7606336d4,2533
+- completed:
+    hackage: hs-opentelemetry-instrumentation-wai-0.1.1.0@sha256:d97b4cb3870217e64e95da3f51db814eca62eb57484ee0a6f747366da5940bc2,1371
+    pantry-tree:
+      sha256: 23bbd4e58ba48b0ec3541a494d02e08e6b934d7173523be8aab04c6b2c7bb98b
+      size: 360
+  original:
+    hackage: hs-opentelemetry-instrumentation-wai-0.1.1.0@sha256:d97b4cb3870217e64e95da3f51db814eca62eb57484ee0a6f747366da5940bc2,1371
+- completed:
+    hackage: thread-utils-context-0.3.0.4@sha256:e763da1c6cab3b6d378fb670ca74aa9bf03c9b61b6fcf7628c56363fb0e3e71e,1671
+    pantry-tree:
+      sha256: 57d909a991b5e0b4c7a28121cb52ee9c2db6c09e0419b89af6c82fae52be88d4
+      size: 397
+  original:
+    hackage: thread-utils-context-0.3.0.4@sha256:e763da1c6cab3b6d378fb670ca74aa9bf03c9b61b6fcf7628c56363fb0e3e71e,1671
+- completed:
+    hackage: thread-utils-finalizers-0.1.1.0@sha256:24944b71d9f1d01695a5908b4a3b44838fab870883114a323336d537995e0a5b,1381
+    pantry-tree:
+      sha256: 8c2c2e2e22c20bf3696ee6f30b50b3a9eeae187a22beb536441eefb0a3f9c549
+      size: 400
+  original:
+    hackage: thread-utils-finalizers-0.1.1.0@sha256:24944b71d9f1d01695a5908b4a3b44838fab870883114a323336d537995e0a5b,1381
+- completed:
     hackage: hasql-1.8.1.1@sha256:fca990145dcb255a769248452b160edc5381b930f9739c1cb6ad9dd83a52e4cb,5674
     pantry-tree:
       sha256: ee285302e2c9ac4b148ec4f35b1ff01fb4604d1d02d362a54f646b5b74c491d3


### PR DESCRIPTION
- [x] Add or disable telemetry collection on Prod

## Overview

Adds open telemetry instrumentation for better observability.
Currently we don't actually collect these on prod, but that should be relatively easy to set up.

## Implementation notes

* Adds open telemetry middleware to tag every request with a span
* Adds a new `withSpan` helper for spans in App code
* Adds `transactionSpan` for adding a span to a chunk of code in a transaction
* Auto-tags every transaction with its callsite.
* Tracks the number of queries made within each transaction.
* Allows enabling a span for every query, but this is disabled by default cuz it's too noisy and would likely slow the app down.
