### PR TITLE
Batch up name lookup queries

### DIFF
--- a/sql/2025-07-14_batch_name_lookups.sql
+++ b/sql/2025-07-14_batch_name_lookups.sql
@@ -86,10 +86,10 @@ BEGIN
       FROM unnest(names) AS n(reversed_name, suffixified_name);
   ELSE
     RETURN QUERY
-      SELECT (reversed_name || reversed_mount_path) AS reversed_name, suffixify_term_fqn(arg_bh_id, arg_namespace_prefix, reversed_mount_path, ROW(scoped_term_name_lookup.*)) AS suffixified_name
+      SELECT (stnl.reversed_name || reversed_mount_path) AS reversed_name, suffixify_term_fqn(arg_bh_id, arg_namespace_prefix, reversed_mount_path, ROW(stnl.*)) AS suffixified_name
         FROM transitive_dependency_mounts(arg_bh_id)
-          INNER JOIN scoped_term_name_lookup
-            ON scoped_term_name_lookup.root_branch_hash_id = transitive_dependency_mounts.root_branch_hash_id
+          INNER JOIN scoped_term_name_lookup stnl
+            ON stnl.root_branch_hash_id = transitive_dependency_mounts.root_branch_hash_id
       WHERE (
               (arg_referent_builtin IS NULL
                   AND referent_builtin IS NULL
@@ -101,7 +101,7 @@ BEGIN
               ( arg_referent_builtin IS NOT NULL
                 AND referent_builtin = arg_referent_builtin
               )
-            ) AND reversed_name LIKE like_escape(arg_reversed_name_prefix) || '%'
+            ) AND stnl.reversed_name LIKE like_escape(arg_reversed_name_prefix) || '%'
       LIMIT 1;
   END IF;
 END;

--- a/sql/2025-07-14_batch_name_lookups.sql
+++ b/sql/2025-07-14_batch_name_lookups.sql
@@ -1,0 +1,110 @@
+CREATE TYPE name_with_suffix AS (
+   reversed_name TEXT,
+   suffixified_name TEXT
+);
+
+CREATE OR REPLACE FUNCTION transitive_dependency_mounts(arg_root_branch_hash_id integer)
+RETURNS TABLE (
+  root_branch_hash_id integer,
+  reversed_mount_path text
+) AS $$
+    WITH RECURSIVE
+      transitive_dependency_mounts(root_branch_hash_id, reversed_mount_path) AS (
+        -- We've already searched direct deps above, so start with children of direct deps
+        SELECT transitive.mounted_root_branch_hash_id, transitive.reversed_mount_path || direct.reversed_mount_path
+        FROM name_lookup_mounts direct
+              JOIN name_lookup_mounts transitive on direct.mounted_root_branch_hash_id = transitive.parent_root_branch_hash_id
+        WHERE direct.parent_root_branch_hash_id = arg_root_branch_hash_id
+        UNION ALL
+        SELECT mount.mounted_root_branch_hash_id, mount.reversed_mount_path || rec.reversed_mount_path
+        FROM name_lookup_mounts mount
+          INNER JOIN transitive_dependency_mounts rec ON mount.parent_root_branch_hash_id = rec.root_branch_hash_id
+    ) SELECT root_branch_hash_id, reversed_mount_path
+        FROM transitive_dependency_mounts;
+$$ LANGUAGE sql STABLE;
+
+CREATE OR REPLACE FUNCTION term_names_for_ref_within_namespace(
+  arg_bh_id integer,
+  arg_namespace_prefix text,
+  arg_referent_builtin text,
+  arg_referent_component_hash_id integer,
+  arg_referent_component_index integer,
+  arg_referent_constructor_index integer,
+  arg_reversed_name_prefix text
+) RETURNS TABLE (
+  reversed_name text,
+  suffixified_name text
+) AS $$
+DECLARE
+  names name_with_suffix[];
+BEGIN
+  SELECT array_agg(ROW(reversed_name, suffixified_name)::name_with_suffix) INTO names
+        FROM (
+          SELECT reversed_name, suffixify_term_fqn(arg_bh_id, arg_namespace_prefix, '', ROW(scoped_term_name_lookup.*)) AS suffixified_name
+            FROM scoped_term_name_lookup
+          WHERE root_branch_hash_id = arg_bh_id
+                -- This may seem overly verbose, but it nudges the query planner to use the
+                -- correct partial index, which is keyed on whether the refBuiltin is null or not.
+                AND (
+                  (arg_referent_builtin IS NULL
+                      AND referent_builtin IS NULL
+                      AND referent_component_hash_id = arg_referent_component_hash_id
+                      AND referent_component_index = arg_referent_component_index
+                      AND referent_constructor_index IS NOT DISTINCT FROM arg_referent_constructor_index
+                  )
+                  OR
+                  ( arg_referent_builtin IS NOT NULL
+                    AND referent_builtin = arg_referent_builtin
+                  )
+                )
+                AND namespace LIKE like_escape(arg_namespace_prefix) || '%'
+                AND reversed_name LIKE like_escape(arg_reversed_name_prefix) || '%'
+          UNION ALL
+          SELECT (names.reversed_name || mount.reversed_mount_path) AS reversed_name, suffixify_term_fqn(arg_bh_id, arg_namespace_prefix, mount.reversed_mount_path, ROW(names.*)) AS suffixified_name
+          FROM name_lookup_mounts mount
+            INNER JOIN scoped_term_name_lookup names ON names.root_branch_hash_id = mount.mounted_root_branch_hash_id
+          WHERE mount.parent_root_branch_hash_id = arg_bh_id
+                AND mount.mount_path LIKE like_escape(arg_namespace_prefix) || '%'
+                AND (
+                  (arg_referent_builtin IS NULL
+                      AND referent_builtin IS NULL
+                      AND referent_component_hash_id = arg_referent_component_hash_id
+                      AND referent_component_index = arg_referent_component_index
+                      AND referent_constructor_index IS NOT DISTINCT FROM arg_referent_constructor_index
+                  )
+                  OR
+                  ( arg_referent_builtin IS NOT NULL
+                    AND referent_builtin = arg_referent_builtin
+                  )
+                )
+                AND reversed_name LIKE like_escape(arg_reversed_name_prefix) || '%'
+        ) AS names
+        ORDER BY length(reversed_name) ASC;
+
+  IF names IS NOT NULL AND array_length(names, 1) > 0 THEN
+    RETURN QUERY 
+      SELECT n.reversed_name, n.suffixified_name 
+      FROM unnest(names) AS n(reversed_name, suffixified_name);
+  ELSE
+    RETURN QUERY
+      SELECT (reversed_name || reversed_mount_path) AS reversed_name, suffixify_term_fqn(arg_bh_id, arg_namespace_prefix, reversed_mount_path, ROW(scoped_term_name_lookup.*)) AS suffixified_name
+        FROM transitive_dependency_mounts(arg_bh_id)
+          INNER JOIN scoped_term_name_lookup
+            ON scoped_term_name_lookup.root_branch_hash_id = transitive_dependency_mounts.root_branch_hash_id
+      WHERE (
+              (arg_referent_builtin IS NULL
+                  AND referent_builtin IS NULL
+                  AND referent_component_hash_id = arg_referent_component_hash_id
+                  AND referent_component_index = arg_referent_component_index
+                  AND referent_constructor_index IS NOT DISTINCT FROM arg_referent_constructor_index
+              )
+              OR
+              ( arg_referent_builtin IS NOT NULL
+                AND referent_builtin = arg_referent_builtin
+              )
+            ) AND reversed_name LIKE like_escape(arg_reversed_name_prefix) || '%'
+      LIMIT 1;
+  END IF;
+END;
+$$ LANGUAGE plpgsql STABLE;
+

--- a/sql/2025-07-14_batch_name_lookups.sql
+++ b/sql/2025-07-14_batch_name_lookups.sql
@@ -107,3 +107,81 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql STABLE;
 
+CREATE OR REPLACE FUNCTION type_names_for_ref_within_namespace(
+  arg_bh_id integer,
+  arg_namespace_prefix text,
+  arg_reference_builtin text,
+  arg_reference_component_hash_id integer,
+  arg_reference_component_index bigint,
+  arg_reversed_name_prefix text
+) RETURNS TABLE (
+  reversed_name text,
+  suffixified_name text
+) AS $$
+DECLARE
+  names name_with_suffix[];
+BEGIN
+  SELECT array_agg(ROW(names.reversed_name, names.suffixified_name)::name_with_suffix) INTO names
+        FROM (
+          SELECT stnl.reversed_name, suffixify_type_fqn(arg_bh_id, arg_namespace_prefix, '', ROW(stnl.*)) AS suffixified_name
+            FROM scoped_type_name_lookup stnl
+          WHERE root_branch_hash_id = arg_bh_id
+                -- This may seem overly verbose, but it nudges the query planner to use the
+                -- correct partial index, which is keyed on whether the refBuiltin is null or not.
+                AND (
+                  (arg_reference_builtin IS NULL
+                      AND reference_builtin IS NULL
+                      AND reference_component_hash_id = arg_reference_component_hash_id
+                      AND reference_component_index = arg_reference_component_index
+                  )
+                  OR
+                  ( arg_reference_builtin IS NOT NULL
+                    AND reference_builtin = arg_reference_builtin
+                  )
+                )
+                AND namespace LIKE like_escape(arg_namespace_prefix) || '%'
+                AND stnl.reversed_name LIKE like_escape(arg_reversed_name_prefix) || '%'
+          UNION ALL
+          SELECT (names.reversed_name || mount.reversed_mount_path) AS reversed_name, suffixify_type_fqn(arg_bh_id, arg_namespace_prefix, mount.reversed_mount_path, ROW(names.*)) AS suffixified_name
+          FROM name_lookup_mounts mount
+            INNER JOIN scoped_type_name_lookup names ON names.root_branch_hash_id = mount.mounted_root_branch_hash_id
+          WHERE mount.parent_root_branch_hash_id = arg_bh_id
+                AND mount.mount_path LIKE like_escape(arg_namespace_prefix) || '%'
+                AND (
+                  (arg_reference_builtin IS NULL
+                      AND reference_builtin IS NULL
+                      AND reference_component_hash_id = arg_reference_component_hash_id
+                      AND reference_component_index = arg_reference_component_index
+                  )
+                  OR
+                  ( arg_reference_builtin IS NOT NULL
+                    AND reference_builtin = arg_reference_builtin
+                  )
+                ) AND names.reversed_name LIKE like_escape(arg_reversed_name_prefix) || '%'
+        ) AS names;
+
+  IF names IS NOT NULL AND array_length(names, 1) > 0 THEN
+    RETURN QUERY 
+      SELECT n.reversed_name, n.suffixified_name 
+      FROM unnest(names) AS n(reversed_name, suffixified_name);
+  ELSE
+    RETURN QUERY
+      SELECT (stnl.reversed_name || reversed_mount_path) AS reversed_name, suffixify_type_fqn(arg_bh_id, arg_namespace_prefix, reversed_mount_path, ROW(stnl.*)) AS suffixified_name
+        FROM transitive_dependency_mounts(arg_bh_id)
+          INNER JOIN scoped_type_name_lookup stnl
+            ON stnl.root_branch_hash_id = transitive_dependency_mounts.root_branch_hash_id
+      WHERE (
+              (arg_reference_builtin IS NULL
+                  AND reference_builtin IS NULL
+                  AND reference_component_hash_id = arg_reference_component_hash_id
+                  AND reference_component_index = arg_reference_component_index
+              )
+              OR
+              ( arg_reference_builtin IS NOT NULL
+                AND reference_builtin = arg_reference_builtin
+              )
+            ) AND stnl.reversed_name LIKE like_escape(arg_reversed_name_prefix) || '%'
+      LIMIT 1;
+  END IF;
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/src/Share/Names/Postgres.hs
+++ b/src/Share/Names/Postgres.hs
@@ -28,15 +28,22 @@ namesForReferences namesPerspective refs = do
       & PG.pipelined
 
   termNames <- concat <$> termNamesOf traversed pgRefTerms
-  typeNames <- concat <$> traverse typeNamesForReference pgRefTypes
+  typeNames <- concat <$> typeNamesOf traversed pgRefTypes
   pure $ Names.fromTermsAndTypes termNames typeNames
   where
     -- TODO: Can probably speed this up by skipping suffixification.
-    typeNamesForReference :: (V1.Reference, PGReference) -> m [(Name, V1.Reference)]
-    typeNamesForReference (ref, pgref) = do
-      typeNames <- fmap (bothMap NameLookups.reversedNameToName) <$> NameLookupOps.typeNamesForRefWithinNamespace namesPerspective pgref Nothing
-      let typeNames' = typeNames <&> \(fqn, _suffixed) -> (fqn, ref)
-      pure $ typeNames'
+    typeNamesOf :: Traversal s t (V1.Reference, PGReference) [(Name, V1.Reference)] -> s -> m t
+    typeNamesOf trav s = do
+      s
+        & unsafePartsOf trav %%~ \refs -> do
+          let pgRefs = snd <$> refs
+          typeNames :: [[(NameLookups.ReversedName, NameLookups.ReversedName)]] <-
+            NameLookupOps.typeNamesForRefsWithinNamespaceOf namesPerspective Nothing traversed pgRefs
+          pure $ do
+            ((ref, _pgRef), names) <- zip refs typeNames
+            pure $ do
+              (fqn, _suffixed) <- names
+              pure $ (NameLookups.reversedNameToName fqn, ref)
 
     termNamesOf :: Traversal s t (V1.Referent, PGReferent) [(Name, V1.Referent)] -> s -> m t
     termNamesOf trav s =

--- a/src/Share/Names/Postgres.hs
+++ b/src/Share/Names/Postgres.hs
@@ -31,7 +31,7 @@ namesForReferences namesPerspective refs = do
     namesForReference :: Either (V1.Referent, PGReferent) (V1.Reference, PGReference) -> m ([(Name, V1.Referent)], [(Name, V1.Reference)])
     namesForReference = \case
       Left (ref, pgref) -> do
-        termNames <- fmap (bothMap NameLookups.reversedNameToName) <$> NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective id pgref
+        termNames <- fmap (bothMap NameLookups.reversedNameToName) <$> NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective Nothing id pgref
         let termNames' = termNames <&> \(fqn, _suffixed) -> (fqn, ref)
         pure $ (termNames', [])
       Right (ref, pgref) -> do

--- a/src/Share/Names/Postgres.hs
+++ b/src/Share/Names/Postgres.hs
@@ -2,6 +2,7 @@
 module Share.Names.Postgres (namesForReferences) where
 
 import Control.Lens
+import Data.Either qualified as List
 import Data.Set qualified as Set
 import Share.Postgres qualified as PG
 import Share.Postgres.NameLookups.Conversions qualified as CV
@@ -19,22 +20,33 @@ import Unison.Referent qualified as V1
 
 namesForReferences :: forall m. (PG.QueryM m) => NamesPerspective -> Set LabeledDependency -> m Names
 namesForReferences namesPerspective refs = do
-  withPGRefs <-
+  (pgRefTerms, pgRefTypes) <-
     Set.toList refs
       & CV.labeledDependencies1ToPG
       & fmap catMaybes -- Filter out any missing components
+      & fmap List.partitionEithers
       & PG.pipelined
-  (termNames, typeNames) <- foldMapM namesForReference withPGRefs
+
+  termNames <- concat <$> termNamesOf traversed pgRefTerms
+  typeNames <- concat <$> traverse typeNamesForReference pgRefTypes
   pure $ Names.fromTermsAndTypes termNames typeNames
   where
     -- TODO: Can probably speed this up by skipping suffixification.
-    namesForReference :: Either (V1.Referent, PGReferent) (V1.Reference, PGReference) -> m ([(Name, V1.Referent)], [(Name, V1.Reference)])
-    namesForReference = \case
-      Left (ref, pgref) -> do
-        termNames <- fmap (bothMap NameLookups.reversedNameToName) <$> NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective Nothing id pgref
-        let termNames' = termNames <&> \(fqn, _suffixed) -> (fqn, ref)
-        pure $ (termNames', [])
-      Right (ref, pgref) -> do
-        typeNames <- fmap (bothMap NameLookups.reversedNameToName) <$> NameLookupOps.typeNamesForRefWithinNamespace namesPerspective pgref Nothing
-        let typeNames' = typeNames <&> \(fqn, _suffixed) -> (fqn, ref)
-        pure $ ([], typeNames')
+    typeNamesForReference :: (V1.Reference, PGReference) -> m [(Name, V1.Reference)]
+    typeNamesForReference (ref, pgref) = do
+      typeNames <- fmap (bothMap NameLookups.reversedNameToName) <$> NameLookupOps.typeNamesForRefWithinNamespace namesPerspective pgref Nothing
+      let typeNames' = typeNames <&> \(fqn, _suffixed) -> (fqn, ref)
+      pure $ typeNames'
+
+    termNamesOf :: Traversal s t (V1.Referent, PGReferent) [(Name, V1.Referent)] -> s -> m t
+    termNamesOf trav s =
+      s
+        & unsafePartsOf trav %%~ \refs -> do
+          let pgRefs = snd <$> refs
+          termNames :: [[(NameLookups.ReversedName, NameLookups.ReversedName)]] <-
+            NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective Nothing traversed pgRefs
+          pure $ do
+            ((ref, _pgRef), names) <- zip refs termNames
+            pure $ do
+              (fqn, _suffixed) <- names
+              pure $ (NameLookups.reversedNameToName fqn, ref)

--- a/src/Share/Names/Postgres.hs
+++ b/src/Share/Names/Postgres.hs
@@ -31,7 +31,7 @@ namesForReferences namesPerspective refs = do
     namesForReference :: Either (V1.Referent, PGReferent) (V1.Reference, PGReference) -> m ([(Name, V1.Referent)], [(Name, V1.Reference)])
     namesForReference = \case
       Left (ref, pgref) -> do
-        termNames <- fmap (bothMap NameLookups.reversedNameToName) <$> NameLookupOps.termNamesForRefWithinNamespace namesPerspective pgref Nothing
+        termNames <- fmap (bothMap NameLookups.reversedNameToName) <$> NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective id pgref
         let termNames' = termNames <&> \(fqn, _suffixed) -> (fqn, ref)
         pure $ (termNames', [])
       Right (ref, pgref) -> do

--- a/src/Share/Names/Postgres.hs
+++ b/src/Share/Names/Postgres.hs
@@ -7,6 +7,7 @@ import Data.Set qualified as Set
 import Share.Postgres qualified as PG
 import Share.Postgres.NameLookups.Conversions qualified as CV
 import Share.Postgres.NameLookups.Ops qualified as NameLookupOps
+import Share.Postgres.NameLookups.Queries (ShouldSuffixify (NoSuffixify))
 import Share.Postgres.NameLookups.Types (NamesPerspective)
 import Share.Postgres.NameLookups.Types qualified as NameLookups
 import Share.Postgres.Refs.Types
@@ -31,14 +32,13 @@ namesForReferences namesPerspective refs = do
   typeNames <- concat <$> typeNamesOf traversed pgRefTypes
   pure $ Names.fromTermsAndTypes termNames typeNames
   where
-    -- TODO: Can probably speed this up by skipping suffixification.
     typeNamesOf :: Traversal s t (V1.Reference, PGReference) [(Name, V1.Reference)] -> s -> m t
     typeNamesOf trav s = do
       s
         & unsafePartsOf trav %%~ \refs -> do
           let pgRefs = snd <$> refs
           typeNames :: [[(NameLookups.ReversedName, NameLookups.ReversedName)]] <-
-            NameLookupOps.typeNamesForRefsWithinNamespaceOf namesPerspective Nothing traversed pgRefs
+            NameLookupOps.typeNamesForRefsWithinNamespaceOf namesPerspective Nothing NoSuffixify traversed pgRefs
           pure $ do
             ((ref, _pgRef), names) <- zip refs typeNames
             pure $ do
@@ -51,7 +51,7 @@ namesForReferences namesPerspective refs = do
         & unsafePartsOf trav %%~ \refs -> do
           let pgRefs = snd <$> refs
           termNames :: [[(NameLookups.ReversedName, NameLookups.ReversedName)]] <-
-            NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective Nothing traversed pgRefs
+            NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective Nothing NoSuffixify traversed pgRefs
           pure $ do
             ((ref, _pgRef), names) <- zip refs termNames
             pure $ do

--- a/src/Share/Postgres/Definitions/Queries.hs
+++ b/src/Share/Postgres/Definitions/Queries.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Share.Postgres.Definitions.Queries
   ( loadTerm,
@@ -292,7 +293,7 @@ expectTypeComponent codebase componentRef = do
 
 -- | Batch load terms by ids.
 loadTermsByIdsOf ::
-  (QueryA m) =>
+  (QueryA m, HasCallStack) =>
   UserId ->
   Traversal s t TermId (Maybe (V2.Term Symbol, V2.Type Symbol)) ->
   s ->
@@ -343,7 +344,7 @@ expectTermById userId refId termId =
 --           (_termId, Just t) -> Right t
 
 loadTermComponentElementByTermIdsOf ::
-  (QueryA m) =>
+  (QueryA m, HasCallStack) =>
   UserId ->
   Traversal s t TermId (Maybe TermComponentElement) ->
   s ->
@@ -371,7 +372,7 @@ termLocalReferences termId =
     <*> termLocalComponentReferences termId
 
 termLocalReferencesOf ::
-  (QueryA m) =>
+  (QueryA m, HasCallStack) =>
   Traversal s t TermId (Share.LocalIds Text ComponentHash) ->
   s ->
   m t
@@ -392,7 +393,7 @@ termLocalTextReferences termId =
           ORDER BY local_index ASC
       |]
 
-termLocalTextReferencesOf :: (QueryA m) => Traversal s t TermId [Text] -> s -> m t
+termLocalTextReferencesOf :: (QueryA m, HasCallStack) => Traversal s t TermId [Text] -> s -> m t
 termLocalTextReferencesOf trav s = do
   s & unsafePartsOf trav \termIds -> do
     let numberedTermIds = zip [0 :: Int32 ..] termIds
@@ -420,7 +421,7 @@ termLocalComponentReferences termId =
           ORDER BY local_index ASC
       |]
 
-termLocalComponentReferencesOf :: (QueryA m) => Traversal s t TermId [ComponentHash] -> s -> m t
+termLocalComponentReferencesOf :: (QueryA m, HasCallStack) => Traversal s t TermId [ComponentHash] -> s -> m t
 termLocalComponentReferencesOf trav s = do
   s & unsafePartsOf trav \termIds -> do
     let numberedTermIds = zip [0 :: Int32 ..] termIds
@@ -472,7 +473,7 @@ resolveConstructorTypeLocalIds (LocalIds.LocalIds {textLookup, defnLookup}) =
 loadDeclKind :: (PG.QueryA m) => TypeReferenceId -> m (Maybe CT.ConstructorType)
 loadDeclKind = loadDeclKindsOf id
 
-loadDeclKindsOf :: (PG.QueryA m) => Traversal s t TypeReferenceId (Maybe CT.ConstructorType) -> s -> m t
+loadDeclKindsOf :: (PG.QueryA m, HasCallStack) => Traversal s t TypeReferenceId (Maybe CT.ConstructorType) -> s -> m t
 loadDeclKindsOf trav s =
   s
     & unsafePartsOf trav %%~ \refIds -> do
@@ -691,7 +692,7 @@ ensureTextIds = ensureTextIdsOf traversed
 
 -- | Efficiently saves all Text's focused by the provided traversal into the database and
 -- replaces them with their corresponding Ids.
-ensureTextIdsOf :: (QueryM m) => Traversal s t Text TextId -> s -> m t
+ensureTextIdsOf :: (QueryM m, HasCallStack) => Traversal s t Text TextId -> s -> m t
 ensureTextIdsOf trav s = do
   s
     & unsafePartsOf trav %%~ \texts -> do
@@ -723,7 +724,7 @@ ensureBytesIds = ensureBytesIdsOf traversed
 
 -- | Efficiently saves all bytestrings focused by the provided traversal into the database and
 -- replaces them with their corresponding Ids.
-ensureBytesIdsOf :: (QueryM m) => Traversal s t BS.ByteString BytesId -> s -> m t
+ensureBytesIdsOf :: (QueryM m, HasCallStack) => Traversal s t BS.ByteString BytesId -> s -> m t
 ensureBytesIdsOf trav s = do
   s
     & unsafePartsOf trav %%~ \bytestrings -> do
@@ -750,7 +751,7 @@ ensureBytesIdsOf trav s = do
         else pure results
 
 -- | Efficiently loads Texts for all TextIds focused by the provided traversal.
-expectTextsOf :: (QueryM m) => Traversal s t TextId Text -> s -> m t
+expectTextsOf :: (QueryM m, HasCallStack) => Traversal s t TextId Text -> s -> m t
 expectTextsOf trav =
   unsafePartsOf trav %%~ \textIds -> do
     let numberedTextIds = zip [0 :: Int32 ..] textIds
@@ -1141,7 +1142,7 @@ saveTypeComponent (codebase@CodebaseEnv {codebaseOwner}) componentHash maySerial
       pure typeIds
 
 -- | Efficiently resolve all pg Ids across selected Local Ids.
-resolveLocalIdsOf :: (QueryM m) => Traversal s t PgLocalIds ResolvedLocalIds -> s -> m t
+resolveLocalIdsOf :: (QueryM m, HasCallStack) => Traversal s t PgLocalIds ResolvedLocalIds -> s -> m t
 resolveLocalIdsOf trav s = do
   s
     & unsafePartsOf trav %%~ \pgLocalIds -> do

--- a/src/Share/Postgres/NameLookups/Ops.hs
+++ b/src/Share/Postgres/NameLookups/Ops.hs
@@ -141,11 +141,11 @@ fuzzySearchDefinitions includeDependencies NamesPerspective {nameLookupBranchHas
     typeNames <- pgTypeNames & CV.referencesPGTo2Of (traversed . _2 . traversed)
     pure (termNames, typeNames)
 
-termNamesForRefsWithinNamespaceOf :: (PG.QueryM m) => NamesPerspective -> Traversal s t PGReferent [(ReversedName, ReversedName)] -> s -> m t
-termNamesForRefsWithinNamespaceOf NamesPerspective {nameLookupBranchHashId, pathToMountedNameLookup, nameLookupReceipt} trav s = do
+termNamesForRefsWithinNamespaceOf :: (PG.QueryM m) => NamesPerspective -> Maybe ReversedName -> Traversal s t PGReferent [(ReversedName, ReversedName)] -> s -> m t
+termNamesForRefsWithinNamespaceOf NamesPerspective {nameLookupBranchHashId, pathToMountedNameLookup, nameLookupReceipt} maySuffix trav s = do
   s
     & unsafePartsOf trav %%~ \refs -> do
-      NameLookupQ.termNamesForRefsWithinNamespaceOf nameLookupReceipt nameLookupBranchHashId mempty Nothing traversed refs
+      NameLookupQ.termNamesForRefsWithinNamespaceOf nameLookupReceipt nameLookupBranchHashId mempty maySuffix traversed refs
         <&> (fmap . fmap) \(NameWithSuffix {reversedName, suffixifiedName}) ->
           ( prefixReversedName pathToMountedNameLookup reversedName,
             suffixifiedName

--- a/src/Share/Postgres/NameLookups/Queries.hs
+++ b/src/Share/Postgres/NameLookups/Queries.hs
@@ -59,7 +59,7 @@ termNamesForRefsWithinNamespaceOf !_nameLookupReceipt bhId namespaceRoot maySuff
         WITH refs(ord, referent_builtin, referent_component_hash_id, referent_component_index, referent_constructor_index) AS (
           SELECT * FROM ^{PG.toTable refsTable}
         )
-        SELECT array_agg((reversed_name, suffixified_name):: ORDER BY length(reversed_name) ASC) AS ref_names
+        SELECT array_agg((reversed_name, suffixified_name) ORDER BY length(reversed_name) ASC) AS ref_names
           FROM refs
           CROSS JOIN LATERAL
             term_names_for_ref_within_namespace(

--- a/src/Share/Postgres/NameLookups/Queries.hs
+++ b/src/Share/Postgres/NameLookups/Queries.hs
@@ -4,6 +4,7 @@
 
 module Share.Postgres.NameLookups.Queries
   ( termNamesForRefWithinNamespace,
+    termNamesForRefsWithinNamespaceOf,
     typeNamesForRefWithinNamespace,
     termRefsForExactName,
     typeRefsForExactName,

--- a/src/Share/Postgres/NameLookups/Queries.hs
+++ b/src/Share/Postgres/NameLookups/Queries.hs
@@ -59,7 +59,7 @@ termNamesForRefsWithinNamespaceOf !_nameLookupReceipt bhId namespaceRoot maySuff
         WITH refs(ord, referent_builtin, referent_component_hash_id, referent_component_index, referent_constructor_index) AS (
           SELECT * FROM ^{PG.toTable refsTable}
         )
-        SELECT array_agg((reversed_name, suffixified_name) ORDER BY length(reversed_name) ASC) AS ref_names
+        SELECT array_agg((names.reversed_name, names.suffixified_name) ORDER BY length(names.reversed_name) ASC) AS ref_names
           FROM refs
           CROSS JOIN LATERAL
             term_names_for_ref_within_namespace(
@@ -70,7 +70,7 @@ termNamesForRefsWithinNamespaceOf !_nameLookupReceipt bhId namespaceRoot maySuff
               refs.referent_component_index,
               refs.referent_constructor_index,
               #{reversedNamePrefix}
-            ) 
+            ) AS names(reversed_name, suffixified_name)
           GROUP BY refs.ord
           ORDER BY refs.ord ASC
       |]

--- a/src/Share/PrettyPrintEnvDecl/Postgres.hs
+++ b/src/Share/PrettyPrintEnvDecl/Postgres.hs
@@ -26,6 +26,7 @@ ppedForReferences namesPerspective refs = do
       & CV.labeledDependencies1ToPG
       & fmap catMaybes -- Filter out any missing components
       & fmap List.partitionEithers
+      & PG.pipelined
   termNames <- concat <$> termNamesOf traversed pgRefTerms
   typeNames <- concat <$> traverse typeName pgRefTypes
   pure $ ppedFromNamesWithSuffixes termNames typeNames

--- a/src/Share/PrettyPrintEnvDecl/Postgres.hs
+++ b/src/Share/PrettyPrintEnvDecl/Postgres.hs
@@ -7,6 +7,7 @@ import Data.Set qualified as Set
 import Share.Postgres qualified as PG
 import Share.Postgres.NameLookups.Conversions qualified as CV
 import Share.Postgres.NameLookups.Ops qualified as NameLookupOps
+import Share.Postgres.NameLookups.Queries (ShouldSuffixify (..))
 import Share.Postgres.NameLookups.Types (NamesPerspective)
 import Share.Postgres.NameLookups.Types qualified as NameLookups
 import Share.Postgres.Refs.Types
@@ -37,7 +38,7 @@ ppedForReferences namesPerspective refs = do
         & unsafePartsOf trav %%~ \refs -> do
           let pgRefs = snd <$> refs
           termNames :: [[(NameLookups.ReversedName, NameLookups.ReversedName)]] <-
-            NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective Nothing traversed pgRefs
+            NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective Nothing Suffixify traversed pgRefs
           pure $ do
             ((ref, _pgRef), names) <- zip refs termNames
             pure $ do
@@ -49,7 +50,7 @@ ppedForReferences namesPerspective refs = do
         & unsafePartsOf trav %%~ \refs -> do
           let pgRefs = snd <$> refs
           typeNames :: [[(NameLookups.ReversedName, NameLookups.ReversedName)]] <-
-            NameLookupOps.typeNamesForRefsWithinNamespaceOf namesPerspective Nothing traversed pgRefs
+            NameLookupOps.typeNamesForRefsWithinNamespaceOf namesPerspective Nothing Suffixify traversed pgRefs
           pure $ do
             ((ref, _pgRef), names) <- zip refs typeNames
             pure $ do

--- a/src/Share/PrettyPrintEnvDecl/Postgres.hs
+++ b/src/Share/PrettyPrintEnvDecl/Postgres.hs
@@ -1,6 +1,7 @@
 module Share.PrettyPrintEnvDecl.Postgres (ppedForReferences) where
 
 import Control.Lens
+import Data.Either qualified as List
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Share.Postgres qualified as PG
@@ -20,23 +21,33 @@ import Unison.Referent qualified as V1
 
 ppedForReferences :: forall m. (PG.QueryM m) => NamesPerspective -> Set LabeledDependency -> m PPED.PrettyPrintEnvDecl
 ppedForReferences namesPerspective refs = do
-  withPGRefs <-
+  (pgRefTerms, pgRefTypes) <-
     Set.toList refs
       & CV.labeledDependencies1ToPG
       & fmap catMaybes -- Filter out any missing components
-  (termNames, typeNames) <- foldMapM namesForReference withPGRefs
+      & fmap List.partitionEithers
+  termNames <- concat <$> termNamesOf traversed pgRefTerms
+  typeNames <- concat <$> traverse typeName pgRefTypes
   pure $ ppedFromNamesWithSuffixes termNames typeNames
   where
-    namesForReference :: Either (V1.Referent, PGReferent) (V1.Reference, PGReference) -> m ([(Name, Name, V1.Referent)], [(Name, Name, V1.Reference)])
-    namesForReference = \case
-      Left (ref, pgref) -> do
-        termNames <- fmap (bothMap NameLookups.reversedNameToName) <$> NameLookupOps.termNamesForRefWithinNamespace namesPerspective pgref Nothing
-        let termNames' = termNames <&> \(fqn, suffixed) -> (fqn, suffixed, ref)
-        pure $ (termNames', [])
-      Right (ref, pgref) -> do
-        typeNames <- fmap (bothMap NameLookups.reversedNameToName) <$> NameLookupOps.typeNamesForRefWithinNamespace namesPerspective pgref Nothing
-        let typeNames' = typeNames <&> \(fqn, suffixed) -> (fqn, suffixed, ref)
-        pure $ ([], typeNames')
+    termNamesOf :: Traversal s t (V1.Referent, PGReferent) [(Name, Name, V1.Referent)] -> s -> m t
+    termNamesOf trav s =
+      s
+        & unsafePartsOf trav %%~ \refs -> do
+          let pgRefs = snd <$> refs
+          termNames :: [[(NameLookups.ReversedName, NameLookups.ReversedName)]] <-
+            NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective traversed pgRefs
+          pure $ do
+            ((ref, _pgRef), names) <- zip refs termNames
+            pure $ do
+              (fqn, suffixed) <- names
+              pure $ (NameLookups.reversedNameToName fqn, NameLookups.reversedNameToName suffixed, ref)
+    -- TODO: convert to typeNamesOf
+    typeName :: (V1.Reference, PGReference) -> m [(Name, Name, V1.Reference)]
+    typeName (ref, pgref) = do
+      typeNames <- fmap (bothMap NameLookups.reversedNameToName) <$> NameLookupOps.typeNamesForRefWithinNamespace namesPerspective pgref Nothing
+      let typeNames' = typeNames <&> \(fqn, suffixed) -> (fqn, suffixed, ref)
+      pure $ typeNames'
 
 -- | Given a list of (fqn, suffixified, ref), return a PrettyPrintEnvDecl
 -- Note: this type of PPE does not (yet) support hash qualifying conflicted names, because this

--- a/src/Share/PrettyPrintEnvDecl/Postgres.hs
+++ b/src/Share/PrettyPrintEnvDecl/Postgres.hs
@@ -36,7 +36,7 @@ ppedForReferences namesPerspective refs = do
         & unsafePartsOf trav %%~ \refs -> do
           let pgRefs = snd <$> refs
           termNames :: [[(NameLookups.ReversedName, NameLookups.ReversedName)]] <-
-            NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective traversed pgRefs
+            NameLookupOps.termNamesForRefsWithinNamespaceOf namesPerspective Nothing traversed pgRefs
           pure $ do
             ((ref, _pgRef), names) <- zip refs termNames
             pure $ do

--- a/src/Unison/Server/NameSearch/Postgres.hs
+++ b/src/Unison/Server/NameSearch/Postgres.hs
@@ -10,6 +10,7 @@ import Share.Codebase qualified as Codebase
 import Share.Postgres qualified as PG
 import Share.Postgres.NameLookups.Conversions qualified as CV
 import Share.Postgres.NameLookups.Ops as NLOps
+import Share.Postgres.NameLookups.Queries (ShouldSuffixify (NoSuffixify))
 import Share.Postgres.NameLookups.Types
 import Share.Prelude
 import Unison.Codebase.Path qualified as Path
@@ -59,7 +60,7 @@ nameSearchForPerspective namesPerspective =
     lookupNamesForTypes :: V1.Reference -> m (Set (HQ'.HashQualified Name))
     lookupNamesForTypes ref = fromMaybeT (pure mempty) $ do
       pgRef <- MaybeT $ CV.references1ToPGOf id ref
-      names <- NLOps.typeNamesForRefsWithinNamespaceOf namesPerspective Nothing id pgRef
+      names <- NLOps.typeNamesForRefsWithinNamespaceOf namesPerspective Nothing NoSuffixify id pgRef
       names
         & fmap (\(fqnSegments, _suffixSegments) -> HQ'.HashQualified (reversedSegmentsToName fqnSegments) (V1Reference.toShortHash ref))
         & Set.fromList
@@ -67,7 +68,7 @@ nameSearchForPerspective namesPerspective =
     lookupNamesForTerms :: V1Referent.Referent -> m (Set (HQ'.HashQualified Name))
     lookupNamesForTerms ref = fromMaybeT (pure mempty) $ do
       pgRef <- MaybeT $ CV.referents1ToPGOf id ref
-      names <- NLOps.termNamesForRefsWithinNamespaceOf namesPerspective Nothing id pgRef
+      names <- NLOps.termNamesForRefsWithinNamespaceOf namesPerspective Nothing NoSuffixify id pgRef
       names
         & fmap (\(fqnSegments, _suffixSegments) -> HQ'.HashQualified (reversedSegmentsToName fqnSegments) (V1Referent.toShortHash ref))
         & Set.fromList
@@ -88,7 +89,7 @@ nameSearchForPerspective namesPerspective =
             Set.toList <$> Codebase.termReferentsByShortHash sh
           termRefsPG <- catMaybes <$> CV.referents1ToPGOf traversed termRefsV1
           names <-
-            NLOps.termNamesForRefsWithinNamespaceOf namesPerspective (Just . coerce $ Name.reverseSegments name) traversed termRefsPG
+            NLOps.termNamesForRefsWithinNamespaceOf namesPerspective (Just . coerce $ Name.reverseSegments name) NoSuffixify traversed termRefsPG
               <&> (fmap . fmap) fst -- Only need the fqn
           zip termRefsV1 names
             & mapMaybe
@@ -116,7 +117,7 @@ nameSearchForPerspective namesPerspective =
           typeRefs <- Set.toList <$> Codebase.typeReferencesByShortHash sh
           typeRefsPG <- catMaybes <$> CV.references1ToPGOf traversed typeRefs
           names <-
-            NLOps.typeNamesForRefsWithinNamespaceOf namesPerspective (Just . coerce $ Name.reverseSegments name) traversed typeRefsPG
+            NLOps.typeNamesForRefsWithinNamespaceOf namesPerspective (Just . coerce $ Name.reverseSegments name) NoSuffixify traversed typeRefsPG
               <&> (fmap . fmap) fst -- Only need the fqn
           zip typeRefs names
             & mapMaybe

--- a/src/Unison/Server/NameSearch/Postgres.hs
+++ b/src/Unison/Server/NameSearch/Postgres.hs
@@ -67,7 +67,7 @@ nameSearchForPerspective namesPerspective =
     lookupNamesForTerms :: V1Referent.Referent -> m (Set (HQ'.HashQualified Name))
     lookupNamesForTerms ref = fromMaybeT (pure mempty) $ do
       pgRef <- MaybeT $ CV.referents1ToPGOf id ref
-      names <- NLOps.termNamesForRefWithinNamespace namesPerspective pgRef Nothing
+      names <- NLOps.termNamesForRefsWithinNamespaceOf namesPerspective Nothing id pgRef
       names
         & fmap (\(fqnSegments, _suffixSegments) -> HQ'.HashQualified (reversedSegmentsToName fqnSegments) (V1Referent.toShortHash ref))
         & Set.fromList
@@ -89,7 +89,7 @@ nameSearchForPerspective namesPerspective =
           termRefsPG <- catMaybes <$> CV.referents1ToPGOf traversed termRefsV1
           fmap Set.fromList . forMaybe (zip termRefsV1 termRefsPG) $ \(termRef, pgTermRef) -> do
             matches <-
-              NLOps.termNamesForRefWithinNamespace namesPerspective pgTermRef (Just . coerce $ Name.reverseSegments name)
+              NLOps.termNamesForRefsWithinNamespaceOf namesPerspective (Just . coerce $ Name.reverseSegments name) id pgTermRef
                 <&> fmap fst -- Only need the fqn
                 -- Return a valid ref if at least one match was found.
             if any (\n -> coerce (Name.reverseSegments fqn) == n) matches


### PR DESCRIPTION
## Overview

* [x] Run migration to add new sql functions

On main right now, when building pretty-printers we do at least 2 queries for EACH reference we need a name for :| 

This reduces that to 1 query to resolve ALL references and one for ALL referents; so what may have previously taken 400 queries will now take 2.

I benchmarked locally with [this diff](https://share.unison-lang.org/@unison/cloud/contributions/61/changes) from cloud.

On my laptop it went from: 490,000 queries, 14 mins
to: 260,576 queries, 7.5 mins

Since I'm chopping down the number of queries, the actual time saved is proportional to the postgres query latency, which is negligible on my laptop, so if anything I'd expect a greater savings factor on prod.

Still a lot of queries to go, but this is definitely moving the right direction :)

## Implementation notes

* Adds new batch base-level queries using the Traversal pattern.
* Moves transitive name resolution into a PL/PGSQL function so we can call it on a batch without round-tripping.
* Get names for aeverything as a batch when constructing a Pretty Printer or Names object.

## Interesting/controversial decisions

Pretty uncontroversial

## Test coverage

Existing transcripts. I'll keep an eye on prod after deploying.

## Loose ends

There are still a lot of optimizations we could do here, e.g. skipping the suffixification process when we really only need the FQN.