### PR TITLE
Track a few additional spans for observability

### DIFF
--- a/src/Share/Names/Postgres.hs
+++ b/src/Share/Names/Postgres.hs
@@ -4,6 +4,7 @@ module Share.Names.Postgres (namesForReferences) where
 import Control.Lens
 import Data.Either qualified as List
 import Data.Set qualified as Set
+import Share.Postgres (transactionSpan)
 import Share.Postgres qualified as PG
 import Share.Postgres.NameLookups.Conversions qualified as CV
 import Share.Postgres.NameLookups.Ops qualified as NameLookupOps
@@ -20,7 +21,7 @@ import Unison.Reference qualified as V1
 import Unison.Referent qualified as V1
 
 namesForReferences :: forall m. (PG.QueryM m) => NamesPerspective -> Set LabeledDependency -> m Names
-namesForReferences namesPerspective refs = do
+namesForReferences namesPerspective refs = transactionSpan "namesForReferences" mempty do
   (pgRefTerms, pgRefTypes) <-
     Set.toList refs
       & CV.labeledDependencies1ToPG

--- a/src/Share/Postgres/Causal/Queries.hs
+++ b/src/Share/Postgres/Causal/Queries.hs
@@ -914,7 +914,7 @@ expectNamespaceStatsOf trav s =
 -- | Copy a causal and all its dependencies from one codebase to another.
 -- Make sure you've done some form of authorization check before calling this.
 importCausalIntoCodebase :: (QueryM m) => CodebaseEnv -> UserId -> CausalId -> m ()
-importCausalIntoCodebase (CodebaseEnv {codebaseOwner}) fromCodebaseUserId causalId = do
+importCausalIntoCodebase (CodebaseEnv {codebaseOwner}) fromCodebaseUserId causalId = transactionSpan "importCausalIntoCodebase" mempty do
   execute_
     [sql|
       SELECT copy_causal_into_codebase(#{causalId}, #{fromCodebaseUserId}, #{codebaseOwner})

--- a/src/Share/Prelude/Orphans.hs
+++ b/src/Share/Prelude/Orphans.hs
@@ -6,6 +6,8 @@
 module Share.Prelude.Orphans () where
 
 import Control.Comonad.Cofree (Cofree (..))
+import Control.Monad.Trans (MonadTrans (..))
+import Control.Monad.Trans.Maybe (MaybeT)
 import Data.Align (Semialign (..))
 import Data.Text (Text)
 import Data.These (These (..))
@@ -13,6 +15,7 @@ import Data.UUID (UUID)
 import Data.UUID qualified as UUID
 import GHC.TypeLits qualified as TypeError
 import Hasql.Interpolate qualified as Interp
+import OpenTelemetry.Trace.Monad
 import Unison.Server.Orphans ()
 import Unison.ShortHash (ShortHash)
 import Unison.ShortHash qualified as SH
@@ -41,3 +44,6 @@ instance From UUID Text where
 
 instance From ShortHash Text where
   from = SH.toText
+
+instance (MonadTracer m) => MonadTracer (MaybeT m) where
+  getTracer = lift getTracer

--- a/src/Share/PrettyPrintEnvDecl/Postgres.hs
+++ b/src/Share/PrettyPrintEnvDecl/Postgres.hs
@@ -21,7 +21,7 @@ import Unison.Reference qualified as V1
 import Unison.Referent qualified as V1
 
 ppedForReferences :: forall m. (PG.QueryM m) => NamesPerspective -> Set LabeledDependency -> m PPED.PrettyPrintEnvDecl
-ppedForReferences namesPerspective refs = do
+ppedForReferences namesPerspective refs = PG.transactionSpan "ppedForReferences" mempty do
   (pgRefTerms, pgRefTypes) <-
     Set.toList refs
       & CV.labeledDependencies1ToPG

--- a/src/Share/Utils/Tags.hs
+++ b/src/Share/Utils/Tags.hs
@@ -7,6 +7,7 @@ module Share.Utils.Tags
   )
 where
 
+import Control.Monad.Trans.Maybe (mapMaybeT)
 import Share.Prelude
 
 type Tags = Map Text Text
@@ -33,6 +34,10 @@ instance (Monad m) => MonadTags (TagT m) where
 instance (MonadTags m) => MonadTags (ReaderT e m) where
   askTags = lift askTags
   withTags newTags = mapReaderT (withTags newTags)
+
+instance (MonadTags m) => MonadTags (MaybeT m) where
+  askTags = lift askTags
+  withTags newTags = mapMaybeT (withTags newTags)
 
 class HasTags ctx where
   getTags :: (MonadIO m) => ctx -> m Tags


### PR DESCRIPTION
## Overview & implementation

Adds spans in large batch operations like building pretty printers, names objects, etc.
Embeds `MonadTracer` and `MonadTags` in QueryM for convenience.
