### PR TITLE
Finish batch queries for terms.

### DIFF
--- a/src/Share/Codebase.hs
+++ b/src/Share/Codebase.hs
@@ -273,7 +273,7 @@ loadTypesOfTermsOf codebase trav s =
 expectTypesOfTermsOf :: (QueryM m) => CodebaseEnv -> Traversal s t V2.Reference (V1.Type Symbol Ann) -> s -> m t
 expectTypesOfTermsOf codebase trav s = do
   s
-    & asListOf trav %%~ \refs -> do
+    & asListOfDeduped trav %%~ \refs -> do
       results <- loadTypesOfTermsOf codebase traversed refs
       for (zip refs results) \case
         (r, Nothing) -> unrecoverableError (MissingTypeForTerm r)

--- a/src/Share/Web/Share/Diffs/Impl.hs
+++ b/src/Share/Web/Share/Diffs/Impl.hs
@@ -144,6 +144,7 @@ computeUpdatedDefinitionDiffs ::
     NamespaceDiffError
     (NamespaceDiffs.NamespaceTreeDiff a b TermDefinition TypeDefinition TermDefinitionDiff TypeDefinitionDiff)
 computeUpdatedDefinitionDiffs !authZReceipt (fromCodebase, fromRuntime, fromPerspective) (toCodebase, toRuntime, toPerspective) diff0 = PG.transactionSpan "computeUpdatedDefinitionDiffs" mempty $ do
+  -- TODO: We can clean this up, and can cut down on the number of traversals.
   diff1 <- PG.transactionSpan "termDiffs" mempty $ do
     diff0
       & NamespaceDiffs.namespaceTreeDiffTermDiffs_ %~ (\name -> (name, name))

--- a/src/Share/Web/Share/Diffs/Impl.hs
+++ b/src/Share/Web/Share/Diffs/Impl.hs
@@ -144,17 +144,21 @@ computeUpdatedDefinitionDiffs ::
     NamespaceDiffError
     (NamespaceDiffs.NamespaceTreeDiff a b TermDefinition TypeDefinition TermDefinitionDiff TypeDefinitionDiff)
 computeUpdatedDefinitionDiffs !authZReceipt (fromCodebase, fromRuntime, fromPerspective) (toCodebase, toRuntime, toPerspective) diff0 = PG.transactionSpan "computeUpdatedDefinitionDiffs" mempty $ do
-  diff1 <-
+  diff1 <- PG.transactionSpan "termDiffs" mempty $ do
     diff0
       & NamespaceDiffs.namespaceTreeDiffTermDiffs_ %~ (\name -> (name, name))
       & expectTermDefinitionsOf fromCodebase fromRuntime fromPerspective (NamespaceDiffs.namespaceTreeDiffTermDiffs_ . _1)
       >>= expectTermDefinitionsOf toCodebase toRuntime toPerspective (NamespaceDiffs.namespaceTreeDiffTermDiffs_ . _2)
       >>= NamespaceDiffs.witherNamespaceTreeDiffTermDiffs (pure . diffTermsPure)
+
   diff2 <- PG.transactionSpan "termDiffKinds" mempty $ do
-    NamespaceDiffs.witherNamespaceTreeTermDiffKinds
-      -- TODO: Batchify this properly
-      (fmap throwAwayConstructorDiffs . renderDiffKind (\(codebase, rt, np, name) -> getTermDefinitionsOf codebase rt np id name))
-      diff1
+    diff1
+      & NamespaceDiffs.namespaceTreeTermDiffKinds_ %~ partitionDiffKind
+      & expectTermDefinitionsOf fromCodebase fromRuntime fromPerspective (NamespaceDiffs.namespaceTreeDiffRenderedTerms_ . _Left)
+      >>= expectTermDefinitionsOf toCodebase toRuntime toPerspective (NamespaceDiffs.namespaceTreeDiffRenderedTerms_ . _Right)
+      <&> NamespaceDiffs.namespaceTreeDiffRenderedTerms_ %~ either id id
+      >>= NamespaceDiffs.witherNamespaceTreeTermDiffKinds (pure . throwAwayConstructorDiffs)
+
   diff3 <- PG.transactionSpan "typeDiffs" mempty $ do
     NamespaceDiffs.namespaceTreeDiffTypeDiffs_
       (\name -> diffTypes authZReceipt (fromCodebase, fromRuntime, fromPerspective, name) (toCodebase, toRuntime, toPerspective, name))
@@ -170,15 +174,15 @@ computeUpdatedDefinitionDiffs !authZReceipt (fromCodebase, fromRuntime, fromPers
     -- Splits the diff kind into the parts from the 'from' and 'to' sections of a diff.
     --
     -- Left = From, Right = To
-    _partitionDiffKind :: DefinitionDiffKind r rendered diff -> DefinitionDiffKind r (Either rendered rendered) diff
-    _partitionDiffKind = \case
+    partitionDiffKind :: DefinitionDiffKind r rendered diff -> DefinitionDiffKind r (Either rendered rendered) diff
+    partitionDiffKind = \case
       Added r name -> Added r (Right name)
       NewAlias r existingNames name -> NewAlias r existingNames (Right name)
       Removed r name -> Removed r (Left name)
       Updated oldRef newRef diff -> Updated oldRef newRef diff
       Propagated oldRef newRef diff -> Propagated oldRef newRef diff
-      RenamedTo r names name -> RenamedTo r names (Right name)
-      RenamedFrom r names name -> RenamedFrom r names (Left name)
+      RenamedTo r names name -> RenamedTo r names (Left name)
+      RenamedFrom r names name -> RenamedFrom r names (Right name)
 
     renderDiffKind ::
       forall diff r x.

--- a/src/Unison/Server/Share/DefinitionSummary.hs
+++ b/src/Unison/Server/Share/DefinitionSummary.hs
@@ -112,7 +112,7 @@ typeSummaryForReference ::
 typeSummaryForReference codebase reference mayName mayWidth = do
   let shortHash = Reference.toShortHash reference
   let displayName = maybe (HQ.HashOnly shortHash) HQ.NameOnly mayName
-  tag <- Backend.getTypeTag reference
+  tag <- Backend.getTypeTagsOf id reference
   displayDecl <- Backend.displayType codebase reference
   let syntaxHeader = Backend.typeToSyntaxHeader width displayName displayDecl
   pure $

--- a/src/Unison/Server/Share/DefinitionSummary.hs
+++ b/src/Unison/Server/Share/DefinitionSummary.hs
@@ -82,7 +82,7 @@ termSummaryForReferent referent typeSig mayName rootBranchHashId relativeTo mayW
   pped <- PPEPostgres.ppedForReferences namesPerspective deps
   let formattedTypeSig = Backend.formatSuffixedType pped width typeSig
   let summary = mkSummary termReference formattedTypeSig
-  tag <- Backend.getTermTag referent typeSig
+  tag <- Backend.getTermTagsOf id (referent, typeSig)
   pure $ TermSummary displayName shortHash summary tag
   where
     width = mayDefaultWidth mayWidth

--- a/src/Unison/Server/Share/Definitions.hs
+++ b/src/Unison/Server/Share/Definitions.hs
@@ -143,7 +143,7 @@ definitionForHQName codebase@(CodebaseEnv {codebaseOwner}) perspective rootCausa
           let referent = Referent.Ref reference
           let hqTermName = PPE.termNameOrHashOnly fqnTermAndTypePPE referent
           docs <- maybe (pure []) docResults (HQ.toName hqTermName)
-          Backend.mkTermDefinition codebase termAndTypePPED width reference docs trm
+          Backend.mkTermDefinitionsOf codebase termAndTypePPED width id (Nothing, reference, docs, trm)
       let renderedDisplayTerms = Map.mapKeys Reference.toText termDefinitions
           renderedDisplayTypes = Map.mapKeys Reference.toText typeDefinitions
           renderedMisses = fmap HQ.toText misses
@@ -264,13 +264,8 @@ termDefinitionByNamesOf codebase ppedBuilder nameSearch width rt includeDocs tra
                 -- TODO: properly batchify this
                 for allDocRefs $ renderDocRefs codebase ppedBuilder width rt
               else pure (names $> [])
-          let syntaxDOs =
-                Backend.termsToSyntaxOf (Suffixify False) width pped traversed (zip refs dos)
-                  <&> snd
-          -- TODO: properly batchify this
-          for (zip4 names refs allRenderedDocs syntaxDOs) \(name, ref, renderedDocs, syntaxDO) -> do
-            let biasedPPED = PPED.biasTo [name] pped
-            Backend.mkTermDefinition codebase biasedPPED width ref renderedDocs syntaxDO
+          let syntaxDOs = snd <$> Backend.termsToSyntaxOf (Suffixify False) width pped traversed (zip refs dos)
+          Backend.mkTermDefinitionsOf codebase pped width traversed (zip4 (Just <$> names) refs allRenderedDocs syntaxDOs)
 
 termDisplayObjectLabeledDependencies :: TermReference -> DisplayObject (Type Symbol Ann) (Term Symbol Ann) -> (Set LD.LabeledDependency)
 termDisplayObjectLabeledDependencies termRef displayObject = do


### PR DESCRIPTION
Batch up term loading queries to avoid too many DB roundtrips.