### PR TITLE
Speed up doc evaluation on Share

### DIFF
--- a/share-api.cabal
+++ b/share-api.cabal
@@ -45,6 +45,8 @@ library
       Share.Branch
       Share.ChatApps
       Share.Codebase
+      Share.Codebase.CodebaseRuntime
+      Share.Codebase.CodeCache
       Share.Codebase.Types
       Share.Contribution
       Share.Env

--- a/src/Share/Backend.hs
+++ b/src/Share/Backend.hs
@@ -38,13 +38,17 @@ import Control.Lens hiding ((??))
 import Data.List (unzip4, zipWith4, zipWith5)
 import Data.List qualified as List
 import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Share.Codebase qualified as Codebase
+import Share.Codebase.CodeCache qualified as CC
 import Share.Codebase.Types (CodebaseRuntime (CodebaseRuntime, cachedEvalResult))
 import Share.Postgres (QueryM)
 import Share.Postgres qualified as PG
 import Share.Postgres.Causal.Conversions (namespaceStatsPgToV2)
 import Share.Postgres.Causal.Queries qualified as CausalQ
+import Share.Postgres.Definitions.Queries qualified as DefnQ
 import Share.Prelude
+import Share.Utils.Data qualified as Data
 import Share.Utils.Lens (asListOfDeduped)
 import U.Codebase.Branch qualified as V2Branch
 import U.Codebase.Causal qualified as Causal
@@ -289,21 +293,31 @@ evalDocRef ::
   Codebase.CodebaseRuntime s IO ->
   V2.TermReference ->
   m (Doc.EvaluatedDoc Symbol)
-evalDocRef codebase (CodebaseRuntime {codeLookup, cachedEvalResult, unisonRuntime}) termRef = PG.transactionSpan "evalDocRef" mempty do
+evalDocRef codebase (CodebaseRuntime {codeLookup, codeCache, cachedEvalResult, unisonRuntime}) termRef = PG.transactionSpan "evalDocRef" mempty do
   let tm = Term.ref () termRef
-  -- TODO: batchify evalDoc.
-  Doc.evalDoc terms typeOf eval decls tm
-  where
-    terms :: Reference -> m (Maybe (V1.Term Symbol ()))
-    terms termRef@(Reference.Builtin _) = pure (Just (Term.ref () termRef))
-    terms (Reference.DerivedId termRef) = PG.transactionSpan "terms" mempty do
-      -- TODO: batchify properly
-      fmap (Term.unannotate . fst) <$> (Codebase.loadTermAndTypeByRefIdsOf codebase id termRef)
+  case termRef of
+    Reference.Builtin _ -> Doc.evalDoc terms typeOf eval decls tm
+    Reference.DerivedId refId -> do
+      termId <- DefnQ.expectTermIdsByRefIdsOf id refId
+      (termDeps, typeDeps) <- DefnQ.termTransitiveDependencies (Set.singleton termId)
+      termComponentHashIds <- DefnQ.expectComponentHashIdsByTermIdsOf traversed (toList termDeps)
+      typeComponentHashIds <- DefnQ.expectComponentHashIdsByTypeIdsOf traversed (toList typeDeps)
 
+      dependencyTerms <- DefnQ.loadTermsByIdsOf codebase traversed (Data.mapFromSelf $ Set.toList termDeps)
+      -- TODO: batchify evalDoc.
+      Doc.evalDoc terms typeOf eval decls tm
+  where
+    -- Loading one at a time is inefficient, so we prime the cache above.
+    terms :: Reference -> m (Maybe (V1.Term Symbol ()))
+    terms = CC.termsForRefsOf codeCache id
+
+    -- Loading one at a time is inefficient, so we prime the cache above.
     typeOf :: Referent.Referent -> m (Maybe (V1.Type Symbol ()))
-    typeOf termRef = PG.transactionSpan "typeOf" mempty do
-      -- TODO: batchify properly
-      fmap void <$> Codebase.loadTypesOfReferentsOf codebase id (Cv.referent1to2 termRef)
+    typeOf = CC.typesOfReferentsOf codeCache id
+
+    -- Loading one at a time is inefficient, so we prime the cache above.
+    decls :: Reference -> m (Maybe (DD.Decl Symbol ()))
+    decls ref = fmap (DD.amap (const ())) <$> CC.getTypeDeclsByRefsOf codeCache id ref
 
     eval :: V1.Term Symbol a -> m (Maybe (V1.Term Symbol ()))
     eval (Term.amap (const mempty) -> tm) = PG.transactionSpan "eval" mempty do
@@ -319,12 +333,6 @@ evalDocRef codebase (CodebaseRuntime {codeLookup, cachedEvalResult, unisonRuntim
             (Term.amap (const mempty) tmr)
         _ -> pure ()
       pure $ termRef <&> Term.amap (const mempty) . snd
-
-    decls :: Reference -> m (Maybe (DD.Decl Symbol ()))
-    decls (Reference.DerivedId typeRef) = PG.transactionSpan "decls" mempty do
-      -- TODO: batchify properly
-      fmap (DD.amap (const ())) <$> (Codebase.loadTypeDeclarationsByRefIdsOf codebase id typeRef)
-    decls _ = pure Nothing
 
 -- | Find all definitions and children reachable from the given 'V2Branch.Branch',
 lsBranch ::
@@ -376,7 +384,7 @@ typeDeclHeader ::
   m (DisplayObject Syntax.SyntaxText Syntax.SyntaxText)
 typeDeclHeader codebase ppe r = case Reference.toId r of
   Just rid ->
-    Codebase.loadTypeDeclarationsByRefIdsOf codebase id rid <&> \case
+    Codebase.loadV1TypeDeclarationsByRefIdsOf codebase id rid <&> \case
       Nothing -> DisplayObject.MissingObject (Reference.toShortHash r)
       Just decl ->
         DisplayObject.UserObject $

--- a/src/Share/BackgroundJobs/Diffs/CausalDiffs.hs
+++ b/src/Share/BackgroundJobs/Diffs/CausalDiffs.hs
@@ -9,6 +9,7 @@ import Share.BackgroundJobs.Errors (reportError)
 import Share.BackgroundJobs.Monad (Background)
 import Share.BackgroundJobs.Workers (newWorker)
 import Share.Codebase qualified as Codebase
+import Share.Codebase.CodebaseRuntime qualified as CR
 import Share.Env qualified as Env
 import Share.IDs qualified as IDs
 import Share.Metrics qualified as Metrics
@@ -98,8 +99,8 @@ maybeComputeAndStoreCausalDiff authZReceipt unisonRuntime (CausalDiffInfo {fromC
   let toCodebase = Codebase.codebaseEnv authZReceipt $ Codebase.codebaseLocationForUserCodebase toCodebaseOwner
   ContributionsQ.existsPrecomputedNamespaceDiff (fromCodebase, fromCausalId) (toCodebase, toCausalId) >>= \case
     True -> pure False
-    False -> Codebase.withCodebaseRuntime fromCodebase unisonRuntime \fromRuntime -> do
-      Codebase.withCodebaseRuntime toCodebase unisonRuntime \toRuntime -> do
+    False -> CR.withCodebaseRuntime fromCodebase unisonRuntime \fromRuntime -> do
+      CR.withCodebaseRuntime toCodebase unisonRuntime \toRuntime -> do
         _ <-
           Diffs.computeAndStoreCausalDiff
             authZReceipt

--- a/src/Share/BackgroundJobs/Search/DefinitionSync.hs
+++ b/src/Share/BackgroundJobs/Search/DefinitionSync.hs
@@ -388,7 +388,7 @@ syncTypes codebase namesPerspective rootBranchHashId typesCursor = do
             Reference.Builtin _ -> pure (mempty, Arity 0)
             Reference.DerivedId refId -> do
               -- TODO: batchify this
-              decl <- lift (Codebase.loadTypeDeclarationsByRefIdsOf codebase id refId) `whenNothingM` throwError (NoDeclForType fqn ref)
+              decl <- lift (Codebase.loadV1TypeDeclarationsByRefIdsOf codebase id refId) `whenNothingM` throwError (NoDeclForType fqn ref)
               pure $ (tokensForDecl refId decl, Arity . fromIntegral . length . DD.bound $ DD.asDataDecl decl)
           let basicTokens = Set.fromList [NameToken fqn, HashToken $ Reference.toShortHash ref]
           typeSummary <- lift $ Summary.typeSummaryForReference codebase ref (Just fqn) Nothing

--- a/src/Share/Codebase/CodeCache.hs
+++ b/src/Share/Codebase/CodeCache.hs
@@ -60,6 +60,9 @@ builtinsCodeLookup =
   Builtin.codeLookup
     <> IOSource.codeLookupM
 
+-- | Build a Unison 'CodeLookup' which is backed by the given 'CodeCache'.
+-- The TVar will be baked in, so it will still share the cache with the CodeCache it's
+-- built from.
 toCodeLookup :: CodeCache s -> CL.CodeLookup Symbol (PG.Transaction e) Ann
 toCodeLookup codeCache = do
   let getTerm refId = fmap fst <$> getTermsAndTypesOf codeCache id refId

--- a/src/Share/Codebase/CodeCache.hs
+++ b/src/Share/Codebase/CodeCache.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Share.Codebase.CodeCache (withCodeCache, toCodeLookup) where
+
+import Control.Concurrent.STM (atomically, modifyTVar', newTVarIO, readTVarIO)
+import Control.Lens
+import Data.Map qualified as Map
+import Share.Codebase qualified as Codebase
+import Share.Codebase.Types
+import Share.Postgres (QueryM)
+import Share.Postgres qualified as PG
+import Share.Utils.Lens (asListOfDeduped)
+import Unison.Builtin qualified as Builtin
+import Unison.Codebase.CodeLookup qualified as CL
+import Unison.DataDeclaration qualified as V1
+import Unison.Parser.Ann
+import Unison.Reference qualified as Reference
+import Unison.Runtime.IOSource qualified as IOSource
+import Unison.Symbol (Symbol)
+import Unison.Term qualified as V1
+import Unison.Type qualified as V1
+
+withCodeCache :: (QueryM m) => CodebaseEnv -> (forall s. CodeCache s -> m r) -> m r
+withCodeCache codeCacheCodebaseEnv action = do
+  codeCacheVar <- PG.transactionUnsafeIO (newTVarIO (CodeCacheData Map.empty Map.empty))
+  let codeCache = CodeCache {codeCacheVar, codeCacheCodebaseEnv}
+  action codeCache
+
+readCodeCache :: (QueryM m) => CodeCache s -> m CodeCacheData
+readCodeCache CodeCache {codeCacheVar} = PG.transactionUnsafeIO (readTVarIO codeCacheVar)
+
+cacheTermAndTypes ::
+  (QueryM m) =>
+  CodeCache s ->
+  [(Reference.Id, (V1.Term Symbol Ann, V1.Type Symbol Ann))] ->
+  m ()
+cacheTermAndTypes CodeCache {codeCacheVar} termAndTypes = do
+  PG.transactionUnsafeIO do
+    atomically do
+      modifyTVar' codeCacheVar \CodeCacheData {termCache, ..} ->
+        let newTermMap = Map.fromList termAndTypes
+            termCache' = Map.union termCache newTermMap
+         in CodeCacheData {termCache = termCache', ..}
+
+cacheDecls ::
+  (QueryM m) =>
+  CodeCache s ->
+  [(Reference.Id, V1.Decl Symbol Ann)] ->
+  m ()
+cacheDecls CodeCache {codeCacheVar} decls = do
+  PG.transactionUnsafeIO do
+    atomically do
+      modifyTVar' codeCacheVar \CodeCacheData {typeCache, ..} ->
+        let newDeclsMap = Map.fromList decls
+            typeCache' = Map.union typeCache newDeclsMap
+         in CodeCacheData {typeCache = typeCache', ..}
+
+builtinsCodeLookup :: (Monad m) => CL.CodeLookup Symbol m Ann
+builtinsCodeLookup =
+  Builtin.codeLookup
+    <> IOSource.codeLookupM
+
+toCodeLookup :: CodeCache s -> CL.CodeLookup Symbol (PG.Transaction e) Ann
+toCodeLookup codeCache = do
+  let getTerm refId = fmap fst <$> getTermsAndTypesOf codeCache id refId
+  let getTypeOfTerm refId = fmap snd <$> getTermsAndTypesOf codeCache id refId
+  let getTypeDeclaration refId = getTypeDeclsOf codeCache id refId
+  CL.CodeLookup {getTerm, getTypeOfTerm, getTypeDeclaration}
+    <> builtinsCodeLookup
+
+getTermsAndTypesOf ::
+  (QueryM m) =>
+  CodeCache scope ->
+  Traversal s t Reference.Id (Maybe (V1.Term Symbol Ann, V1.Type Symbol Ann)) ->
+  s ->
+  m t
+getTermsAndTypesOf codeCache@(CodeCache {codeCacheCodebaseEnv}) trav s = do
+  CodeCacheData {termCache} <- readCodeCache codeCache
+  s
+    & asListOfDeduped trav %%~ \refs -> do
+      -- Parition by cache misses
+      let partitioned =
+            refs
+              <&> \r ->
+                case Map.lookup r termCache of
+                  Just termAndType -> Right termAndType
+                  Nothing -> Left (r, r)
+      -- Load the missing terms and types
+      withUncachedLoaded <- Codebase.loadV1TermAndTypeByRefIdsOf codeCacheCodebaseEnv (traversed . _Left . _2) partitioned
+      -- Pull out the new things to cache, and merge newly loaded and cached results.
+      let (cacheable, hydrated') =
+            withUncachedLoaded
+              & traversed %%~ \case
+                Left (r, mayTT) ->
+                  case mayTT of
+                    Just tt -> ([(r, tt)], Just tt)
+                    Nothing -> (mempty, Nothing)
+                Right tt -> (mempty, Just tt)
+
+      cacheTermAndTypes codeCache cacheable
+      pure $ hydrated'
+
+getTypeDeclsOf ::
+  (QueryM m) =>
+  CodeCache scope ->
+  Traversal s t Reference.Id (Maybe (V1.Decl Symbol Ann)) ->
+  s ->
+  m t
+getTypeDeclsOf codeCache@(CodeCache {codeCacheCodebaseEnv}) trav s = do
+  CodeCacheData {typeCache} <- readCodeCache codeCache
+  s
+    & asListOfDeduped trav %%~ \refs -> do
+      -- Parition by cache misses
+      let partitioned =
+            refs
+              <&> \r ->
+                case Map.lookup r typeCache of
+                  Just decl -> Right decl
+                  Nothing -> Left (r, r)
+      -- Load the missing type declarations
+      withUncachedLoaded <- Codebase.loadV1TypeDeclarationsByRefIdsOf codeCacheCodebaseEnv (traversed . _Left . _2) partitioned
+      -- Pull out the new things to cache, and merge newly loaded and cached results.
+      let (cacheable, hydrated') =
+            withUncachedLoaded
+              & traversed %%~ \case
+                Left (r, mayDecl) ->
+                  case mayDecl of
+                    Just decl -> ([(r, decl)], Just decl)
+                    Nothing -> (mempty, Nothing)
+                Right decl -> (mempty, Just decl)
+
+      cacheDecls codeCache cacheable
+      pure $ hydrated'

--- a/src/Share/Codebase/CodebaseRuntime.hs
+++ b/src/Share/Codebase/CodebaseRuntime.hs
@@ -1,0 +1,46 @@
+module Share.Codebase.CodebaseRuntime
+  ( withCodebaseRuntime,
+  )
+where
+
+import Share.Codebase qualified as Codebase
+import Share.Codebase.CodeCache qualified as CC
+import Share.Codebase.Types
+import Share.Postgres qualified as PG
+import Share.Prelude
+import Unison.Codebase.Runtime (Runtime)
+import Unison.Symbol (Symbol)
+import Unison.Term qualified as Term
+import UnliftIO qualified
+
+-- | Construct a Runtime linked to a specific codebase and transaction.
+-- Don't use the runtime for one codebase with another codebase.
+-- Don't use this runtime in any transaction other than the one where it's created.
+--
+--
+-- Ideally, we'd use a runtime with lookup actions in transaction, not IO. But that will require refactoring to
+-- the runtime interface in ucm, so we can't use it for now.
+--
+-- As a result, the 'IO' actions embedded in the CodebaseRuntime are scoped to the transaction
+-- in which it is created, thus we use a scoped skolem type variable `s` to prevent the runtime from escaping the transaction so it's safe(r).
+withCodebaseRuntime :: (Exception e) => CodebaseEnv -> Runtime Symbol -> (forall s. CodebaseRuntime s IO -> PG.Transaction e r) -> PG.Transaction e r
+withCodebaseRuntime codebase sandboxedRuntime f = do
+  CC.withCodeCache codebase \codeCache -> do
+    withCodebaseRuntimeTransaction sandboxedRuntime codeCache \cr -> do
+      PG.asUnliftIOTransaction $ do
+        UnliftIO.withRunInIO \toIO -> do
+          toIO . PG.UnliftIOTransaction $ f $ hoistCodebaseRuntime (toIO . PG.UnliftIOTransaction) cr
+
+-- | Ideally, we'd use this – a runtime with lookup actions in transaction, not IO. But that will require refactoring to
+-- the runtime interface in ucm, so we can't use it for now. That's bad: we end up unsafely running separate
+-- transactions for inner calls to 'codeLookup' / 'cachedEvalResult', which can lead to deadlock due to a starved
+-- connection pool.
+withCodebaseRuntimeTransaction :: Runtime Symbol -> CodeCache s1 -> (forall s2. CodebaseRuntime s2 (PG.Transaction e) -> PG.Transaction e a) -> PG.Transaction e a
+withCodebaseRuntimeTransaction sandboxedRuntime codeCache@(CodeCache {codeCacheCodebaseEnv}) f = do
+  f $
+    CodebaseRuntime
+      { codeLookup = CC.toCodeLookup codeCache,
+        codeCache,
+        cachedEvalResult = (fmap . fmap) Term.unannotate . Codebase.loadCachedEvalResult codeCacheCodebaseEnv,
+        unisonRuntime = sandboxedRuntime
+      }

--- a/src/Share/Codebase/Types.hs
+++ b/src/Share/Codebase/Types.hs
@@ -2,6 +2,8 @@ module Share.Codebase.Types
   ( CodebaseEnv (..),
     CodebaseRuntime (..),
     CodebaseLocation (..),
+    CodeCache (..),
+    CodeCacheData (..),
     hoistCodebaseRuntime,
     codebaseLocationForUserCodebase,
     codebaseLocationForProjectBranchCodebase,
@@ -11,14 +13,19 @@ module Share.Codebase.Types
 where
 
 import Control.Monad.Morph (MFunctor (..))
+import Data.Map (Map)
 import Share.IDs
 import Unison.Codebase.CodeLookup qualified as CL
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.Runtime qualified as Rt
+import Unison.DataDeclaration qualified as V1
 import Unison.NameSegment.Internal (NameSegment (..))
 import Unison.Parser.Ann (Ann)
 import Unison.Reference qualified as Reference
 import Unison.Symbol (Symbol)
+import Unison.Term qualified as V1
+import Unison.Type qualified as V1
+import UnliftIO.STM (TVar)
 
 publicRoot :: Path.Path
 publicRoot = Path.singleton (NameSegment "public")
@@ -28,20 +35,32 @@ data CodebaseEnv = CodebaseEnv
   { codebaseOwner :: UserId
   }
 
+data CodeCache scope = CodeCache
+  { codeCacheCodebaseEnv :: CodebaseEnv,
+    codeCacheVar :: TVar CodeCacheData
+  }
+
+data CodeCacheData = CodeCacheData
+  { termCache :: Map Reference.Id (V1.Term Symbol Ann, V1.Type Symbol Ann),
+    typeCache :: Map Reference.Id (V1.Decl Symbol Ann)
+  }
+
 -- | The runtime environment for a codebase transaction.
 -- Includes a skolem scope type var to prevent the runtime from escaping the transaction its
 -- runtime was initialized with.
 data CodebaseRuntime scope m = CodebaseRuntime
   { codeLookup :: CL.CodeLookup Symbol m Ann,
+    codeCache :: CodeCache scope,
     -- Function to look up cached evaluation results for the runtime.
     cachedEvalResult :: Reference.Id -> m (Maybe (Rt.Term Symbol)),
     unisonRuntime :: Rt.Runtime Symbol
   }
 
 hoistCodebaseRuntime :: (Monad m) => (forall x. m x -> n x) -> CodebaseRuntime s m -> CodebaseRuntime s n
-hoistCodebaseRuntime f (CodebaseRuntime lookup eval runtime) =
+hoistCodebaseRuntime f (CodebaseRuntime lookup codeCache eval runtime) =
   CodebaseRuntime
     { codeLookup = hoist f lookup,
+      codeCache,
       cachedEvalResult = \id -> f (eval id),
       unisonRuntime = runtime
     }

--- a/src/Share/Postgres/Definitions/Queries.hs
+++ b/src/Share/Postgres/Definitions/Queries.hs
@@ -1266,7 +1266,7 @@ saveSerializedComponent (CodebaseEnv {codebaseOwner}) chId (CBORBytes bytes) = d
       ON CONFLICT DO NOTHING
     |]
 
-termTransitiveDependencies :: Set TermId -> Transaction e (Set.Set TermId, Set.Set TypeId)
+termTransitiveDependencies :: (QueryM m) => Set TermId -> m (Set.Set TermId, Set.Set TypeId)
 termTransitiveDependencies termIds = do
   queryExpect1Row @([TermId], [TypeId])
     [sql|

--- a/src/Share/Prelude/Orphans.hs
+++ b/src/Share/Prelude/Orphans.hs
@@ -6,6 +6,8 @@
 module Share.Prelude.Orphans () where
 
 import Control.Comonad.Cofree (Cofree (..))
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Maybe (MaybeT)
 import Data.Align (Semialign (..))
 import Data.Text (Text)
 import Data.These (These (..))
@@ -13,6 +15,7 @@ import Data.UUID (UUID)
 import Data.UUID qualified as UUID
 import GHC.TypeLits qualified as TypeError
 import Hasql.Interpolate qualified as Interp
+import OpenTelemetry.Trace.Monad (MonadTracer (..))
 import Unison.Server.Orphans ()
 import Unison.ShortHash (ShortHash)
 import Unison.ShortHash qualified as SH
@@ -41,3 +44,6 @@ instance From UUID Text where
 
 instance From ShortHash Text where
   from = SH.toText
+
+instance (MonadTracer m) => MonadTracer (MaybeT m) where
+  getTracer = lift getTracer

--- a/src/Share/Utils/Tags.hs
+++ b/src/Share/Utils/Tags.hs
@@ -7,6 +7,7 @@ module Share.Utils.Tags
   )
 where
 
+import Control.Monad.Trans.Maybe (mapMaybeT)
 import Share.Prelude
 
 type Tags = Map Text Text
@@ -33,6 +34,10 @@ instance (Monad m) => MonadTags (TagT m) where
 instance (MonadTags m) => MonadTags (ReaderT e m) where
   askTags = lift askTags
   withTags newTags = mapReaderT (withTags newTags)
+
+instance (MonadTags m) => MonadTags (MaybeT m) where
+  askTags = lift askTags
+  withTags newTags = mapMaybeT (withTags newTags)
 
 class HasTags ctx where
   getTags :: (MonadIO m) => ctx -> m Tags

--- a/src/Share/Web/Share/Contributions/Impl.hs
+++ b/src/Share/Web/Share/Contributions/Impl.hs
@@ -23,6 +23,7 @@ import Share.BackgroundJobs.Diffs.Queries qualified as DiffsQ
 import Share.Branch (Branch (..))
 import Share.Branch qualified as Branch
 import Share.Codebase qualified as Codebase
+import Share.Codebase.CodebaseRuntime qualified as CR
 import Share.Contribution
 import Share.Env qualified as Env
 import Share.IDs (PrefixedHash (..), ProjectSlug (..), UserHandle)
@@ -364,8 +365,8 @@ contributionDiffTermsEndpoint (AuthN.MaybeAuthedUserID mayCallerUserId) userHand
         unisonRuntime <- asks Env.sandboxedRuntime
         result <-
           PG.tryRunTransaction do
-            Codebase.withCodebaseRuntime oldCodebase unisonRuntime \oldRuntime -> do
-              Codebase.withCodebaseRuntime newCodebase unisonRuntime \newRuntime -> do
+            CR.withCodebaseRuntime oldCodebase unisonRuntime \oldRuntime -> do
+              CR.withCodebaseRuntime newCodebase unisonRuntime \newRuntime -> do
                 (oldBranchHashId, newBranchHashId) <- CausalQ.expectNamespaceIdsByCausalIdsOf both (oldCausalId, newBranchCausalId)
                 (oldPerspective, newPerspective) <- (oldBranchHashId, newBranchHashId) & traverseOf both NPOps.namesPerspectiveForRoot
                 Diffs.diffTerms
@@ -424,8 +425,8 @@ contributionDiffTypesEndpoint (AuthN.MaybeAuthedUserID mayCallerUserId) userHand
       typeDiff <-
         (either respondError pure =<<) do
           PG.tryRunTransaction do
-            Codebase.withCodebaseRuntime oldCodebase unisonRuntime \oldRuntime -> do
-              Codebase.withCodebaseRuntime newCodebase unisonRuntime \newRuntime -> do
+            CR.withCodebaseRuntime oldCodebase unisonRuntime \oldRuntime -> do
+              CR.withCodebaseRuntime newCodebase unisonRuntime \newRuntime -> do
                 (oldBranchHashId, newBranchHashId) <- CausalQ.expectNamespaceIdsByCausalIdsOf both (oldCausalId, newBranchCausalId)
                 (oldPerspective, newPerspective) <- (oldBranchHashId, newBranchHashId) & traverseOf both NPOps.namesPerspectiveForRoot
                 Diffs.diffTypes authZReceipt (oldCodebase, oldRuntime, oldPerspective, oldTypeName) (newCodebase, newRuntime, newPerspective, newTypeName)

--- a/src/Unison/Server/Share/Definitions.hs
+++ b/src/Unison/Server/Share/Definitions.hs
@@ -17,7 +17,7 @@ import Share.Backend qualified as Backend
 import Share.Codebase (CodebaseEnv, CodebaseRuntime)
 import Share.Codebase qualified as Codebase
 import Share.Codebase.Types (CodebaseEnv (..))
-import Share.Postgres (QueryM)
+import Share.Postgres (QueryM, transactionSpan)
 import Share.Postgres.Causal.Queries qualified as CausalQ
 import Share.Postgres.IDs (CausalId)
 import Share.Postgres.NameLookups.Types (pathToPathSegments)
@@ -162,7 +162,7 @@ renderDocRefs ::
   [TermReference] ->
   m [(HashQualifiedName, UnisonHash, Doc.Doc)]
 renderDocRefs _codebase _ppedBuilder _width _rt [] = pure []
-renderDocRefs codebase ppedBuilder width rt docRefs = do
+renderDocRefs codebase ppedBuilder width rt docRefs = transactionSpan "" mempty do
   eDocs <- for docRefs \ref -> (ref,) <$> (Backend.evalDocRef codebase rt ref)
   let docDeps = foldMap (Doc.dependencies . snd) eDocs <> Set.fromList (LD.TermReference <$> docRefs)
   docsPPED <- ppedBuilder docDeps


### PR DESCRIPTION
## Overview

Doc evaluation is getting pretty slow; the current trunk implementation will evaluate a little, then the runtime will ask for more dependencies, it'll call out to Postgres to load a single dependency, then more eval, then another single definition, etc. It's extremely inefficient to do it this way.

Instead, it now crawls the doc's transitive dependencies and pre-loads them all into a code cache. The runtime still asks for them one at a time, but now they'll be provided from an in-memory map rather than making a DB call 😎 

On local I'm getting about a 10x speedup on one particularly beefy doc, this will be larger on production where DB calls are more costly.

## Implementation notes

* The "CodeLookup" interface is too specialized to UCM to be useful anymore, so I added a new CodeCache concept, then allow down-casting it into a CodeLookup when needed.
* The CodeCache now supports looking things up in a batch
* Adds a new query to get the transitive term/type reference dependencies of a given term
* When running a doc eval, fetch the transitive deps of the doc, then load the terms and decls, thus priming the cache efficiently in a batch.

## Test coverage

There are docs in transcript tests; and even if this optimization fails, the code cache will still call through, though it will be less efficient in that case.

## Loose ends

It would be nice to introduce more of a batching style to UCM methods so I don't need to manually prime the caches, but probably not worth the large amount of effort, at least at the moment.