### PR TITLE
Copy select projects from prod in `reset_fixtures`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ prelude.output.md
 # Scratch files
 *.u
 
-# End users can customize their own 
-transcripts/fixtures/projects.txt
+# Developers can customize their own local development setup
+/transcripts/fixtures/custom_projects.txt

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ prelude.output.md
 
 # Scratch files
 *.u
+
+# End users can customize their own 
+transcripts/fixtures/projects.txt

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ reset_fixtures:
 	  sleep 1; \
 	done;
 	@echo "Booting up share";
-	@( . ./local.env \
-		$(exe) 2>&1 & \
+	@( . ./local.env ; \
+		$(exe) & \
 		SERVER_PID=$$!; \
 	trap "kill $$SERVER_PID 2>/dev/null || true" EXIT INT TERM; \
 	echo "Loading fixtures"; \

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A [flake.nix](flake.nix) file is provided in this repo. It currently doesn't use
 ## Running Locally
 
 The first time you run locally, start with `make reset_fixtures`, then on subsequent runs just use `make serve`.
+`make reset_fixtures` will set up some basic test data in your local database, and will copy all projects from `./transcripts/fixtures/projects.txt` and `./transcripts/fixtures/custom_projects.txt` from Share into your local database.
 
 Data changes in Postgres using `make serve` are persistent locally.
 You can reset the database to a known state with `make reset_fixtures`.

--- a/transcripts/fixtures/load-from-share.sh
+++ b/transcripts/fixtures/load-from-share.sh
@@ -27,9 +27,12 @@ push_transcript="$(mktemp).md"
 
 while IFS= read -r line; do
   read -r project_source project_dest <<< "$line"
+# Annoyingly clone will fail if it's already been cloned, but succeed otherwise, so we just add a bad command to
+# force the block to always fail so we can use the :error directive.
 cat << EOF
-\`\`\`ucm
+\`\`\`ucm:error
 scratch/main> clone ${project_source}
+scratch/main> force-failure
 \`\`\`
 
 EOF

--- a/transcripts/fixtures/load-from-share.sh
+++ b/transcripts/fixtures/load-from-share.sh
@@ -14,7 +14,12 @@ if [ ! -d "$cache_dir" ]; then
   mkdir -p "$cache_dir"
 fi
 
-project_list="${SHARE_PROJECT_ROOT}/transcripts/fixtures/projects.txt"
+main_project_list="${SHARE_PROJECT_ROOT}/transcripts/fixtures/projects.txt"
+custom_project_list="${SHARE_PROJECT_ROOT}/transcripts/fixtures/custom_projects.txt"
+# create the custom projects file if it doesn't exist
+if [ ! -f "$custom_project_list" ]; then
+  touch "$custom_project_list"
+fi
 
 typeset -A projects
 projects=(
@@ -36,7 +41,7 @@ scratch/main> force-failure
 \`\`\`
 
 EOF
-done <"$project_list" >"$pull_transcript"
+done <(cat "$main_project_list" "$custom_project_list") >"$pull_transcript"
 
 while IFS= read -r line; do
   read -r project_source project_dest <<< "$line"
@@ -46,7 +51,7 @@ ${project_source}> push ${project_dest}
 \`\`\`
 
 EOF
-done <"$project_list"  >"$push_transcript"
+done <(cat "$main_project_list" "$custom_project_list")  >"$push_transcript"
 
 UNISON_SHARE_HOST="https://api.unison-lang.org" ucm -C "${cache_dir}/code-cache" transcript.in-place "$pull_transcript"
 UNISON_SHARE_HOST="http://localhost:5424" ucm -c "${cache_dir}/code-cache" transcript.in-place "$push_transcript"

--- a/transcripts/fixtures/projects.txt
+++ b/transcripts/fixtures/projects.txt
@@ -1,0 +1,1 @@
+@unison/base/releases/4.8.0 @test/base/main

--- a/transcripts/fixtures/run.zsh
+++ b/transcripts/fixtures/run.zsh
@@ -6,3 +6,5 @@ source "${SHARE_PROJECT_ROOT}/transcripts/transcript_functions.sh"
 # Set up database so helper scripts know it's a local db
 pg_file "${SHARE_PROJECT_ROOT}/transcripts/sql/configure_local_database.sql"
 pg_init_fixtures
+
+source "${SHARE_PROJECT_ROOT}/transcripts/fixtures/load-from-share.sh"


### PR DESCRIPTION
## Overview

Now `make reset_fixtures` will copy the projects from `transcripts/fixtures/projects.txt` and `transcripts/fixtures/custom_projects.txt` into your local dv server from prod.

You can customize `transcripts/fixtures/custom_projects.txt` to your needs, it's gitignore'd

## Implementation notes

Generates the needed ucm transcripts from the listed projects, then runs a UCM against prod to clone, and a transcript against local to push.

## Interesting/controversial decisions

lots of bash... 😬 