### PR TITLE
Add admin endpoint for creating orgs

### DIFF
--- a/src/Share/Web/Admin/API.hs
+++ b/src/Share/Web/Admin/API.hs
@@ -5,10 +5,10 @@
 
 module Share.Web.Admin.API where
 
+import Servant
 import Share.IDs
 import Share.OAuth.Session
 import Share.Web.Admin.Types
-import Servant
 
 type API =
   AuthenticatedSession :> UnauthenticatedAPI
@@ -21,6 +21,7 @@ type UnauthenticatedAPI =
              :> ( ("delete-user" :> DeleteUserEndpoint)
                 )
          )
+    :<|> ("orgs" :> "create" :> AdminCreateOrgEndpoint)
 
 type CreateMissingLooseCodeMappingsEndpoint =
   Post '[JSON] ()
@@ -54,3 +55,7 @@ type AddCloudUserEndpoint =
 type RemoveCloudUserEndpoint =
   ReqBody '[JSON] RemoveCloudUserRequest
     :> Delete '[JSON] ()
+
+type AdminCreateOrgEndpoint =
+  ReqBody '[JSON] AdminCreateOrgRequest
+    :> Post '[JSON] AdminCreateOrgResponse

--- a/src/Share/Web/Admin/Types.hs
+++ b/src/Share/Web/Admin/Types.hs
@@ -4,8 +4,11 @@
 module Share.Web.Admin.Types where
 
 import Data.Aeson
+import Data.Text (Text)
 import Data.Time (Day)
 import Share.IDs
+import Share.Utils.URI
+import Share.Web.Share.DisplayInfo.Types (OrgDisplayInfo)
 
 data ProjectCategory = ProjectCategory
   { categoryName :: CategoryName,
@@ -46,3 +49,50 @@ data DeleteUserRequest = DeleteUserRequest
 instance FromJSON DeleteUserRequest where
   parseJSON = withObject "DeleteUserRequest" $ \o ->
     DeleteUserRequest <$> o .: "currentDate"
+
+data AdminCreateOrgRequest = AdminCreateOrgRequest
+  { orgName :: Text,
+    orgHandle :: OrgHandle,
+    orgEmail :: Maybe Email,
+    orgAvatarUrl :: Maybe URIParam,
+    orgOwner :: UserHandle,
+    isCommercial :: Bool
+  }
+  deriving (Show)
+
+instance FromJSON AdminCreateOrgRequest where
+  parseJSON = withObject "AdminCreateOrgRequest" $ \o -> do
+    orgName <- o .: "name"
+    orgHandle <- o .: "handle"
+    orgEmail <- o .:? "email"
+    orgAvatarUrl <- o .:? "avatarUrl"
+    orgOwner <- o .: "owner"
+    isCommercial <- o .:? "isCommercial" .!= False
+    pure AdminCreateOrgRequest {..}
+
+instance ToJSON AdminCreateOrgRequest where
+  toJSON AdminCreateOrgRequest {..} =
+    object
+      [ "name" .= orgName,
+        "handle" .= orgHandle,
+        "email" .= orgEmail,
+        "avatarUrl" .= orgAvatarUrl,
+        "owner" .= orgOwner,
+        "isCommercial" .= isCommercial
+      ]
+
+data AdminCreateOrgResponse = AdminCreateOrgResponse
+  { org :: OrgDisplayInfo
+  }
+  deriving (Show)
+
+instance FromJSON AdminCreateOrgResponse where
+  parseJSON = withObject "AdminCreateOrgResponse" $ \o -> do
+    org <- o .: "org"
+    pure AdminCreateOrgResponse {..}
+
+instance ToJSON AdminCreateOrgResponse where
+  toJSON AdminCreateOrgResponse {..} =
+    object
+      [ "org" .= org
+      ]


### PR DESCRIPTION
## Overview

Allow admins to create orgs via API so I don't have to be carefully copy paste SQL to do it.

## Implementation notes

Adds an admin-only endpoint for creating privileged orgs

## Test coverage

Tested locally
