### PR TITLE
Add/remove users from org memberships when roles change

### DIFF
--- a/transcripts/share-apis/roles/check-contributor-membership-addition.json
+++ b/transcripts/share-apis/roles/check-contributor-membership-addition.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "members": [
+      {
+        "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+        "handle": "admin",
+        "name": "Admin User",
+        "userId": "U-<UUID>"
+      },
+      {
+        "avatarUrl": null,
+        "handle": "some-user",
+        "name": null,
+        "userId": "U-<UUID>"
+      },
+      {
+        "avatarUrl": null,
+        "handle": "test",
+        "name": null,
+        "userId": "U-<UUID>"
+      },
+      {
+        "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+        "handle": "transcripts",
+        "name": "The Transcript User",
+        "userId": "U-<UUID>"
+      }
+    ]
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/roles/check-contributor-membership-removal.json
+++ b/transcripts/share-apis/roles/check-contributor-membership-removal.json
@@ -1,0 +1,29 @@
+{
+  "body": {
+    "members": [
+      {
+        "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+        "handle": "admin",
+        "name": "Admin User",
+        "userId": "U-<UUID>"
+      },
+      {
+        "avatarUrl": null,
+        "handle": "test",
+        "name": null,
+        "userId": "U-<UUID>"
+      },
+      {
+        "avatarUrl": "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y&d=retro",
+        "handle": "transcripts",
+        "name": "The Transcript User",
+        "userId": "U-<UUID>"
+      }
+    ]
+  },
+  "status": [
+    {
+      "status_code": 200
+    }
+  ]
+}

--- a/transcripts/share-apis/roles/maintainer-project-view.json
+++ b/transcripts/share-apis/roles/maintainer-project-view.json
@@ -20,7 +20,18 @@
     },
     "permissions": [
       "project:view",
-      "project:contribute"
+      "project:contribute",
+      "project:maintain",
+      "project:create",
+      "org:view",
+      "org:edit",
+      "team:view",
+      "notification_hub_entry:view",
+      "notification_hub_entry:update",
+      "notification_subscription:view",
+      "notification_subscription:manage",
+      "notification_delivery_method:view",
+      "notification_delivery_method:manage"
     ],
     "releaseDownloads": [],
     "slug": "privateorgproject",

--- a/transcripts/share-apis/roles/run.zsh
+++ b/transcripts/share-apis/roles/run.zsh
@@ -36,6 +36,9 @@ fetch "$test_user" POST grant-project-contributor '/orgs/unison/roles' "
     ]
 }"
 
+# Now the user should be a member of the org
+fetch "$test_user" GET check-contributor-membership-addition '/orgs/unison/members'
+
 fetch "$some_user" GET maintainer-project-view '/users/unison/projects/privateorgproject'
 
 # Remove the user from the org again
@@ -49,3 +52,6 @@ fetch "$test_user" DELETE revoke-project-contributor '/orgs/unison/roles' "
 }"
 
 fetch "$some_user" GET non-maintainer-project-view '/users/unison/projects/privateorgproject'
+
+# Now the user should be no longer be a member of the org
+fetch "$test_user" GET check-contributor-membership-removal '/orgs/unison/members'


### PR DESCRIPTION
## Overview

Patches org membership & roles system to fix issue where users were given roles in an org but not considered members

## Implementation notes

Check the roles a member has after updates and add/remove them from the org accordingly

## Test coverage

Transcripts

## Loose ends

Need to revisit this system, it's a bit clunky and error-prone at the moment.